### PR TITLE
Fix width cycling from fullscreen mode

### DIFF
--- a/Sources/DefiCore/Workspace.swift
+++ b/Sources/DefiCore/Workspace.swift
@@ -173,15 +173,20 @@ public func cycleWidth(
 ) {
   guard !presets.isEmpty else { return }
   if column.fullscreenPreviousWidth != nil {
-    let boundaryIndex: Int
+    let boundaryIndex: Int?
     switch direction {
     case .next, .right, .first:
-      boundaryIndex = 0
+      boundaryIndex = presets.firstIndex {
+        abs($0 - 1) >= .ulpOfOne
+      }
     case .previous, .left, .last:
-      boundaryIndex = presets.count - 1
+      boundaryIndex = presets.lastIndex {
+        abs($0 - 1) >= .ulpOfOne
+      }
     case .up, .down:
-      boundaryIndex = nearestPresetIndex(current: 1, presets: presets)
+      boundaryIndex = nil
     }
+    guard let boundaryIndex else { return }
     column.width = .fraction(presets[boundaryIndex])
     column.fullscreenPreviousWidth = nil
     return

--- a/Sources/DefiCore/Workspace.swift
+++ b/Sources/DefiCore/Workspace.swift
@@ -172,6 +172,20 @@ public func cycleWidth(
   presets: [Double]
 ) {
   guard !presets.isEmpty else { return }
+  if column.fullscreenPreviousWidth != nil {
+    let boundaryIndex: Int
+    switch direction {
+    case .next, .right, .first:
+      boundaryIndex = 0
+    case .previous, .left, .last:
+      boundaryIndex = presets.count - 1
+    case .up, .down:
+      boundaryIndex = nearestPresetIndex(current: 1, presets: presets)
+    }
+    column.width = .fraction(presets[boundaryIndex])
+    column.fullscreenPreviousWidth = nil
+    return
+  }
   guard case .fraction(let current) = column.width else {
     column.width = .fraction(presets[0])
     column.fullscreenPreviousWidth = nil

--- a/Tests/DefiCoreTests/LayoutTests.swift
+++ b/Tests/DefiCoreTests/LayoutTests.swift
@@ -190,7 +190,7 @@ final class LayoutTests: XCTestCase {
 
   func testCyclingForwardFromFullscreenUsesFirstPreset() {
     var column = Column(window: WindowID(rawValue: 1), width: .fraction(0.5))
-    let presets = [0.33, 0.5, 0.66, 0.8]
+    let presets = [1.0, 0.33, 0.5, 0.66, 0.8]
 
     toggleFullscreen(of: &column, defaultWidth: 0.8)
     cycleWidth(of: &column, direction: .next, presets: presets)
@@ -201,13 +201,23 @@ final class LayoutTests: XCTestCase {
 
   func testCyclingBackwardFromFullscreenUsesLastPreset() {
     var column = Column(window: WindowID(rawValue: 1), width: .fraction(0.5))
-    let presets = [0.33, 0.5, 0.66, 0.8]
+    let presets = [0.33, 0.5, 0.66, 0.8, 1.0]
 
     toggleFullscreen(of: &column, defaultWidth: 0.8)
     cycleWidth(of: &column, direction: .previous, presets: presets)
 
     XCTAssertEqual(column.width, .fraction(0.8))
     XCTAssertNil(column.fullscreenPreviousWidth)
+  }
+
+  func testCyclingFromFullscreenWithOnlyFullWidthPresetDoesNothing() {
+    var column = Column(window: WindowID(rawValue: 1), width: .fraction(0.5))
+
+    toggleFullscreen(of: &column, defaultWidth: 0.8)
+    cycleWidth(of: &column, direction: .previous, presets: [1.0])
+
+    XCTAssertEqual(column.width, .fraction(1))
+    XCTAssertEqual(column.fullscreenPreviousWidth, .fraction(0.5))
   }
 
   func testSpeculativeNavigationSettlementWaitsPastVisualAnimation() {

--- a/Tests/DefiCoreTests/LayoutTests.swift
+++ b/Tests/DefiCoreTests/LayoutTests.swift
@@ -188,6 +188,28 @@ final class LayoutTests: XCTestCase {
     XCTAssertNil(column.fullscreenPreviousWidth)
   }
 
+  func testCyclingForwardFromFullscreenUsesFirstPreset() {
+    var column = Column(window: WindowID(rawValue: 1), width: .fraction(0.5))
+    let presets = [0.33, 0.5, 0.66, 0.8]
+
+    toggleFullscreen(of: &column, defaultWidth: 0.8)
+    cycleWidth(of: &column, direction: .next, presets: presets)
+
+    XCTAssertEqual(column.width, .fraction(0.33))
+    XCTAssertNil(column.fullscreenPreviousWidth)
+  }
+
+  func testCyclingBackwardFromFullscreenUsesLastPreset() {
+    var column = Column(window: WindowID(rawValue: 1), width: .fraction(0.5))
+    let presets = [0.33, 0.5, 0.66, 0.8]
+
+    toggleFullscreen(of: &column, defaultWidth: 0.8)
+    cycleWidth(of: &column, direction: .previous, presets: presets)
+
+    XCTAssertEqual(column.width, .fraction(0.8))
+    XCTAssertNil(column.fullscreenPreviousWidth)
+  }
+
   func testSpeculativeNavigationSettlementWaitsPastVisualAnimation() {
     XCTAssertEqual(
       speculativeNavigationSettlementDelay(animationDuration: 0.035),


### PR DESCRIPTION
## Summary

- Reset fullscreen columns to the correct boundary preset when cycling width
- Add unit tests for forward and backward cycling from fullscreen mode

## Testing

- Not run (not requested)