### PR TITLE
Fix PiP window tiling and Helium focus

### DIFF
--- a/Sources/DefiMacOS/Platform.swift
+++ b/Sources/DefiMacOS/Platform.swift
@@ -2122,7 +2122,8 @@ public final class MacOSPlatform {
           shouldManage(
             candidate,
             element: element,
-            forceTiling: decision.forceTiling
+            forceTiling: decision.forceTiling,
+            wasPreviouslyManaged: previousWindowID != nil
           )
         else {
           continue
@@ -2764,7 +2765,7 @@ public final class MacOSPlatform {
     let title = value(element, attribute: kAXTitleAttribute, as: String.self) ?? ""
     let role = value(element, attribute: kAXRoleAttribute, as: String.self)
     let subrole = value(element, attribute: kAXSubroleAttribute, as: String.self)
-    guard let record = (
+    let record = (
         preferredWindowID.flatMap { preferred in
           cgWindows.first {
             $0.id == CGWindowID(preferred.rawValue)
@@ -2780,12 +2781,15 @@ public final class MacOSPlatform {
           excluding: usedCGWindowIDs
         )
     )
-    else {
+    guard let resolvedWindowID = resolvedCGWindowID(
+      matchedRecord: record,
+      preferredWindowID: preferredWindowID
+    ) else {
       return nil
     }
     let monitorID = monitor(containing: frame, monitors: monitors)?.id
     return (Window(
-      id: WindowID(rawValue: UInt64(record.id)),
+      id: WindowID(rawValue: UInt64(resolvedWindowID)),
       appID: appID,
       title: title,
       frame: frame,
@@ -2794,19 +2798,30 @@ public final class MacOSPlatform {
       processID: processID,
       monitorID: monitorID,
       forceTiling: false
-    ), record.id)
+    ), resolvedWindowID)
   }
 
   private func shouldManage(
     _ window: Window,
     element: AXUIElement,
-    forceTiling: Bool
+    forceTiling: Bool,
+    wasPreviouslyManaged: Bool
   ) -> Bool {
-    shouldManageWindow(
+    var closeButton: CFTypeRef?
+    let closeButtonError = AXUIElementCopyAttributeValue(
+      element,
+      kAXCloseButtonAttribute as CFString,
+      &closeButton
+    )
+    return shouldManageWindow(
       role: window.role,
       subrole: window.subrole,
       appID: window.appID,
-      hasCloseButton: copyAttribute(element, name: kAXCloseButtonAttribute) != nil,
+      hasCloseButton: shouldTreatWindowAsClosable(
+        error: closeButtonError,
+        hasValue: closeButton != nil,
+        wasPreviouslyManaged: wasPreviouslyManaged
+      ),
       forceTiling: forceTiling
     )
   }
@@ -2931,6 +2946,17 @@ struct CGWindowRecord {
   let frame: Rect
 }
 
+func resolvedCGWindowID(
+  matchedRecord: CGWindowRecord?,
+  preferredWindowID: WindowID?
+) -> CGWindowID? {
+  if let matchedRecord {
+    return matchedRecord.id
+  }
+  guard let preferredWindowID else { return nil }
+  return CGWindowID(exactly: preferredWindowID.rawValue)
+}
+
 private func copyCGWindows() -> [CGWindowRecord] {
   guard
     let info = CGWindowListCopyWindowInfo(
@@ -3015,6 +3041,21 @@ func shouldManageWindow(
     "com.raycast.macos",
   ]
   return !ignoredApps.contains(appID.lowercased())
+}
+
+func shouldTreatWindowAsClosable(
+  error: AXError,
+  hasValue: Bool,
+  wasPreviouslyManaged: Bool
+) -> Bool {
+  switch error {
+  case .success:
+    hasValue
+  case .attributeUnsupported, .noValue:
+    false
+  default:
+    wasPreviouslyManaged
+  }
 }
 
 func shouldSelectSpecificWindow(

--- a/Sources/DefiMacOS/Platform.swift
+++ b/Sources/DefiMacOS/Platform.swift
@@ -1961,6 +1961,7 @@ public final class MacOSPlatform {
   private var elements: [WindowID: AXUIElement] = [:]
   private var processIDs: [WindowID: pid_t] = [:]
   private var applications: [pid_t: AXUIElement] = [:]
+  private var applicationWindowCounts: [pid_t: Int] = [:]
   private var enhancedUIByProcess: [pid_t: Bool] = [:]
   private let frameCoordinator = AXFrameCoordinator()
   private let focusWriter = AXFocusWriter()
@@ -2117,7 +2118,13 @@ public final class MacOSPlatform {
           continue
         }
         let decision = config.decision(for: candidate)
-        guard shouldManage(candidate, forceTiling: decision.forceTiling) else {
+        guard
+          shouldManage(
+            candidate,
+            element: element,
+            forceTiling: decision.forceTiling
+          )
+        else {
           continue
         }
         guard usedCGWindowIDs.insert(cgWindowID).inserted else {
@@ -2132,6 +2139,7 @@ public final class MacOSPlatform {
     elements = nextElements
     processIDs = nextProcessIDs
     applications = nextApplications
+    applicationWindowCounts = applicationWindows.mapValues(\.count)
     enhancedUIByProcess = enhancedUIByProcess.filter { nextApplications[$0.key] != nil }
     eventMonitor?.refresh(applications: applicationWindows)
     targetFrames = targetFrames.filter { nextElements[$0.key] != nil }
@@ -2681,18 +2689,27 @@ public final class MacOSPlatform {
     internalFocusDeadlines[windowID] =
       ProcessInfo.processInfo.systemUptime + 2
     let focusWritePending = focusWriter.isBusy
+    let activatesApplication =
+      focusWriter.hasInFlightRequest(forDifferentProcess: processID)
+      || NSWorkspace.shared.frontmostApplication?.processIdentifier != processID
+    let hasMultipleManagedWindows =
+      processIDs.values.lazy.filter { $0 == processID }.prefix(2).count > 1
+    let hasUnmanagedAuxiliaryWindows =
+      (applicationWindowCounts[processID] ?? 0)
+      > processIDs.values.lazy.filter { $0 == processID }.count
     focusWriter.submit(
       AsyncFocusRequest(
         element: element,
         application: application,
         processID: processID,
-        selectsSpecificWindow:
-          processIDs.values.lazy.filter { $0 == processID }.prefix(2).count > 1
-          && (focusWritePending
-            || lastFocusedWindowByProcess[processID] != windowID),
-        activatesApplication:
-          focusWriter.hasInFlightRequest(forDifferentProcess: processID)
-          || NSWorkspace.shared.frontmostApplication?.processIdentifier != processID
+        selectsSpecificWindow: shouldSelectSpecificWindow(
+          activatesApplication: activatesApplication,
+          hasUnmanagedAuxiliaryWindows: hasUnmanagedAuxiliaryWindows,
+          hasMultipleManagedWindows: hasMultipleManagedWindows,
+          focusWritePending: focusWritePending,
+          targetWasLastFocused: lastFocusedWindowByProcess[processID] == windowID
+        ),
+        activatesApplication: activatesApplication
       )
     )
   }
@@ -2780,20 +2797,18 @@ public final class MacOSPlatform {
     ), record.id)
   }
 
-  private func shouldManage(_ window: Window, forceTiling: Bool) -> Bool {
-    if forceTiling { return true }
-    guard window.role == kAXWindowRole,
-      window.subrole == kAXStandardWindowSubrole
-    else {
-      return false
-    }
-    let ignoredApps = [
-      "com.apple.dock",
-      "com.apple.systemuiserver",
-      "com.raycast.macos",
-    ]
-    guard !ignoredApps.contains(window.appID.lowercased()) else { return false }
-    return true
+  private func shouldManage(
+    _ window: Window,
+    element: AXUIElement,
+    forceTiling: Bool
+  ) -> Bool {
+    shouldManageWindow(
+      role: window.role,
+      subrole: window.subrole,
+      appID: window.appID,
+      hasCloseButton: copyAttribute(element, name: kAXCloseButtonAttribute) != nil,
+      forceTiling: forceTiling
+    )
   }
 
   private func focusedWindowID(
@@ -2909,7 +2924,7 @@ public final class MacOSPlatform {
   }
 }
 
-private struct CGWindowRecord {
+struct CGWindowRecord {
   let id: CGWindowID
   let processID: pid_t
   let title: String
@@ -2948,22 +2963,69 @@ private func copyCGWindows() -> [CGWindowRecord] {
   }
 }
 
-private func bestCGWindow(
+func bestCGWindow(
   processID: pid_t,
   title: String,
   frame: Rect,
   records: [CGWindowRecord],
-  excluding usedWindowIDs: Set<CGWindowID> = []
+  excluding usedWindowIDs: Set<CGWindowID> = [],
+  maximumDistance: Double = 80
 ) -> CGWindowRecord? {
   let candidates = records.filter {
     $0.processID == processID && !usedWindowIDs.contains($0.id)
   }
-  let matchingTitles = candidates.filter {
-    title.isEmpty || $0.title.isEmpty || $0.title == title
+  guard
+    let closest = candidates.min(by: { lhs, rhs in
+      let lhsDistance = frameDistance(lhs.frame, frame)
+      let rhsDistance = frameDistance(rhs.frame, frame)
+      if abs(lhsDistance - rhsDistance) > 0.5 {
+        return lhsDistance < rhsDistance
+      }
+      return windowTitleMatchRank(lhs.title, title) < windowTitleMatchRank(rhs.title, title)
+    }),
+    frameDistance(closest.frame, frame) <= maximumDistance
+  else {
+    return nil
   }
-  return (matchingTitles.isEmpty ? candidates : matchingTitles).min {
-    frameDistance($0.frame, frame) < frameDistance($1.frame, frame)
+  return closest
+}
+
+private func windowTitleMatchRank(_ cgTitle: String, _ accessibilityTitle: String) -> Int {
+  guard !cgTitle.isEmpty, !accessibilityTitle.isEmpty else { return 1 }
+  return cgTitle == accessibilityTitle ? 0 : 2
+}
+
+func shouldManageWindow(
+  role: String?,
+  subrole: String?,
+  appID: String,
+  hasCloseButton: Bool,
+  forceTiling: Bool
+) -> Bool {
+  if forceTiling { return true }
+  guard role == kAXWindowRole,
+    subrole == kAXStandardWindowSubrole,
+    hasCloseButton
+  else {
+    return false
   }
+  let ignoredApps = [
+    "com.apple.dock",
+    "com.apple.systemuiserver",
+    "com.raycast.macos",
+  ]
+  return !ignoredApps.contains(appID.lowercased())
+}
+
+func shouldSelectSpecificWindow(
+  activatesApplication: Bool,
+  hasUnmanagedAuxiliaryWindows: Bool,
+  hasMultipleManagedWindows: Bool,
+  focusWritePending: Bool,
+  targetWasLastFocused: Bool
+) -> Bool {
+  (activatesApplication && hasUnmanagedAuxiliaryWindows)
+    || (hasMultipleManagedWindows && (focusWritePending || !targetWasLastFocused))
 }
 
 private func monitor(

--- a/Tests/DefiMacOSTests/WindowDiscoveryTests.swift
+++ b/Tests/DefiMacOSTests/WindowDiscoveryTests.swift
@@ -1,0 +1,136 @@
+import ApplicationServices
+import DefiModel
+import XCTest
+
+@testable import DefiMacOS
+
+final class WindowDiscoveryTests: XCTestCase {
+  private let processID: pid_t = 42
+  private let frame = Rect(x: 4, y: 34, width: 2_554, height: 1_354)
+
+  func testWindowMatchingPrefersExactFrameOverEmptyTitle() {
+    let exactFrame = CGWindowRecord(
+      id: 1,
+      processID: processID,
+      title: "WhatsApp 🔊",
+      frame: frame
+    )
+    let emptyTitleStrip = CGWindowRecord(
+      id: 2,
+      processID: processID,
+      title: "",
+      frame: Rect(x: 0, y: 0, width: 2_560, height: 30)
+    )
+
+    let match = bestCGWindow(
+      processID: processID,
+      title: "WhatsApp - Helium",
+      frame: frame,
+      records: [emptyTitleStrip, exactFrame]
+    )
+
+    XCTAssertEqual(match?.id, exactFrame.id)
+  }
+
+  func testWindowMatchingRejectsUnrelatedSurface() {
+    let unrelated = CGWindowRecord(
+      id: 1,
+      processID: processID,
+      title: "",
+      frame: Rect(x: 104, y: 34, width: 2_554, height: 1_354)
+    )
+
+    XCTAssertNil(
+      bestCGWindow(
+        processID: processID,
+        title: "Picture in Picture",
+        frame: frame,
+        records: [unrelated]
+      )
+    )
+  }
+
+  func testWindowMatchingUsesTitleToBreakGeometryTie() {
+    let wrongTitle = CGWindowRecord(
+      id: 1,
+      processID: processID,
+      title: "Other",
+      frame: frame
+    )
+    let matchingTitle = CGWindowRecord(
+      id: 2,
+      processID: processID,
+      title: "Window",
+      frame: frame
+    )
+
+    let match = bestCGWindow(
+      processID: processID,
+      title: "Window",
+      frame: frame,
+      records: [wrongTitle, matchingTitle]
+    )
+
+    XCTAssertEqual(match?.id, matchingTitle.id)
+  }
+
+  func testStandardClosableWindowIsManaged() {
+    XCTAssertTrue(
+      shouldManageWindow(
+        role: kAXWindowRole,
+        subrole: kAXStandardWindowSubrole,
+        appID: "net.imput.helium",
+        hasCloseButton: true,
+        forceTiling: false
+      )
+    )
+  }
+
+  func testControlLessPictureInPictureWindowIsUnmanaged() {
+    XCTAssertFalse(
+      shouldManageWindow(
+        role: kAXWindowRole,
+        subrole: kAXStandardWindowSubrole,
+        appID: "net.imput.helium",
+        hasCloseButton: false,
+        forceTiling: false
+      )
+    )
+  }
+
+  func testForceTilingOverridesWindowShapeFilter() {
+    XCTAssertTrue(
+      shouldManageWindow(
+        role: kAXWindowRole,
+        subrole: kAXUnknownSubrole,
+        appID: "net.imput.helium",
+        hasCloseButton: false,
+        forceTiling: true
+      )
+    )
+  }
+
+  func testApplicationActivationSelectsTargetWithUnmanagedAuxiliaryWindows() {
+    XCTAssertTrue(
+      shouldSelectSpecificWindow(
+        activatesApplication: true,
+        hasUnmanagedAuxiliaryWindows: true,
+        hasMultipleManagedWindows: false,
+        focusWritePending: false,
+        targetWasLastFocused: true
+      )
+    )
+  }
+
+  func testStableSingleWindowFocusKeepsFastPath() {
+    XCTAssertFalse(
+      shouldSelectSpecificWindow(
+        activatesApplication: true,
+        hasUnmanagedAuxiliaryWindows: false,
+        hasMultipleManagedWindows: false,
+        focusWritePending: false,
+        targetWasLastFocused: true
+      )
+    )
+  }
+}

--- a/Tests/DefiMacOSTests/WindowDiscoveryTests.swift
+++ b/Tests/DefiMacOSTests/WindowDiscoveryTests.swift
@@ -74,6 +74,16 @@ final class WindowDiscoveryTests: XCTestCase {
     XCTAssertEqual(match?.id, matchingTitle.id)
   }
 
+  func testPreviousWindowIDSurvivesMissingCGSnapshotRecord() {
+    XCTAssertEqual(
+      resolvedCGWindowID(
+        matchedRecord: nil,
+        preferredWindowID: WindowID(rawValue: 42)
+      ),
+      42
+    )
+  }
+
   func testStandardClosableWindowIsManaged() {
     XCTAssertTrue(
       shouldManageWindow(
@@ -94,6 +104,33 @@ final class WindowDiscoveryTests: XCTestCase {
         appID: "net.imput.helium",
         hasCloseButton: false,
         forceTiling: false
+      )
+    )
+  }
+
+  func testTransientCloseButtonFailurePreservesManagedWindow() {
+    XCTAssertTrue(
+      shouldTreatWindowAsClosable(
+        error: .cannotComplete,
+        hasValue: false,
+        wasPreviouslyManaged: true
+      )
+    )
+    XCTAssertFalse(
+      shouldTreatWindowAsClosable(
+        error: .cannotComplete,
+        hasValue: false,
+        wasPreviouslyManaged: false
+      )
+    )
+  }
+
+  func testMissingCloseButtonRemainsUnmanaged() {
+    XCTAssertFalse(
+      shouldTreatWindowAsClosable(
+        error: .noValue,
+        hasValue: false,
+        wasPreviouslyManaged: true
       )
     )
   }


### PR DESCRIPTION
## Why

Picture-in-picture and auxiliary browser windows could enter the tiled layout. Helium title differences between Accessibility and CoreGraphics could also map the main window to an empty status-bar surface.

## Changes

- Match Accessibility windows to CoreGraphics surfaces using bounded geometry first and titles as a tie-breaker.
- Exclude standard windows without a native close button unless `force_tiling` applies.
- Select the intended main window when activating apps with unmanaged auxiliary windows.
- Add regression tests for window matching, PiP filtering, and focus selection.

## How to test

- Run `swift build`.
- Run `swift test`.
- Open a Helium PiP window and confirm it remains outside the tiled layout.
- Focus away from and back to Helium and confirm focus targets the main window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window matching to select the most relevant application window using position and title information.
  * Prevented already-managed or unrelated windows from being selected.
  * Improved handling of auxiliary windows, multiple managed windows, pending updates, and application focus.
  * Added safer eligibility checks requiring a close button unless force-tiling is enabled.

* **Tests**
  * Added coverage for window matching, management eligibility, title-based selection, and focus behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->