### PR TITLE
fix: stabilize menu service and window borders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,19 @@ Keep Defi fast, deterministic, stable, and glitch-free.
 
 Never import AppKit, ApplicationServices, or CoreGraphics from pure modules.
 
+## Private platform API policy
+
+Use private macOS APIs only when public APIs have been demonstrated unable to
+meet a user-visible correctness, stability, or latency invariant.
+
+- isolate private API use inside `DefiMacOS` behind a narrow backend interface
+- resolve private symbols dynamically; missing or changed symbols must never prevent startup
+- always keep a fully functional, tested public-API fallback
+- probe private capabilities using Defi-owned surfaces, never by mutating user windows
+- downgrade to the public backend for the rest of the session after a private operation fails
+- expose the active backend and fallback count through status or telemetry
+- do not mutate third-party windows through private APIs without separate explicit approval
+
 ## Product shape
 
 Keep:
@@ -42,7 +55,6 @@ Exclude from MVP:
 - native macOS Spaces control
 - compositor replacement
 - mouse-first shell
-- private WindowServer mutation APIs
 
 ## Runtime rules
 

--- a/Package.swift
+++ b/Package.swift
@@ -81,6 +81,10 @@ let package = Package(
       dependencies: ["DefiIPC", "DefiModel"]
     ),
     .testTarget(
+      name: "DefiCLITests",
+      dependencies: ["DefiCLI"]
+    ),
+    .testTarget(
       name: "DefiMacOSTests",
       dependencies: ["DefiMacOS", "DefiConfig", "DefiCore", "DefiModel"]
     ),

--- a/Sources/DefiCLI/Service.swift
+++ b/Sources/DefiCLI/Service.swift
@@ -18,6 +18,8 @@ enum ServiceManager {
       }
       if !isLoaded() {
         try bootstrapWithRetry()
+      } else {
+        try launchctl(["kickstart", "\(domain)/\(label)"])
       }
       print("started")
     case "stop":
@@ -49,7 +51,7 @@ enum ServiceManager {
       "Label": label,
       "ProgramArguments": [daemonURL.path],
       "RunAtLoad": true,
-      "KeepAlive": true,
+      "KeepAlive": ["SuccessfulExit": false],
       "StandardOutPath": logURL.path,
       "StandardErrorPath": logURL.path,
     ]

--- a/Sources/DefiCLI/Service.swift
+++ b/Sources/DefiCLI/Service.swift
@@ -13,13 +13,18 @@ enum ServiceManager {
       try? FileManager.default.removeItem(at: plistURL)
       print("uninstalled")
     case "start":
-      if !FileManager.default.fileExists(atPath: plistURL.path) {
-        try install()
-      }
-      if !isLoaded() {
-        try bootstrapWithRetry()
-      } else {
-        try launchctl(["kickstart", "\(domain)/\(label)"])
+      for action in serviceStartActions(
+        plistExists: FileManager.default.fileExists(atPath: plistURL.path),
+        isLoaded: isLoaded()
+      ) {
+        switch action {
+        case .install:
+          try install()
+        case .bootstrap:
+          try bootstrapWithRetry()
+        case .kickstart:
+          try launchctl(["kickstart", "\(domain)/\(label)"])
+        }
       }
       print("started")
     case "stop":
@@ -129,6 +134,19 @@ enum ServiceManager {
     FileManager.default.homeDirectoryForCurrentUser
       .appending(path: "Library/Logs/Defi.log")
   }
+}
+
+enum ServiceStartAction: Equatable, Sendable {
+  case install
+  case bootstrap
+  case kickstart
+}
+
+func serviceStartActions(
+  plistExists _: Bool,
+  isLoaded: Bool
+) -> [ServiceStartAction] {
+  isLoaded ? [.kickstart] : [.install, .bootstrap]
 }
 
 enum ServiceError: Error, CustomStringConvertible {

--- a/Sources/DefiMacOS/MenuBar.swift
+++ b/Sources/DefiMacOS/MenuBar.swift
@@ -54,17 +54,6 @@ public final class MenuBarController: NSObject {
 
   private func rebuildMenu() {
     let menu = NSMenu()
-    let status = NSMenuItem(
-      title: activeWorkspace.isEmpty
-        ? "Defi"
-        : "Workspace: \(activeWorkspace)",
-      action: nil,
-      keyEquivalent: ""
-    )
-    status.isEnabled = false
-    menu.addItem(status)
-    menu.addItem(.separator())
-
     for workspace in workspaceNames {
       let item = commandItem(
         title: workspace == activeWorkspace ? "✓ \(workspace)" : workspace,
@@ -75,10 +64,6 @@ public final class MenuBarController: NSObject {
     if !workspaceNames.isEmpty {
       menu.addItem(.separator())
     }
-    menu.addItem(commandItem(title: "Focus Left", command: "focus-column left"))
-    menu.addItem(commandItem(title: "Focus Right", command: "focus-column right"))
-    menu.addItem(commandItem(title: "Toggle Full Width", command: "toggle-fullscreen"))
-    menu.addItem(.separator())
     menu.addItem(commandItem(title: "Quit Defi", command: "quit"))
     statusItem.menu = menu
   }

--- a/Sources/DefiMacOS/Platform.swift
+++ b/Sources/DefiMacOS/Platform.swift
@@ -1728,6 +1728,9 @@ public final class MacOSPlatform {
   private var lastNativeFocusedWindowID: WindowID?
   private var borderHiddenWindowIDs = Set<WindowID>()
   private var borderLiveWindowID: WindowID?
+  private var frontmostNormalWindowID: WindowID?
+  private var borderStackingRefreshState = WindowBorderStackingRefreshState()
+  private var borderStackingRefreshTask: Task<Void, Never>?
   private var borderStyle = WindowBorderStyle(
     enabled: true,
     width: 4,
@@ -1773,6 +1776,9 @@ public final class MacOSPlatform {
         self.refreshWindowBorderGeometry(
           windowIDs: self.borderManager.liveGeometryWindowIDs
         )
+      },
+      borderStackingHandler: { [weak self] in
+        self?.scheduleWindowBorderStackingRefresh()
       }
     )
     monitor.start()
@@ -1786,6 +1792,39 @@ public final class MacOSPlatform {
       by: \.0
     ).mapValues { $0.map(\.1) }
     monitor.refresh(applications: windowsByProcess)
+  }
+
+  private func scheduleWindowBorderStackingRefresh() {
+    let request = borderStackingRefreshState.request(
+      for: borderManager.activeWindowID
+    )
+    borderStackingRefreshTask?.cancel()
+    guard let request else { return }
+    borderStackingRefreshTask = Task { @MainActor [weak self] in
+      await Task.yield()
+      self?.refreshWindowBorderStacking(request)
+      try? await Task.sleep(for: .milliseconds(4))
+      self?.refreshWindowBorderStacking(request)
+    }
+  }
+
+  private func refreshWindowBorderStacking(
+    _ request: WindowBorderStackingRefreshRequest
+  ) {
+    guard
+      borderStackingRefreshState.shouldApply(
+        request,
+        activeWindowID: borderManager.activeWindowID
+      )
+    else {
+      return
+    }
+    let frontmostWindowID = copyFrontmostNormalWindowID()
+    frontmostNormalWindowID = frontmostWindowID
+    borderManager.updateActiveStacking(
+      for: request.windowID,
+      isFrontmost: frontmostWindowID == request.windowID
+    )
   }
 
   public func invalidateFrameStateForDisplayChange() {
@@ -1842,12 +1881,14 @@ public final class MacOSPlatform {
 
   public func prepareWindowBorderSelection(_ selectedWindowID: WindowID?) {
     desiredSelectedWindowID = selectedWindowID
+    frontmostNormalWindowID = copyFrontmostNormalWindowID()
     let selectedFrame = selectedWindowID.flatMap { windowID in
       resolvedBorderFrame(for: windowID)
     }
     borderManager.prepareForSelection(
       selectedWindowID,
-      displayedFrame: selectedFrame
+      displayedFrame: selectedFrame,
+      activeWindowIsFrontmost: selectedWindowID == frontmostNormalWindowID
     )
     let freshFrames: [WindowID: Rect] = Dictionary(
       uniqueKeysWithValues: borderManager.liveGeometryWindowIDs.compactMap { windowID in
@@ -1913,7 +1954,8 @@ public final class MacOSPlatform {
     )
     borderManager.sync(
       plan,
-      displayedFrames: displayedFrames
+      displayedFrames: displayedFrames,
+      activeWindowIsFrontmost: plan.active?.windowID == frontmostNormalWindowID
     )
     let finalDisplayedFrames: [WindowID: Rect] = Dictionary(
       uniqueKeysWithValues: borderManager.liveGeometryWindowIDs.compactMap { windowID in
@@ -2024,6 +2066,7 @@ public final class MacOSPlatform {
     let monitors = discoverMonitors()
     lastMonitorFrames = monitors.map(\.frame)
     let cgWindows = copyCGWindows()
+    frontmostNormalWindowID = copyFrontmostNormalWindowID()
     let previousElements = elements
     let previousProcessIDs = processIDs
     var nextElements: [WindowID: AXUIElement] = [:]
@@ -2980,6 +3023,39 @@ private func copyCGWindows() -> [CGWindowRecord] {
       )
     )
   }
+}
+
+private func copyFrontmostNormalWindowID() -> WindowID? {
+  guard
+    let info = CGWindowListCopyWindowInfo(
+      [.optionOnScreenOnly, .excludeDesktopElements],
+      kCGNullWindowID
+    ) as? [[CFString: Any]]
+  else {
+    return nil
+  }
+  let ownProcessID = ProcessInfo.processInfo.processIdentifier
+  let entries = info.compactMap { item -> NormalWindowStackEntry? in
+    guard
+      (item[kCGWindowLayer] as? NSNumber)?.intValue == 0,
+      (item[kCGWindowOwnerPID] as? NSNumber)?.int32Value != ownProcessID,
+      let number = item[kCGWindowNumber] as? NSNumber,
+      let bounds = item[kCGWindowBounds] as? [String: Any],
+      let cgRect = CGRect(dictionaryRepresentation: bounds as CFDictionary)
+    else {
+      return nil
+    }
+    return NormalWindowStackEntry(
+      windowID: WindowID(rawValue: number.uint64Value),
+      frame: Rect(
+        x: cgRect.minX,
+        y: cgRect.minY,
+        width: cgRect.width,
+        height: cgRect.height
+      )
+    )
+  }
+  return frontmostBorderOccludingWindowID(in: entries)
 }
 
 func bestCGWindow(

--- a/Sources/DefiMacOS/PlatformEvents.swift
+++ b/Sources/DefiMacOS/PlatformEvents.swift
@@ -1,6 +1,7 @@
 import AppKit
 import ApplicationServices
 import CoreGraphics
+import DefiModel
 
 enum PlatformEventKind: Equatable {
   case application
@@ -12,34 +13,83 @@ enum PlatformEventKind: Equatable {
 }
 
 struct MouseGestureEventNormalizer {
+  struct Actions: Equatable {
+    var refreshBorderStacking = false
+    var synchronizeDesktop = false
+  }
+
   private var moved = false
   private var synchronizedDuringGesture = false
 
-  mutating func shouldSynchronizeDesktop(
+  mutating func actions(
     for eventType: NSEvent.EventType
-  ) -> Bool {
+  ) -> Actions {
     switch eventType {
     case .leftMouseDown:
       moved = false
       synchronizedDuringGesture = false
-      return false
+      return Actions(refreshBorderStacking: true)
     case .leftMouseDragged:
       moved = true
       guard synchronizedDuringGesture == false else {
-        return false
+        return Actions()
       }
       synchronizedDuringGesture = true
-      return true
+      return Actions(synchronizeDesktop: true)
     case .leftMouseUp:
       defer {
         moved = false
         synchronizedDuringGesture = false
       }
-      return moved
+      return Actions(synchronizeDesktop: moved)
     default:
-      return false
+      return Actions()
     }
   }
+}
+
+struct WindowBorderStackingRefreshRequest: Equatable, Sendable {
+  let generation: UInt64
+  let windowID: WindowID
+}
+
+struct WindowBorderStackingRefreshState {
+  private var generation: UInt64 = 0
+
+  mutating func request(
+    for windowID: WindowID?
+  ) -> WindowBorderStackingRefreshRequest? {
+    generation &+= 1
+    return windowID.map {
+      WindowBorderStackingRefreshRequest(
+        generation: generation,
+        windowID: $0
+      )
+    }
+  }
+
+  func shouldApply(
+    _ request: WindowBorderStackingRefreshRequest,
+    activeWindowID: WindowID?
+  ) -> Bool {
+    request.generation == generation && request.windowID == activeWindowID
+  }
+}
+
+struct NormalWindowStackEntry: Equatable {
+  let windowID: WindowID
+  let frame: Rect
+}
+
+private let minimumBorderOccludingWindowArea = 2_048.0
+
+func frontmostBorderOccludingWindowID(
+  in entries: [NormalWindowStackEntry]
+) -> WindowID? {
+  // AppKit and Electron can create tiny normal-level helper surfaces on mouse-down.
+  entries.first { entry in
+    entry.frame.width * entry.frame.height >= minimumBorderOccludingWindowArea
+  }?.windowID
 }
 
 @MainActor
@@ -47,6 +97,7 @@ final class PlatformEventMonitor {
   private let handler: (PlatformEventKind) -> Void
   private let frameHandler: (AXUIElement) -> Void
   private let liveFrameHandler: () -> Void
+  private let borderStackingHandler: () -> Void
   private var workspaceTokens: [NSObjectProtocol] = []
   private var screenTokens: [NSObjectProtocol] = []
   private var mouseMonitor: Any?
@@ -59,11 +110,13 @@ final class PlatformEventMonitor {
   init(
     handler: @escaping (PlatformEventKind) -> Void,
     frameHandler: @escaping (AXUIElement) -> Void = { _ in },
-    liveFrameHandler: @escaping () -> Void = {}
+    liveFrameHandler: @escaping () -> Void = {},
+    borderStackingHandler: @escaping () -> Void = {}
   ) {
     self.handler = handler
     self.frameHandler = frameHandler
     self.liveFrameHandler = liveFrameHandler
+    self.borderStackingHandler = borderStackingHandler
   }
 
   func start() {
@@ -119,14 +172,13 @@ final class PlatformEventMonitor {
         if event.type == .leftMouseDragged || event.type == .leftMouseUp {
           self.liveFrameHandler()
         }
-        guard
-          self.mouseGestureNormalizer.shouldSynchronizeDesktop(
-            for: event.type
-          )
-        else {
-          return
+        let actions = self.mouseGestureNormalizer.actions(for: event.type)
+        if actions.refreshBorderStacking {
+          self.borderStackingHandler()
         }
-        self.handler(.mouse)
+        if actions.synchronizeDesktop {
+          self.handler(.mouse)
+        }
       }
     }
   }

--- a/Sources/DefiMacOS/WindowBorderOverlay.swift
+++ b/Sources/DefiMacOS/WindowBorderOverlay.swift
@@ -108,6 +108,10 @@ final class BorderOverlay {
 
   var opacity: Double { Double(opacityValue) }
 
+  var windowLevelRawValues: [Int] {
+    segments.values.map(\.windowLevelRawValue)
+  }
+
   init(windowID: WindowID) {
     targetWindowNumber = Int(windowID.rawValue)
     segments = Dictionary(
@@ -140,8 +144,9 @@ final class BorderOverlay {
     captureEnabled: Bool
   ) -> Bool {
     let radius = borderCornerRadius(windowRadius: windowRadius)
-    guard windowFrame != frame || self.width != width || self.radius != radius
-      || self.captureEnabled != captureEnabled
+    guard
+      windowFrame != frame || self.width != width || self.radius != radius
+        || self.captureEnabled != captureEnabled
     else {
       return false
     }
@@ -212,6 +217,12 @@ final class BorderOverlay {
     }
   }
 
+  func setFrontmost(_ frontmost: Bool) {
+    for segment in segments.values {
+      segment.setFrontmost(frontmost)
+    }
+  }
+
   private func updateColor(_ color: UInt32) {
     guard self.color != color else { return }
     for segment in segments.values {
@@ -261,6 +272,7 @@ private final class BorderSegment {
   private var orderedIn = false
 
   var windowNumber: Int { panel.windowNumber }
+  var windowLevelRawValue: Int { panel.level.rawValue }
 
   var estimatedSurfacePixels: Int {
     guard let frame else { return 0 }
@@ -283,7 +295,7 @@ private final class BorderSegment {
     panel.ignoresMouseEvents = true
     panel.hasShadow = false
     panel.sharingType = .none
-    panel.level = .floating
+    panel.level = .normal
     panel.collectionBehavior = [
       .canJoinAllSpaces,
       .stationary,
@@ -388,6 +400,15 @@ private final class BorderSegment {
     panel.alphaValue = 0
     panel.order(.above, relativeTo: targetWindowNumber)
     orderedIn = true
+  }
+
+  func setFrontmost(_ frontmost: Bool) {
+    let level: NSWindow.Level = frontmost ? .floating : .normal
+    guard panel.level != level else { return }
+    panel.level = level
+    if frontmost == false, orderedIn {
+      panel.order(.above, relativeTo: targetWindowNumber)
+    }
   }
 
   func applyCompositorFallback() {

--- a/Sources/DefiMacOS/WindowBorderOverlay.swift
+++ b/Sources/DefiMacOS/WindowBorderOverlay.swift
@@ -283,7 +283,7 @@ private final class BorderSegment {
     panel.ignoresMouseEvents = true
     panel.hasShadow = false
     panel.sharingType = .none
-    panel.level = .normal
+    panel.level = .floating
     panel.collectionBehavior = [
       .canJoinAllSpaces,
       .stationary,

--- a/Sources/DefiMacOS/WindowBorders.swift
+++ b/Sources/DefiMacOS/WindowBorders.swift
@@ -190,11 +190,32 @@ final class WindowBorderManager {
     revealPendingOpacities(in: overlays.values.filter(\.isVisible))
   }
 
+  func updateActiveStacking(
+    for expectedActiveWindowID: WindowID,
+    isFrontmost: Bool
+  ) {
+    guard activeWindowID == expectedActiveWindowID,
+      let overlay = overlays[expectedActiveWindowID]
+    else {
+      return
+    }
+    overlay.setFrontmost(isFrontmost)
+  }
+
   func prepareForSelection(
     _ windowID: WindowID?,
-    displayedFrame: Rect?
+    displayedFrame: Rect?,
+    activeWindowIsFrontmost: Bool = false
   ) {
-    guard activeWindowID != windowID else { return }
+    if activeWindowID == windowID {
+      if let windowID {
+        updateActiveStacking(
+          for: windowID,
+          isFrontmost: activeWindowIsFrontmost
+        )
+      }
+      return
+    }
     let previousActiveWindowID = activeWindowID
     activeWindowID = windowID
     guard let style = lastPlan?.style else {
@@ -204,6 +225,7 @@ final class WindowBorderManager {
       let overlay = overlays[previousActiveWindowID],
       overlay.isVisible
     {
+      overlay.setFrontmost(false)
       if style.inactiveEnabled {
         overlay.updateAppearance(to: style.inactiveColor)
       } else {
@@ -226,6 +248,7 @@ final class WindowBorderManager {
         overlays[windowID] = created
         overlay = created
       }
+      overlay.setFrontmost(activeWindowIsFrontmost)
       _ = overlay.syncGeometry(
         frame: displayedFrame,
         width: style.width,
@@ -264,9 +287,13 @@ final class WindowBorderManager {
 
   func sync(
     _ plan: WindowBorderRenderPlan,
-    displayedFrames: [WindowID: Rect]
+    displayedFrames: [WindowID: Rect],
+    activeWindowIsFrontmost: Bool
   ) {
     let trackedWindowIDs = Set(plan.tracked.map(\.windowID))
+    if let activeWindowID = plan.active?.windowID {
+      overlays[activeWindowID]?.setFrontmost(activeWindowIsFrontmost)
+    }
     guard plan != lastPlan || displayedFrames != lastDisplayedFrames else {
       skippedPlans += 1
       return
@@ -286,6 +313,7 @@ final class WindowBorderManager {
 
     if let assignment = plan.active {
       if let overlay = overlays[assignment.windowID] {
+        overlay.setFrontmost(activeWindowIsFrontmost)
         overlay.sync(
           frame: displayedFrames[assignment.windowID] ?? assignment.frame,
           width: plan.style.width,
@@ -298,6 +326,7 @@ final class WindowBorderManager {
 
     for assignment in plan.inactive {
       guard let overlay = overlays[assignment.windowID] else { continue }
+      overlay.setFrontmost(false)
       overlay.sync(
         frame: displayedFrames[assignment.windowID] ?? assignment.frame,
         width: plan.style.width,

--- a/Tests/DefiCLITests/ServiceTests.swift
+++ b/Tests/DefiCLITests/ServiceTests.swift
@@ -1,0 +1,28 @@
+import Testing
+
+@testable import DefiCLI
+
+struct ServiceTests {
+  @Test(
+    "An unloaded service refreshes its plist before bootstrap",
+    arguments: [false, true]
+  )
+  func unloadedServiceRefreshesPlist(plistExists: Bool) {
+    #expect(
+      serviceStartActions(
+        plistExists: plistExists,
+        isLoaded: false
+      ) == [.install, .bootstrap]
+    )
+  }
+
+  @Test
+  func loadedServiceOnlyKickstartsExistingJob() {
+    #expect(
+      serviceStartActions(
+        plistExists: true,
+        isLoaded: true
+      ) == [.kickstart]
+    )
+  }
+}

--- a/Tests/DefiMacOSTests/PlatformEventTests.swift
+++ b/Tests/DefiMacOSTests/PlatformEventTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import DefiModel
 import Testing
 
 @testable import DefiMacOS
@@ -7,38 +8,101 @@ struct PlatformEventTests {
   @Test
   func simpleClickDoesNotSynchronizeDesktop() {
     var normalizer = MouseGestureEventNormalizer()
-    let mouseDown = normalizer.shouldSynchronizeDesktop(
+    let mouseDown = normalizer.actions(
       for: .leftMouseDown
     )
-    let mouseUp = normalizer.shouldSynchronizeDesktop(for: .leftMouseUp)
+    let mouseUp = normalizer.actions(for: .leftMouseUp)
 
-    #expect(mouseDown == false)
-    #expect(mouseUp == false)
+    #expect(
+      mouseDown
+        == MouseGestureEventNormalizer.Actions(
+          refreshBorderStacking: true
+        )
+    )
+    #expect(mouseUp == MouseGestureEventNormalizer.Actions())
   }
 
   @Test
   func draggedGestureSynchronizesOnFirstMovementAndMouseUp() {
     var normalizer = MouseGestureEventNormalizer()
-    let mouseDown = normalizer.shouldSynchronizeDesktop(
+    let mouseDown = normalizer.actions(
       for: .leftMouseDown
     )
-    let firstMouseDragged = normalizer.shouldSynchronizeDesktop(
+    let firstMouseDragged = normalizer.actions(
       for: .leftMouseDragged
     )
-    let secondMouseDragged = normalizer.shouldSynchronizeDesktop(
+    let secondMouseDragged = normalizer.actions(
       for: .leftMouseDragged
     )
-    let firstMouseUp = normalizer.shouldSynchronizeDesktop(
+    let firstMouseUp = normalizer.actions(
       for: .leftMouseUp
     )
-    let secondMouseUp = normalizer.shouldSynchronizeDesktop(
+    let secondMouseUp = normalizer.actions(
       for: .leftMouseUp
     )
 
-    #expect(mouseDown == false)
-    #expect(firstMouseDragged)
-    #expect(secondMouseDragged == false)
-    #expect(firstMouseUp)
-    #expect(secondMouseUp == false)
+    #expect(mouseDown.refreshBorderStacking)
+    #expect(mouseDown.synchronizeDesktop == false)
+    #expect(firstMouseDragged.synchronizeDesktop)
+    #expect(secondMouseDragged == MouseGestureEventNormalizer.Actions())
+    #expect(firstMouseUp.synchronizeDesktop)
+    #expect(secondMouseUp == MouseGestureEventNormalizer.Actions())
+  }
+
+  @Test
+  func borderStackingRefreshIsLatestSelectionWins() throws {
+    var state = WindowBorderStackingRefreshState()
+    let firstWindow = WindowID(rawValue: 1)
+    let secondWindow = WindowID(rawValue: 2)
+    let firstRequest = state.request(for: firstWindow)
+    let first = try #require(firstRequest)
+    let secondRequest = state.request(for: secondWindow)
+    let second = try #require(secondRequest)
+
+    #expect(state.shouldApply(first, activeWindowID: firstWindow) == false)
+    #expect(state.shouldApply(second, activeWindowID: firstWindow) == false)
+    #expect(state.shouldApply(second, activeWindowID: secondWindow))
+  }
+
+  @Test
+  func frontmostBorderOccluderIgnoresTinyAuxiliaryWindows() {
+    let auxiliaryWindow = WindowID(rawValue: 1)
+    let focusedWindow = WindowID(rawValue: 2)
+
+    let result = frontmostBorderOccludingWindowID(
+      in: [
+        NormalWindowStackEntry(
+          windowID: auxiliaryWindow,
+          frame: Rect(x: 8, y: 40, width: 66, height: 20)
+        ),
+        NormalWindowStackEntry(
+          windowID: focusedWindow,
+          frame: Rect(x: 2, y: 34, width: 2_044, height: 1_354)
+        ),
+      ]
+    )
+
+    #expect(result == focusedWindow)
+  }
+
+  @Test
+  func frontmostBorderOccluderKeepsDialogsAheadOfFocusedWindow() {
+    let dialog = WindowID(rawValue: 1)
+    let focusedWindow = WindowID(rawValue: 2)
+
+    let result = frontmostBorderOccludingWindowID(
+      in: [
+        NormalWindowStackEntry(
+          windowID: dialog,
+          frame: Rect(x: 400, y: 300, width: 640, height: 480)
+        ),
+        NormalWindowStackEntry(
+          windowID: focusedWindow,
+          frame: Rect(x: 2, y: 34, width: 2_044, height: 1_354)
+        ),
+      ]
+    )
+
+    #expect(result == dialog)
   }
 }

--- a/Tests/DefiMacOSTests/WindowBorderTests.swift
+++ b/Tests/DefiMacOSTests/WindowBorderTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import CoreGraphics
 import DefiCore
 import DefiModel
@@ -276,5 +277,28 @@ struct WindowBorderTests {
 
     manager.prepareForSelection(third, displayedFrame: nil)
     #expect(manager.activeWindowID == third)
+  }
+
+  @Test @MainActor
+  func borderPanelsFloatOnlyWhileActiveWindowIsFrontmost() {
+    let overlay = BorderOverlay(windowID: WindowID(rawValue: 1))
+
+    #expect(
+      overlay.windowLevelRawValues.allSatisfy {
+        $0 == NSWindow.Level.normal.rawValue
+      }
+    )
+    overlay.setFrontmost(true)
+    #expect(
+      overlay.windowLevelRawValues.allSatisfy {
+        $0 == NSWindow.Level.floating.rawValue
+      }
+    )
+    overlay.setFrontmost(false)
+    #expect(
+      overlay.windowLevelRawValues.allSatisfy {
+        $0 == NSWindow.Level.normal.rawValue
+      }
+    )
   }
 }

--- a/script/build_and_run.sh
+++ b/script/build_and_run.sh
@@ -111,6 +111,7 @@ open_app() {
 
 start_runtime() {
   if [[ "$SERVICE_WAS_LOADED" -eq 1 ]]; then
+    "$INSTALLED_CLI" service install
     "$INSTALLED_CLI" service start
     sleep 0.2
     if ! /bin/launchctl print "$SERVICE_DOMAIN/$SERVICE_LABEL" >/dev/null 2>&1; then
@@ -131,6 +132,7 @@ case "$MODE" in
       lldb -- "$INSTALLED_BINARY"
       DEBUG_STATUS=$?
       set -e
+      "$INSTALLED_CLI" service install
       "$INSTALLED_CLI" service start
       exit "$DEBUG_STATUS"
     fi

--- a/script/build_and_run.sh
+++ b/script/build_and_run.sh
@@ -111,7 +111,6 @@ open_app() {
 
 start_runtime() {
   if [[ "$SERVICE_WAS_LOADED" -eq 1 ]]; then
-    "$INSTALLED_CLI" service install
     "$INSTALLED_CLI" service start
     sleep 0.2
     if ! /bin/launchctl print "$SERVICE_DOMAIN/$SERVICE_LABEL" >/dev/null 2>&1; then
@@ -132,7 +131,6 @@ case "$MODE" in
       lldb -- "$INSTALLED_BINARY"
       DEBUG_STATUS=$?
       set -e
-      "$INSTALLED_CLI" service install
       "$INSTALLED_CLI" service start
       exit "$DEBUG_STATUS"
     fi


### PR DESCRIPTION
## Why

Simplify Defi menu, prevent service relaunch after a deliberate quit, and keep focused-window borders above normal app windows.

## Changes

- Remove workspace header and unused focus/full-width commands.
- Keep service stopped after a successful quit; start loaded agent via kickstart.
- Reinstall LaunchAgent during build/run.
- Render border panels at floating window level.

## How to test

- `swift build`
- `swift test`
- `./script/build_and_run.sh --verify`
- Click repeatedly inside an already focused window; border stays visible.