### PR TITLE
Add live mouse window reordering

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -76,6 +76,16 @@ request Screen Recording permission. Z-order and capture sharing are independent
 after changing it. App-scoped capture tools such as Computer Use expose the Defi
 edge surfaces individually; full-desktop capture shows the composed border.
 
+## Mouse reordering
+
+Drag a tiled window by its native title bar. Crossing a neighboring slot reorders
+the column live and animates the other columns while the dragged window stays
+under the pointer. Vertical dragging reorders windows inside the same stacked
+column. Resizing remains width learning and never changes order. Reordering stays
+inside the window's current monitor and active workspace. Mouse-down on an
+adjacent column defers scroll alignment until release, so the strip stays fixed
+under the pointer while deciding between a click and a drag.
+
 ## `[workspaces]`
 
 ```toml

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Basic MVP includes:
 - `launchd` development service commands
 - native application/focus event synchronization
 - real frame/target reconciliation and mouse-resize width learning
+- title-bar drag reordering for columns and stacked windows
 - topology-aware parking lanes with one-pixel side anchors
 - delayed real-frame verification and automatic parking repair
 - continuous scrolling strip with bounded neighboring-column prefetch

--- a/Sources/DefiDaemon/DaemonAnimation.swift
+++ b/Sources/DefiDaemon/DaemonAnimation.swift
@@ -66,7 +66,7 @@ extension Daemon {
     }
   }
 
-  private func beginFrameAnimationActivity() {
+  func beginFrameAnimationActivity() {
     if animationActivity == nil {
       currentAnimationFrameCount = 0
       maximumAnimationStepDurationMS = 0
@@ -132,6 +132,9 @@ extension Daemon {
   }
 
   func cancelAnimationForMouseGesture() {
+    if activelyResizedWindowID != nil && platform.isLeftMouseButtonDown {
+      return
+    }
     guard !scrollAnimations.isEmpty || platform.hasPendingAnimatedFrameWrites else {
       return
     }

--- a/Sources/DefiDaemon/DaemonAnimation.swift
+++ b/Sources/DefiDaemon/DaemonAnimation.swift
@@ -134,9 +134,14 @@ extension Daemon {
   func cancelAnimationForMouseGesture() {
     cancelDeferredSlowLane()
     needsDesktopSync = true
-    guard !scrollAnimations.isEmpty || platform.hasPendingAnimatedFrameWrites else {
+    guard mouseGestureAnimationCancellationIsNeeded(
+      mouseReorderAnimationActive: mouseReorderAnimationActive,
+      scrollAnimationActive: !scrollAnimations.isEmpty,
+      animatedWritesPending: platform.hasPendingAnimatedFrameWrites
+    ) else {
       return
     }
+    rebaseActiveScrollOffsetToDisplayedFrames()
     if activelyResizedWindowID == nil {
       mouseGestureDisplayedOriginFrames = Dictionary(
         uniqueKeysWithValues: state.windows.map { windowID, window in
@@ -161,9 +166,24 @@ extension Daemon {
   }
 
   func beginMouseGesture() {
+    mouseGestureGeneration &+= 1
+    mouseGestureSettlement = nil
+    mouseReorderAnimationActive = false
     activelyResizedWindowID = nil
     mouseGestureInitialFrame = nil
     mouseGestureScrollAnchor = nil
+    mouseGestureDisplayedOriginFrames.removeAll(keepingCapacity: true)
+  }
+
+  func finishMouseGestureTracking(
+    preservingScrollAnchor: Bool = false
+  ) {
+    mouseGestureSettlement = nil
+    activelyResizedWindowID = nil
+    mouseGestureInitialFrame = nil
+    if !preservingScrollAnchor {
+      mouseGestureScrollAnchor = nil
+    }
     mouseGestureDisplayedOriginFrames.removeAll(keepingCapacity: true)
   }
 

--- a/Sources/DefiDaemon/DaemonAnimation.swift
+++ b/Sources/DefiDaemon/DaemonAnimation.swift
@@ -168,11 +168,18 @@ extension Daemon {
   func beginMouseGesture() {
     mouseGestureGeneration &+= 1
     mouseGestureSettlement = nil
+    mouseGesturePreempted = false
     mouseReorderAnimationActive = false
     activelyResizedWindowID = nil
     mouseGestureInitialFrame = nil
     mouseGestureScrollAnchor = nil
     mouseGestureDisplayedOriginFrames.removeAll(keepingCapacity: true)
+  }
+
+  func preemptMouseGesture() {
+    mouseGestureGeneration &+= 1
+    mouseGesturePreempted = true
+    finishMouseGestureTracking()
   }
 
   func finishMouseGestureTracking(

--- a/Sources/DefiDaemon/DaemonAnimation.swift
+++ b/Sources/DefiDaemon/DaemonAnimation.swift
@@ -132,6 +132,8 @@ extension Daemon {
   }
 
   func cancelAnimationForMouseGesture() {
+    cancelDeferredSlowLane()
+    needsDesktopSync = true
     guard !scrollAnimations.isEmpty || platform.hasPendingAnimatedFrameWrites else {
       return
     }
@@ -155,9 +157,14 @@ extension Daemon {
     }
     scrollAnimations.removeAll(keepingCapacity: true)
     pendingAnimatedFocusWindowID = nil
-    cancelDeferredSlowLane()
     platform.cancelPendingFrameWrites()
-    needsDesktopSync = true
+  }
+
+  func beginMouseGesture() {
+    activelyResizedWindowID = nil
+    mouseGestureInitialFrame = nil
+    mouseGestureScrollAnchor = nil
+    mouseGestureDisplayedOriginFrames.removeAll(keepingCapacity: true)
   }
 
   func finishPendingAnimatedFocusIfReady() {

--- a/Sources/DefiDaemon/DaemonAnimation.swift
+++ b/Sources/DefiDaemon/DaemonAnimation.swift
@@ -138,6 +138,19 @@ extension Daemon {
     guard !scrollAnimations.isEmpty || platform.hasPendingAnimatedFrameWrites else {
       return
     }
+    mouseGestureDisplayedOriginFrames = Dictionary(
+      uniqueKeysWithValues: state.windows.map { windowID, window in
+        let displayedPosition = platform.completedPosition(for: windowID)
+        return (
+          windowID,
+          resolvedMouseGestureOriginFrame(
+            observedFrame: window.frame,
+            displayedX: displayedPosition.map { Double($0.x) },
+            displayedY: displayedPosition.map { Double($0.y) }
+          )
+        )
+      }
+    )
     scrollAnimations.removeAll(keepingCapacity: true)
     pendingAnimatedFocusWindowID = nil
     cancelDeferredSlowLane()

--- a/Sources/DefiDaemon/DaemonAnimation.swift
+++ b/Sources/DefiDaemon/DaemonAnimation.swift
@@ -132,25 +132,27 @@ extension Daemon {
   }
 
   func cancelAnimationForMouseGesture() {
-    if activelyResizedWindowID != nil && platform.isLeftMouseButtonDown {
-      return
-    }
     guard !scrollAnimations.isEmpty || platform.hasPendingAnimatedFrameWrites else {
       return
     }
-    mouseGestureDisplayedOriginFrames = Dictionary(
-      uniqueKeysWithValues: state.windows.map { windowID, window in
-        let displayedPosition = platform.completedPosition(for: windowID)
-        return (
-          windowID,
-          resolvedMouseGestureOriginFrame(
-            observedFrame: window.frame,
-            displayedX: displayedPosition.map { Double($0.x) },
-            displayedY: displayedPosition.map { Double($0.y) }
+    if activelyResizedWindowID == nil {
+      mouseGestureDisplayedOriginFrames = Dictionary(
+        uniqueKeysWithValues: state.windows.map { windowID, window in
+          let displayedPosition = platform.completedPosition(for: windowID)
+          let displayedSize = platform.completedSize(for: windowID)
+          return (
+            windowID,
+            resolvedMouseGestureOriginFrame(
+              observedFrame: window.frame,
+              displayedX: displayedPosition.map { Double($0.x) },
+              displayedY: displayedPosition.map { Double($0.y) },
+              displayedWidth: displayedSize.map { Double($0.width) },
+              displayedHeight: displayedSize.map { Double($0.height) }
+            )
           )
-        )
-      }
-    )
+        }
+      )
+    }
     scrollAnimations.removeAll(keepingCapacity: true)
     pendingAnimatedFocusWindowID = nil
     cancelDeferredSlowLane()

--- a/Sources/DefiDaemon/DaemonCommands.swift
+++ b/Sources/DefiDaemon/DaemonCommands.swift
@@ -77,12 +77,13 @@ extension Daemon {
       pendingWindowRemovalFocusGuard = nil
       let switchesWorkspace = command.activatesWorkspace
       let mutatesWorkspaceWindows = command.movesWindowBetweenWorkspaces
-      if switchesWorkspace || mutatesWorkspaceWindows {
+      let resizesManagedLayout = command.resizesManagedLayout
+      if switchesWorkspace || mutatesWorkspaceWindows || resizesManagedLayout {
         preemptMouseGesture()
       }
       let speculativeRibbonNavigation = isSpeculativeRibbonNavigation(command)
       let animatedManagedResize =
-        command.resizesManagedLayout
+        resizesManagedLayout
         && config.animation.enabled
         && config.animation.durationMS > 0
       if !speculativeRibbonNavigation {

--- a/Sources/DefiDaemon/DaemonCommands.swift
+++ b/Sources/DefiDaemon/DaemonCommands.swift
@@ -78,10 +78,12 @@ extension Daemon {
       let switchesWorkspace = command.activatesWorkspace
       let mutatesWorkspaceWindows = command.movesWindowBetweenWorkspaces
       let resizesManagedLayout = command.resizesManagedLayout
-      if switchesWorkspace || mutatesWorkspaceWindows || resizesManagedLayout {
+      let speculativeRibbonNavigation = isSpeculativeRibbonNavigation(command)
+      if switchesWorkspace || mutatesWorkspaceWindows || resizesManagedLayout
+        || speculativeRibbonNavigation
+      {
         preemptMouseGesture()
       }
-      let speculativeRibbonNavigation = isSpeculativeRibbonNavigation(command)
       let animatedManagedResize =
         resizesManagedLayout
         && config.animation.enabled

--- a/Sources/DefiDaemon/DaemonCommands.swift
+++ b/Sources/DefiDaemon/DaemonCommands.swift
@@ -62,6 +62,7 @@ extension Daemon {
     do {
       let commandStartedAt = ProcessInfo.processInfo.systemUptime
       let command = try parseCommand(rawCommand)
+      latestCommandInputTimestamp = commandStartedAt
       pendingWindowRemovalFocusGuard = nil
       let switchesWorkspace = command.activatesWorkspace
       let mutatesWorkspaceWindows = command.movesWindowBetweenWorkspaces

--- a/Sources/DefiDaemon/DaemonCommands.swift
+++ b/Sources/DefiDaemon/DaemonCommands.swift
@@ -68,6 +68,7 @@ extension Daemon {
     do {
       let commandStartedAt = ProcessInfo.processInfo.systemUptime
       let command = try parseCommand(rawCommand)
+      mouseReorderAnimationActive = false
       latestCommandInputTimestamp = resolvedLatestCommandInputTimestamp(
         previousTimestamp: latestCommandInputTimestamp,
         capturedInputTimestamp: inputTimestamp,

--- a/Sources/DefiDaemon/DaemonCommands.swift
+++ b/Sources/DefiDaemon/DaemonCommands.swift
@@ -10,9 +10,9 @@ import OSLog
 
 @MainActor
 extension Daemon {
-  func enqueueHotKey(_ command: String) {
+  func enqueueHotKey(_ invocation: HotKeyInvocation) {
     guard pendingHotKeyCommands.count < 64 else { return }
-    pendingHotKeyCommands.append(command)
+    pendingHotKeyCommands.append(invocation)
     processPendingHotKeys()
   }
 
@@ -21,8 +21,11 @@ extension Daemon {
     processingHotKeyCommands = true
     defer { processingHotKeyCommands = false }
     for _ in 0..<min(pendingHotKeyCommands.count, 8) {
-      let command = pendingHotKeyCommands.removeFirst()
-      _ = handle(command)
+      let invocation = pendingHotKeyCommands.removeFirst()
+      _ = handle(
+        invocation.command,
+        inputTimestamp: invocation.timestamp
+      )
       processedHotKeyCount += 1
     }
   }
@@ -44,7 +47,10 @@ extension Daemon {
   }
 
   @discardableResult
-  func handle(_ rawCommand: String) -> CommandResponse {
+  func handle(
+    _ rawCommand: String,
+    inputTimestamp: TimeInterval? = nil
+  ) -> CommandResponse {
     if rawCommand == "status" {
       return .success(status())
     }
@@ -62,7 +68,11 @@ extension Daemon {
     do {
       let commandStartedAt = ProcessInfo.processInfo.systemUptime
       let command = try parseCommand(rawCommand)
-      latestCommandInputTimestamp = commandStartedAt
+      latestCommandInputTimestamp = resolvedLatestCommandInputTimestamp(
+        previousTimestamp: latestCommandInputTimestamp,
+        capturedInputTimestamp: inputTimestamp,
+        commandHandledAt: commandStartedAt
+      )
       pendingWindowRemovalFocusGuard = nil
       let switchesWorkspace = command.activatesWorkspace
       let mutatesWorkspaceWindows = command.movesWindowBetweenWorkspaces

--- a/Sources/DefiDaemon/DaemonCommands.swift
+++ b/Sources/DefiDaemon/DaemonCommands.swift
@@ -77,6 +77,9 @@ extension Daemon {
       pendingWindowRemovalFocusGuard = nil
       let switchesWorkspace = command.activatesWorkspace
       let mutatesWorkspaceWindows = command.movesWindowBetweenWorkspaces
+      if switchesWorkspace || mutatesWorkspaceWindows {
+        preemptMouseGesture()
+      }
       let speculativeRibbonNavigation = isSpeculativeRibbonNavigation(command)
       let animatedManagedResize =
         command.resizesManagedLayout

--- a/Sources/DefiDaemon/DaemonDesktop.swift
+++ b/Sources/DefiDaemon/DaemonDesktop.swift
@@ -17,6 +17,7 @@ private let displayLogger = Logger(
 extension Daemon {
   func synchronizeDesktop() {
     let snapshot = platform.snapshot(config: config)
+    let previousObservedWindowFrames = state.windows.mapValues(\.frame)
     let tracesWindowCreation = platform.hasNewlyDiscoveredWindows
     if tracesWindowCreation {
       platform.recordPerformanceTrace("sync-snapshot-return")
@@ -28,6 +29,11 @@ extension Daemon {
     }
     let previousSelectedWindowID = previousActiveMonitorID.flatMap {
       state.selectedWindowID(on: $0)
+    }
+    let mouseGestureEnded =
+      snapshot.mouseResizeGestureObserved && !snapshot.leftMouseButtonDown
+    let nativeFocusedScrollAnchor = snapshot.focusedWindowID.flatMap {
+      workspaceScrollAnchor(containing: $0, state: state)
     }
     let previousFloatingMonitorIDs = Dictionary(
       uniqueKeysWithValues: floatingWindowFrames.keys.compactMap { windowID in
@@ -82,11 +88,13 @@ extension Daemon {
       displayGeometryChanged: displayGeometryChanged,
       mouseResizeGestureActive: mouseResizeGestureActive
     )
-    let reassignedMonitorID = snapshot.focusedWindowID.flatMap {
-      reassignedFloatingMonitorIDs[$0]
-    } ?? previousSelectedWindowID.flatMap {
-      reassignedFloatingMonitorIDs[$0]
-    }
+    let reassignedMonitorID =
+      snapshot.focusedWindowID.flatMap {
+        reassignedFloatingMonitorIDs[$0]
+      }
+      ?? previousSelectedWindowID.flatMap {
+        reassignedFloatingMonitorIDs[$0]
+      }
     if let reassignedMonitorID {
       activeMonitorID = reassignedMonitorID
       nativelyFocusedMonitorID = reassignedMonitorID
@@ -137,21 +145,38 @@ extension Daemon {
     }
     if let focusedWindowID = snapshot.focusedWindowID {
       let nativeFocusAccepted =
-        snapshot.nativeFocusChanged
+        nativeFocusMutationIsReady(
+          nativeFocusChanged: snapshot.nativeFocusChanged,
+          mouseGestureEnded: mouseGestureEnded,
+          leftMouseButtonDown: snapshot.leftMouseButtonDown
+        )
         && !preservesWorkspaceAfterRemoval
-        && ProcessInfo.processInfo.systemUptime >= suppressNativeFocusUntil
+        && (mouseGestureEnded
+          || ProcessInfo.processInfo.systemUptime >= suppressNativeFocusUntil)
       let selectionChanged = nativeFocusChangesSelection(
         focusedWindowID,
         activeMonitorID: activeMonitorID,
         state: state
       )
-      if !preservesWorkspaceAfterRemoval
+      if snapshot.leftMouseButtonDown && snapshot.nativeFocusChanged
+        && selectionChanged
+      {
+        platform.recordPerformanceTrace(
+          "mouse-focus-deferred window=\(focusedWindowID.rawValue)"
+        )
+      }
+      if !preservesWorkspaceAfterRemoval && !snapshot.leftMouseButtonDown
         && (activeMonitorID == nil || (nativeFocusAccepted && selectionChanged))
       {
         let activatedWorkspace = focusWindow(focusedWindowID, state: &state)
         nativelyActivatedWorkspace = nativeFocusAccepted && activatedWorkspace
         activeMonitorID = state.monitorID(containing: focusedWindowID)
         nativelyFocusedMonitorID = activeMonitorID
+        if mouseGestureEnded {
+          platform.recordPerformanceTrace(
+            "mouse-focus-committed window=\(focusedWindowID.rawValue)"
+          )
+        }
       } else if nativeFocusAccepted {
         ignoredRedundantNativeFocusCount += 1
       }
@@ -166,11 +191,86 @@ extension Daemon {
       ?? snapshot.focusedWindowID.flatMap { state.monitorID(containing: $0) }
       ?? state.monitors.first?.id
 
+    var mouseReordered = false
     if !displayGeometryChanged && mouseResizeGestureActive {
-      if !snapshot.leftMouseButtonDown {
-        activelyResizedWindowID = nil
+      let translatedWindowID = mouseTranslatedTiledWindowID(
+        externallyChangedFrames: snapshot.externallyChangedFrames,
+        state: state,
+        viewports: viewportsByMonitor
+      )
+      let gestureWindowID = mouseGestureTiledWindowID(
+        translatedWindowID: translatedWindowID,
+        activeWindowID: activelyResizedWindowID,
+        focusedWindowID: snapshot.focusedWindowID,
+        state: state
+      )
+      let actualFrame = gestureWindowID.flatMap { windowID in
+        snapshot.windows.first(where: { $0.id == windowID })?.frame
       }
-      for (windowID, frame) in snapshot.externallyChangedFrames {
+      if snapshot.leftMouseButtonDown {
+        if gestureWindowID != activelyResizedWindowID {
+          mouseGestureInitialFrame = gestureWindowID.flatMap { windowID in
+            previousObservedWindowFrames[windowID] ?? actualFrame
+          }
+        }
+        activelyResizedWindowID = gestureWindowID
+        if let gestureWindowID,
+          let actualFrame,
+          let mouseGestureInitialFrame,
+          mouseFrameWasTranslated(
+            from: mouseGestureInitialFrame,
+            to: actualFrame
+          ),
+          reorderTiledWindowAfterMouseDrag(
+            gestureWindowID,
+            actualFrame: actualFrame,
+            initialFrame: mouseGestureInitialFrame,
+            state: &state,
+            viewports: viewportsByMonitor
+          )
+        {
+          mouseReordered = true
+          platform.recordPerformanceTrace(
+            "mouse-reorder-live window=\(gestureWindowID.rawValue)"
+          )
+        }
+      } else {
+        if let gestureWindowID,
+          let actualFrame,
+          let mouseGestureInitialFrame,
+          mouseFrameWasTranslated(
+            from: mouseGestureInitialFrame,
+            to: actualFrame
+          ),
+          reorderTiledWindowAfterMouseDrag(
+            gestureWindowID,
+            actualFrame: actualFrame,
+            initialFrame: mouseGestureInitialFrame,
+            state: &state,
+            viewports: viewportsByMonitor
+          )
+        {
+          mouseReordered = true
+          platform.recordPerformanceTrace(
+            "mouse-reorder window=\(gestureWindowID.rawValue)"
+          )
+        }
+        activelyResizedWindowID = nil
+        mouseGestureInitialFrame = nil
+      }
+      if !mouseReordered,
+        let gestureWindowID,
+        let actualFrame
+      {
+        _ = learnTiledWindowWidth(
+          gestureWindowID,
+          actualFrame: actualFrame,
+          state: &state,
+          viewports: viewportsByMonitor
+        )
+      }
+      for (windowID, frame) in snapshot.externallyChangedFrames
+      where windowID != gestureWindowID {
         if learnTiledWindowWidth(
           windowID,
           actualFrame: frame,
@@ -182,10 +282,15 @@ extension Daemon {
       }
     } else {
       activelyResizedWindowID = nil
+      mouseGestureInitialFrame = nil
       learnPersistentWidthConstraints(targetMismatches)
     }
     synchronizeScrollOffsets(state: &state, viewports: viewportsByMonitor)
-    if let nativelyFocusedMonitorID,
+    let preservesMouseViewport = mouseReordered && nativeFocusedScrollAnchor != nil
+    if preservesMouseViewport, let nativeFocusedScrollAnchor {
+      restoreWorkspaceScroll(nativeFocusedScrollAnchor, state: &state)
+    }
+    if !preservesMouseViewport, let nativelyFocusedMonitorID,
       snapshot.focusedWindowID.flatMap({ state.windows[$0]?.floating }) != true
     {
       alignFocusedColumnLeft(
@@ -198,15 +303,27 @@ extension Daemon {
     if tracesWindowCreation {
       platform.recordPerformanceTrace("sync-before-layout")
     }
+    let animatesMouseReorder =
+      mouseReordered
+      && snapshot.leftMouseButtonDown
+      && config.animation.enabled
+      && config.animation.durationMS > 0
+    if animatesMouseReorder {
+      beginFrameAnimationActivity()
+    }
     applyCurrentLayout(
       asynchronousPositions: true,
       updateVisibility: true,
       positionTimeoutSeconds: 0.05,
+      animationDuration: animatesMouseReorder
+        ? TimeInterval(config.animation.durationMS) / 1_000
+        : 0,
+      positionsOnly: animatesMouseReorder,
       stagesVisibleBeforeParking: nativelyActivatedWorkspace,
       forceFloatingFrameWrites: displayGeometryChanged,
       source: nativelyActivatedWorkspace
         ? "native-workspace"
-        : "desktop-sync"
+        : (animatesMouseReorder ? "mouse-reorder-animation" : "desktop-sync")
     )
     if let guardedRemovalFocus {
       platform.focus(

--- a/Sources/DefiDaemon/DaemonDesktop.swift
+++ b/Sources/DefiDaemon/DaemonDesktop.swift
@@ -18,6 +18,11 @@ extension Daemon {
   func synchronizeDesktop() {
     let snapshot = platform.snapshot(config: config)
     let previousObservedWindowFrames = state.windows.mapValues(\.frame)
+    let previousMouseGestureWindowFrames = previousObservedWindowFrames.merging(
+      mouseGestureDisplayedOriginFrames
+    ) { _, displayedFrame in
+      displayedFrame
+    }
     let tracesWindowCreation = platform.hasNewlyDiscoveredWindows
     if tracesWindowCreation {
       platform.recordPerformanceTrace("sync-snapshot-return")
@@ -58,6 +63,7 @@ extension Daemon {
       pendingWindowRemovalFocusGuard = nil
       cancelDeferredSlowLane()
       persistentWidthDriftCounts.removeAll(keepingCapacity: true)
+      mouseGestureDisplayedOriginFrames.removeAll(keepingCapacity: true)
     }
     latestMonitors = snapshot.monitors
     targetMismatchCount = displayGeometryChanged ? 0 : snapshot.targetMismatchCount
@@ -146,6 +152,10 @@ extension Daemon {
       }
     }
     if let focusedWindowID = snapshot.focusedWindowID {
+      let keyboardFocusIntentCurrent = keyboardFocusIntentIsCurrent(
+        keyboardFocusIntentTimestamp: snapshot.keyboardFocusIntentTimestamp,
+        latestCommandInputTimestamp: latestCommandInputTimestamp
+      )
       let mouseReleaseFocusIntentCurrent = mouseReleaseFocusIntentIsCurrent(
         focusedWindowID: focusedWindowID,
         mouseFocusIntentWindowID: snapshot.mouseFocusIntentWindowID,
@@ -158,23 +168,26 @@ extension Daemon {
           nativeFocusChanged: snapshot.nativeFocusChanged,
           mouseInteractionEnded: mouseInteractionEnded,
           leftMouseButtonDown: snapshot.leftMouseButtonDown,
-          mouseReleaseFocusIntentCurrent: mouseReleaseFocusIntentCurrent
+          mouseReleaseFocusIntentCurrent: mouseReleaseFocusIntentCurrent,
+          keyboardFocusIntentCurrent: keyboardFocusIntentCurrent
         )
         && !preservesWorkspaceAfterRemoval
-        && ProcessInfo.processInfo.systemUptime >= suppressNativeFocusUntil
+        && (keyboardFocusIntentCurrent
+          || ProcessInfo.processInfo.systemUptime >= suppressNativeFocusUntil)
       let selectionChanged = nativeFocusChangesSelection(
         focusedWindowID,
         activeMonitorID: activeMonitorID,
         state: state
       )
       if snapshot.leftMouseButtonDown && snapshot.nativeFocusChanged
-        && selectionChanged
+        && selectionChanged && !nativeFocusAccepted
       {
         platform.recordPerformanceTrace(
           "mouse-focus-deferred window=\(focusedWindowID.rawValue)"
         )
       }
-      if !preservesWorkspaceAfterRemoval && !snapshot.leftMouseButtonDown
+      if !preservesWorkspaceAfterRemoval
+        && (!snapshot.leftMouseButtonDown || nativeFocusAccepted)
         && (activeMonitorID == nil || (nativeFocusAccepted && selectionChanged))
       {
         let activatedWorkspace = focusWindow(focusedWindowID, state: &state)
@@ -229,7 +242,7 @@ extension Daemon {
         activeWindowID: activelyResizedWindowID,
         translatedWindowID: translatedWindowID,
         leftMouseButtonDown: snapshot.leftMouseButtonDown,
-        previousObservedFrames: previousObservedWindowFrames,
+        previousObservedFrames: previousMouseGestureWindowFrames,
         actualFrame: actualFrame
       )
       if snapshot.leftMouseButtonDown {
@@ -277,6 +290,7 @@ extension Daemon {
         }
         activelyResizedWindowID = nil
         mouseGestureInitialFrame = nil
+        mouseGestureDisplayedOriginFrames.removeAll(keepingCapacity: true)
       }
       if !mouseReordered,
         let gestureWindowID,
@@ -294,6 +308,7 @@ extension Daemon {
     } else {
       activelyResizedWindowID = nil
       mouseGestureInitialFrame = nil
+      mouseGestureDisplayedOriginFrames.removeAll(keepingCapacity: true)
       learnPersistentWidthConstraints(targetMismatches)
     }
     synchronizeScrollOffsets(state: &state, viewports: viewportsByMonitor)

--- a/Sources/DefiDaemon/DaemonDesktop.swift
+++ b/Sources/DefiDaemon/DaemonDesktop.swift
@@ -280,11 +280,13 @@ extension Daemon {
       }
       if !mouseReordered,
         let gestureWindowID,
-        let actualFrame
+        let externallyChangedFrame = snapshot.externallyChangedFrames[
+          gestureWindowID
+        ]
       {
         _ = learnTiledWindowWidth(
           gestureWindowID,
-          actualFrame: actualFrame,
+          actualFrame: externallyChangedFrame,
           state: &state,
           viewports: viewportsByMonitor
         )

--- a/Sources/DefiDaemon/DaemonDesktop.swift
+++ b/Sources/DefiDaemon/DaemonDesktop.swift
@@ -81,6 +81,16 @@ extension Daemon {
       placementPreferences: placementPreferences,
       state: &state
     )
+    deferredMouseFocusIntent = updatedDeferredMouseFocusIntent(
+      current: deferredMouseFocusIntent,
+      mouseFocusIntentWindowID: snapshot.mouseFocusIntentWindowID.flatMap {
+        state.windows[$0] == nil ? nil : $0
+      },
+      mouseFocusIntentTimestamp: snapshot.mouseFocusIntentTimestamp,
+      focusedWindowID: snapshot.focusedWindowID,
+      nativeFocusChanged: snapshot.nativeFocusChanged,
+      mouseInteractionEnded: mouseInteractionEnded
+    )
     if displayGeometryChanged {
       rebaseFloatingWindowFrames(
         previousViewports: previousViewports,
@@ -158,16 +168,23 @@ extension Daemon {
       )
       let mouseReleaseFocusIntentCurrent = mouseReleaseFocusIntentIsCurrent(
         focusedWindowID: focusedWindowID,
-        mouseFocusIntentWindowID: snapshot.mouseFocusIntentWindowID,
-        mouseFocusIntentTimestamp: snapshot.mouseFocusIntentTimestamp,
+        mouseFocusIntentWindowID: deferredMouseFocusIntent?.windowID,
+        mouseFocusIntentTimestamp: deferredMouseFocusIntent?.timestamp,
         latestCommandInputTimestamp: latestCommandInputTimestamp,
-        nativeFocusChanged: snapshot.nativeFocusChanged
+        nativeFocusChanged: deferredMouseFocusIntent?.focusObserved == true
       )
+      let deferredMouseFocusPending = deferredMouseFocusIntent != nil
+      let deferredMouseFocusReady =
+        deferredMouseFocusIntent?.mouseInteractionEnded == true
+        && (deferredMouseFocusIntent?.focusObserved == true
+          || deferredMouseFocusIntent?.windowID == focusedWindowID)
       let nativeFocusAccepted =
         nativeFocusMutationIsReady(
           nativeFocusChanged: snapshot.nativeFocusChanged,
           mouseInteractionEnded: mouseInteractionEnded,
           leftMouseButtonDown: snapshot.leftMouseButtonDown,
+          deferredMouseFocusPending: deferredMouseFocusPending,
+          deferredMouseFocusReady: deferredMouseFocusReady,
           mouseReleaseFocusIntentCurrent: mouseReleaseFocusIntentCurrent,
           keyboardFocusIntentCurrent: keyboardFocusIntentCurrent
         )
@@ -201,6 +218,16 @@ extension Daemon {
         }
       } else if nativeFocusAccepted {
         ignoredRedundantNativeFocusCount += 1
+      }
+      if nativeFocusAccepted && deferredMouseFocusReady {
+        deferredMouseFocusIntent = nil
+      } else if deferredMouseFocusPending
+        && snapshot.nativeFocusChanged
+        && !snapshot.leftMouseButtonDown
+        && !keyboardFocusIntentCurrent
+        && !mouseReleaseFocusIntentCurrent
+      {
+        deferredMouseFocusIntent = nil
       }
     }
     if let activeMonitorID,
@@ -275,7 +302,7 @@ extension Daemon {
             from: mouseGestureInitialFrame,
             to: actualFrame
           ),
-          reorderTiledWindowAfterMouseDrag(
+          reorderTiledWindowAfterCompletedMouseDrag(
             gestureWindowID,
             actualFrame: actualFrame,
             initialFrame: mouseGestureInitialFrame,

--- a/Sources/DefiDaemon/DaemonDesktop.swift
+++ b/Sources/DefiDaemon/DaemonDesktop.swift
@@ -32,6 +32,8 @@ extension Daemon {
     }
     let mouseGestureEnded =
       snapshot.mouseResizeGestureObserved && !snapshot.leftMouseButtonDown
+    let mouseInteractionEnded =
+      mouseGestureEnded || snapshot.mouseFocusReleaseObserved
     let nativeFocusedScrollAnchor = snapshot.focusedWindowID.flatMap {
       workspaceScrollAnchor(containing: $0, state: state)
     }
@@ -144,15 +146,22 @@ extension Daemon {
       }
     }
     if let focusedWindowID = snapshot.focusedWindowID {
+      let mouseReleaseFocusIntentCurrent = mouseReleaseFocusIntentIsCurrent(
+        focusedWindowID: focusedWindowID,
+        mouseFocusIntentWindowID: snapshot.mouseFocusIntentWindowID,
+        mouseFocusIntentTimestamp: snapshot.mouseFocusIntentTimestamp,
+        latestCommandInputTimestamp: latestCommandInputTimestamp,
+        nativeFocusChanged: snapshot.nativeFocusChanged
+      )
       let nativeFocusAccepted =
         nativeFocusMutationIsReady(
           nativeFocusChanged: snapshot.nativeFocusChanged,
-          mouseGestureEnded: mouseGestureEnded,
-          leftMouseButtonDown: snapshot.leftMouseButtonDown
+          mouseInteractionEnded: mouseInteractionEnded,
+          leftMouseButtonDown: snapshot.leftMouseButtonDown,
+          mouseReleaseFocusIntentCurrent: mouseReleaseFocusIntentCurrent
         )
         && !preservesWorkspaceAfterRemoval
-        && (mouseGestureEnded
-          || ProcessInfo.processInfo.systemUptime >= suppressNativeFocusUntil)
+        && ProcessInfo.processInfo.systemUptime >= suppressNativeFocusUntil
       let selectionChanged = nativeFocusChangesSelection(
         focusedWindowID,
         activeMonitorID: activeMonitorID,
@@ -172,7 +181,7 @@ extension Daemon {
         nativelyActivatedWorkspace = nativeFocusAccepted && activatedWorkspace
         activeMonitorID = state.monitorID(containing: focusedWindowID)
         nativelyFocusedMonitorID = activeMonitorID
-        if mouseGestureEnded {
+        if mouseInteractionEnded {
           platform.recordPerformanceTrace(
             "mouse-focus-committed window=\(focusedWindowID.rawValue)"
           )
@@ -193,7 +202,13 @@ extension Daemon {
 
     var mouseReordered = false
     if !displayGeometryChanged && mouseResizeGestureActive {
+      let mouseGestureCandidateWindowIDs = [
+        activelyResizedWindowID,
+        snapshot.mouseFocusIntentWindowID,
+        snapshot.focusedWindowID,
+      ].compactMap { $0 }
       let translatedWindowID = mouseTranslatedTiledWindowID(
+        candidateWindowIDs: mouseGestureCandidateWindowIDs,
         externallyChangedFrames: snapshot.externallyChangedFrames,
         state: state,
         viewports: viewportsByMonitor
@@ -201,18 +216,23 @@ extension Daemon {
       let gestureWindowID = mouseGestureTiledWindowID(
         translatedWindowID: translatedWindowID,
         activeWindowID: activelyResizedWindowID,
+        mouseFocusIntentWindowID: snapshot.mouseFocusIntentWindowID,
         focusedWindowID: snapshot.focusedWindowID,
         state: state
       )
       let actualFrame = gestureWindowID.flatMap { windowID in
         snapshot.windows.first(where: { $0.id == windowID })?.frame
       }
+      mouseGestureInitialFrame = resolvedMouseGestureInitialFrame(
+        currentInitialFrame: mouseGestureInitialFrame,
+        gestureWindowID: gestureWindowID,
+        activeWindowID: activelyResizedWindowID,
+        translatedWindowID: translatedWindowID,
+        leftMouseButtonDown: snapshot.leftMouseButtonDown,
+        previousObservedFrames: previousObservedWindowFrames,
+        actualFrame: actualFrame
+      )
       if snapshot.leftMouseButtonDown {
-        if gestureWindowID != activelyResizedWindowID {
-          mouseGestureInitialFrame = gestureWindowID.flatMap { windowID in
-            previousObservedWindowFrames[windowID] ?? actualFrame
-          }
-        }
         activelyResizedWindowID = gestureWindowID
         if let gestureWindowID,
           let actualFrame,
@@ -268,17 +288,6 @@ extension Daemon {
           state: &state,
           viewports: viewportsByMonitor
         )
-      }
-      for (windowID, frame) in snapshot.externallyChangedFrames
-      where windowID != gestureWindowID {
-        if learnTiledWindowWidth(
-          windowID,
-          actualFrame: frame,
-          state: &state,
-          viewports: viewportsByMonitor
-        ) {
-          activelyResizedWindowID = snapshot.leftMouseButtonDown ? windowID : nil
-        }
       }
     } else {
       activelyResizedWindowID = nil

--- a/Sources/DefiDaemon/DaemonDesktop.swift
+++ b/Sources/DefiDaemon/DaemonDesktop.swift
@@ -102,9 +102,10 @@ extension Daemon {
     }
     let postReleaseMouseGestureActive = mouseGestureSettlement != nil
     let mouseResizeGestureActive =
-      snapshot.leftMouseButtonDown
-      || snapshot.mouseResizeGestureObserved
-      || postReleaseMouseGestureActive
+      !mouseGesturePreempted
+      && (snapshot.leftMouseButtonDown
+        || snapshot.mouseResizeGestureObserved
+        || postReleaseMouseGestureActive)
     let reassignedFloatingMonitorIDs = updateFloatingWindowFrames(
       from: snapshot.windows,
       externallyChangedFrames: snapshot.externallyChangedFrames,
@@ -366,13 +367,17 @@ extension Daemon {
       }
       if !mouseReordered,
         let gestureWindowID,
-        let externallyChangedFrame = snapshot.externallyChangedFrames[
-          gestureWindowID
-        ]
+        let widthLearningFrame = mouseGestureWidthLearningFrame(
+          externallyChangedFrame: snapshot.externallyChangedFrames[
+            gestureWindowID
+          ],
+          actualFrame: actualFrame,
+          postReleaseSettlementActive: postReleaseMouseGestureActive
+        )
       {
         _ = learnTiledWindowWidth(
           gestureWindowID,
-          actualFrame: externallyChangedFrame,
+          actualFrame: widthLearningFrame,
           state: &state,
           viewports: viewportsByMonitor
         )

--- a/Sources/DefiDaemon/DaemonDesktop.swift
+++ b/Sources/DefiDaemon/DaemonDesktop.swift
@@ -39,9 +39,6 @@ extension Daemon {
       snapshot.mouseResizeGestureObserved && !snapshot.leftMouseButtonDown
     let mouseInteractionEnded =
       mouseGestureEnded || snapshot.mouseFocusReleaseObserved
-    let nativeFocusedScrollAnchor = snapshot.focusedWindowID.flatMap {
-      workspaceScrollAnchor(containing: $0, state: state)
-    }
     let previousFloatingMonitorIDs = Dictionary(
       uniqueKeysWithValues: floatingWindowFrames.keys.compactMap { windowID in
         state.monitorID(containing: windowID).map { (windowID, $0) }
@@ -64,6 +61,7 @@ extension Daemon {
       consumeDeferredMouseFocusIntent()
       cancelDeferredSlowLane()
       persistentWidthDriftCounts.removeAll(keepingCapacity: true)
+      mouseGestureScrollAnchor = nil
       mouseGestureDisplayedOriginFrames.removeAll(keepingCapacity: true)
     }
     latestMonitors = snapshot.monitors
@@ -262,6 +260,12 @@ extension Daemon {
         focusedWindowID: snapshot.focusedWindowID,
         state: state
       )
+      mouseGestureScrollAnchor = resolvedMouseGestureScrollAnchor(
+        current: mouseGestureScrollAnchor,
+        gestureWindowID: gestureWindowID,
+        mouseGestureActive: mouseResizeGestureActive,
+        state: state
+      )
       let actualFrame = gestureWindowID.flatMap { windowID in
         snapshot.windows.first(where: { $0.id == windowID })?.frame
       }
@@ -337,13 +341,14 @@ extension Daemon {
     } else {
       activelyResizedWindowID = nil
       mouseGestureInitialFrame = nil
+      mouseGestureScrollAnchor = nil
       mouseGestureDisplayedOriginFrames.removeAll(keepingCapacity: true)
       learnPersistentWidthConstraints(targetMismatches)
     }
     synchronizeScrollOffsets(state: &state, viewports: viewportsByMonitor)
-    let preservesMouseViewport = mouseReordered && nativeFocusedScrollAnchor != nil
-    if preservesMouseViewport, let nativeFocusedScrollAnchor {
-      restoreWorkspaceScroll(nativeFocusedScrollAnchor, state: &state)
+    let preservesMouseViewport = mouseGestureScrollAnchor != nil
+    if let mouseGestureScrollAnchor {
+      restoreWorkspaceScroll(mouseGestureScrollAnchor, state: &state)
     }
     if !preservesMouseViewport, let nativelyFocusedMonitorID,
       snapshot.focusedWindowID.flatMap({ state.windows[$0]?.floating }) != true
@@ -388,6 +393,9 @@ extension Daemon {
     }
     persistPlacements()
     updateMenuBar()
+    if !snapshot.leftMouseButtonDown {
+      mouseGestureScrollAnchor = nil
+    }
   }
 
   func persistPlacements() {

--- a/Sources/DefiDaemon/DaemonDesktop.swift
+++ b/Sources/DefiDaemon/DaemonDesktop.swift
@@ -61,6 +61,7 @@ extension Daemon {
       scrollAnimations.removeAll(keepingCapacity: true)
       pendingAnimatedFocusWindowID = nil
       pendingWindowRemovalFocusGuard = nil
+      consumeDeferredMouseFocusIntent()
       cancelDeferredSlowLane()
       persistentWidthDriftCounts.removeAll(keepingCapacity: true)
       mouseGestureDisplayedOriginFrames.removeAll(keepingCapacity: true)
@@ -83,6 +84,7 @@ extension Daemon {
     )
     deferredMouseFocusIntent = updatedDeferredMouseFocusIntent(
       current: deferredMouseFocusIntent,
+      consumedMouseFocusIntentTimestamp: consumedMouseFocusIntentTimestamp,
       mouseFocusIntentWindowID: snapshot.mouseFocusIntentWindowID.flatMap {
         state.windows[$0] == nil ? nil : $0
       },
@@ -220,14 +222,14 @@ extension Daemon {
         ignoredRedundantNativeFocusCount += 1
       }
       if nativeFocusAccepted && deferredMouseFocusReady {
-        deferredMouseFocusIntent = nil
+        consumeDeferredMouseFocusIntent()
       } else if deferredMouseFocusPending
         && snapshot.nativeFocusChanged
         && !snapshot.leftMouseButtonDown
         && !keyboardFocusIntentCurrent
         && !mouseReleaseFocusIntentCurrent
       {
-        deferredMouseFocusIntent = nil
+        consumeDeferredMouseFocusIntent()
       }
     }
     if let activeMonitorID,
@@ -398,6 +400,16 @@ extension Daemon {
     } catch {
       log("placement persistence failed: \(error)")
     }
+  }
+
+  private func consumeDeferredMouseFocusIntent() {
+    if let timestamp = deferredMouseFocusIntent?.timestamp {
+      consumedMouseFocusIntentTimestamp = max(
+        consumedMouseFocusIntentTimestamp,
+        timestamp
+      )
+    }
+    deferredMouseFocusIntent = nil
   }
 
   private func displayGeometryDescription(

--- a/Sources/DefiDaemon/DaemonDesktop.swift
+++ b/Sources/DefiDaemon/DaemonDesktop.swift
@@ -61,8 +61,7 @@ extension Daemon {
       consumeDeferredMouseFocusIntent()
       cancelDeferredSlowLane()
       persistentWidthDriftCounts.removeAll(keepingCapacity: true)
-      mouseGestureScrollAnchor = nil
-      mouseGestureDisplayedOriginFrames.removeAll(keepingCapacity: true)
+      finishMouseGestureTracking()
     }
     latestMonitors = snapshot.monitors
     targetMismatchCount = displayGeometryChanged ? 0 : snapshot.targetMismatchCount
@@ -98,8 +97,14 @@ extension Daemon {
         previousMonitorIDs: previousFloatingMonitorIDs
       )
     }
+    if mouseGestureSettlement?.generation != mouseGestureGeneration {
+      mouseGestureSettlement = nil
+    }
+    let postReleaseMouseGestureActive = mouseGestureSettlement != nil
     let mouseResizeGestureActive =
-      snapshot.leftMouseButtonDown || snapshot.mouseResizeGestureObserved
+      snapshot.leftMouseButtonDown
+      || snapshot.mouseResizeGestureObserved
+      || postReleaseMouseGestureActive
     let reassignedFloatingMonitorIDs = updateFloatingWindowFrames(
       from: snapshot.windows,
       externallyChangedFrames: snapshot.externallyChangedFrames,
@@ -321,9 +326,43 @@ extension Daemon {
             "mouse-reorder window=\(gestureWindowID.rawValue)"
           )
         }
-        activelyResizedWindowID = nil
-        mouseGestureInitialFrame = nil
-        mouseGestureDisplayedOriginFrames.removeAll(keepingCapacity: true)
+        if mouseGestureEnded,
+          let gestureWindowID,
+          let mouseGestureInitialFrame,
+          let actualFrame
+        {
+          let now = ProcessInfo.processInfo.systemUptime
+          mouseGestureSettlement = MouseGestureSettlement(
+            generation: mouseGestureGeneration,
+            windowID: gestureWindowID,
+            initialFrame: mouseGestureInitialFrame,
+            releasedFrame: actualFrame,
+            now: now,
+            maximumDuration: mouseGestureSettlementMaximumDuration(
+              latencySensitive: platform.latencySensitiveWindowIDs.contains(
+                gestureWindowID
+              )
+            )
+          )
+          activelyResizedWindowID = gestureWindowID
+        } else if let settlement = mouseGestureSettlement,
+          settlement.generation == mouseGestureGeneration,
+          settlement.windowID == gestureWindowID,
+          let actualFrame
+        {
+          let update = advanceMouseGestureSettlement(
+            settlement,
+            actualFrame: actualFrame,
+            now: ProcessInfo.processInfo.systemUptime,
+            animationPending: platform.hasPendingAnimatedFrameWrites
+          )
+          mouseGestureSettlement = update.settlement
+          if update.shouldFinish {
+            finishMouseGestureTracking(preservingScrollAnchor: true)
+          }
+        } else {
+          finishMouseGestureTracking()
+        }
       }
       if !mouseReordered,
         let gestureWindowID,
@@ -339,10 +378,7 @@ extension Daemon {
         )
       }
     } else {
-      activelyResizedWindowID = nil
-      mouseGestureInitialFrame = nil
-      mouseGestureScrollAnchor = nil
-      mouseGestureDisplayedOriginFrames.removeAll(keepingCapacity: true)
+      finishMouseGestureTracking()
       learnPersistentWidthConstraints(targetMismatches)
     }
     synchronizeScrollOffsets(state: &state, viewports: viewportsByMonitor)
@@ -369,6 +405,7 @@ extension Daemon {
       && config.animation.enabled
       && config.animation.durationMS > 0
     if animatesMouseReorder {
+      mouseReorderAnimationActive = true
       beginFrameAnimationActivity()
     }
     applyCurrentLayout(
@@ -393,7 +430,7 @@ extension Daemon {
     }
     persistPlacements()
     updateMenuBar()
-    if !snapshot.leftMouseButtonDown {
+    if !snapshot.leftMouseButtonDown && mouseGestureSettlement == nil {
       mouseGestureScrollAnchor = nil
     }
   }

--- a/Sources/DefiDaemon/DefiDaemon.swift
+++ b/Sources/DefiDaemon/DefiDaemon.swift
@@ -97,6 +97,7 @@ final class Daemon: NSObject {
   var targetMismatches: [FrameMismatch] = []
   var activelyResizedWindowID: WindowID?
   var mouseGestureInitialFrame: Rect?
+  var mouseGestureScrollAnchor: WorkspaceScrollAnchor?
   var mouseGestureDisplayedOriginFrames: [WindowID: Rect] = [:]
   var persistentWidthDriftCounts: [WindowID: Int] = [:]
   var floatingWindowFrames: [WindowID: Rect] = [:]
@@ -152,6 +153,9 @@ final class Daemon: NSObject {
       displayConfigurationHandler: { [weak self] in
         self?.scheduleDisplayReconciliation()
       },
+      mouseGestureStartedHandler: { [weak self] in
+        self?.beginMouseGesture()
+      },
       mouseGestureHandler: { [weak self] in
         self?.cancelAnimationForMouseGesture()
       }
@@ -195,6 +199,9 @@ final class Daemon: NSObject {
     let mouseGestureSyncPending =
       needsDesktopSync
       && (liveBorderGesture || activelyResizedWindowID != nil)
+    if mouseGestureSyncPending && !deferredSlowWindowIDs.isEmpty {
+      cancelDeferredSlowLane()
+    }
     if mouseGestureSyncPending
       && (!scrollAnimations.isEmpty || platform.hasPendingAnimatedFrameWrites)
     {

--- a/Sources/DefiDaemon/DefiDaemon.swift
+++ b/Sources/DefiDaemon/DefiDaemon.swift
@@ -101,6 +101,7 @@ final class Daemon: NSObject {
   var mouseGestureDisplayedOriginFrames: [WindowID: Rect] = [:]
   var mouseGestureGeneration: UInt64 = 0
   var mouseGestureSettlement: MouseGestureSettlement?
+  var mouseGesturePreempted = false
   var mouseReorderAnimationActive = false
   var persistentWidthDriftCounts: [WindowID: Int] = [:]
   var floatingWindowFrames: [WindowID: Rect] = [:]

--- a/Sources/DefiDaemon/DefiDaemon.swift
+++ b/Sources/DefiDaemon/DefiDaemon.swift
@@ -97,6 +97,7 @@ final class Daemon: NSObject {
   var targetMismatches: [FrameMismatch] = []
   var activelyResizedWindowID: WindowID?
   var mouseGestureInitialFrame: Rect?
+  var mouseGestureDisplayedOriginFrames: [WindowID: Rect] = [:]
   var persistentWidthDriftCounts: [WindowID: Int] = [:]
   var floatingWindowFrames: [WindowID: Rect] = [:]
   var scrollAnimations: [ScrollAnimationKey: ScrollAnimation] = [:]

--- a/Sources/DefiDaemon/DefiDaemon.swift
+++ b/Sources/DefiDaemon/DefiDaemon.swift
@@ -88,7 +88,7 @@ final class Daemon: NSObject {
   private var tickCount = 0
   var shouldShutdown = false
   var signalSources: [DispatchSourceSignal] = []
-  var pendingHotKeyCommands: [String] = []
+  var pendingHotKeyCommands: [HotKeyInvocation] = []
   var processingHotKeyCommands = false
   var processedHotKeyCount = 0
   var needsDesktopSync = true
@@ -158,8 +158,8 @@ final class Daemon: NSObject {
       let manager = try HotKeyManager(
         config: config,
         userInputTracker: platform.userInputTracker
-      ) { [weak self] command in
-        self?.enqueueHotKey(command)
+      ) { [weak self] invocation in
+        self?.enqueueHotKey(invocation)
       }
       try manager.start()
       hotKeys = manager

--- a/Sources/DefiDaemon/DefiDaemon.swift
+++ b/Sources/DefiDaemon/DefiDaemon.swift
@@ -109,6 +109,7 @@ final class Daemon: NSObject {
   var lastAnimationDurationMS = 0.0
   var lastCommandDurationMS = 0.0
   var latestCommandInputTimestamp: TimeInterval = 0
+  var deferredMouseFocusIntent: DeferredMouseFocusIntent?
   var suppressNativeFocusUntil: TimeInterval = 0
   var ignoredRedundantNativeFocusCount = 0
   var pendingWindowRemovalFocusGuard: WindowRemovalFocusGuard?
@@ -189,8 +190,16 @@ final class Daemon: NSObject {
       needsDesktopSync = true
     }
     tickCount += 1
-    let animatedWritesPending = platform.hasPendingAnimatedFrameWrites
     let liveBorderGesture = platform.isLeftMouseButtonDown
+    let mouseGestureSyncPending =
+      needsDesktopSync
+      && (liveBorderGesture || activelyResizedWindowID != nil)
+    if mouseGestureSyncPending
+      && (!scrollAnimations.isEmpty || platform.hasPendingAnimatedFrameWrites)
+    {
+      cancelAnimationForMouseGesture()
+    }
+    let animatedWritesPending = platform.hasPendingAnimatedFrameWrites
     if liveBorderGesture {
       setTimerFrequency(min(activeDisplayRefreshRate, 120))
     }
@@ -206,10 +215,14 @@ final class Daemon: NSObject {
       }
       setTimerFrequency(60)
     }
-    if scrollAnimations.isEmpty && !animatedWritesPending
-      && deferredSlowWindowIDs.isEmpty
-      && (needsDesktopSync || tickCount.isMultiple(of: 18))
-    {
+    if desktopSynchronizationIsReady(
+      scrollAnimationActive: !scrollAnimations.isEmpty,
+      animatedWritesPending: animatedWritesPending,
+      slowLanePending: !deferredSlowWindowIDs.isEmpty,
+      mouseGestureSyncPending: mouseGestureSyncPending,
+      needsDesktopSync: needsDesktopSync,
+      periodicSyncDue: tickCount.isMultiple(of: 18)
+    ) {
       needsDesktopSync = false
       synchronizeDesktop()
     }

--- a/Sources/DefiDaemon/DefiDaemon.swift
+++ b/Sources/DefiDaemon/DefiDaemon.swift
@@ -96,6 +96,7 @@ final class Daemon: NSObject {
   var targetMismatchCount = 0
   var targetMismatches: [FrameMismatch] = []
   var activelyResizedWindowID: WindowID?
+  var mouseGestureInitialFrame: Rect?
   var persistentWidthDriftCounts: [WindowID: Int] = [:]
   var floatingWindowFrames: [WindowID: Rect] = [:]
   var scrollAnimations: [ScrollAnimationKey: ScrollAnimation] = [:]

--- a/Sources/DefiDaemon/DefiDaemon.swift
+++ b/Sources/DefiDaemon/DefiDaemon.swift
@@ -107,6 +107,7 @@ final class Daemon: NSObject {
   var maximumAnimationStepDurationMS = 0.0
   var lastAnimationDurationMS = 0.0
   var lastCommandDurationMS = 0.0
+  var latestCommandInputTimestamp: TimeInterval = 0
   var suppressNativeFocusUntil: TimeInterval = 0
   var ignoredRedundantNativeFocusCount = 0
   var pendingWindowRemovalFocusGuard: WindowRemovalFocusGuard?

--- a/Sources/DefiDaemon/DefiDaemon.swift
+++ b/Sources/DefiDaemon/DefiDaemon.swift
@@ -99,6 +99,9 @@ final class Daemon: NSObject {
   var mouseGestureInitialFrame: Rect?
   var mouseGestureScrollAnchor: WorkspaceScrollAnchor?
   var mouseGestureDisplayedOriginFrames: [WindowID: Rect] = [:]
+  var mouseGestureGeneration: UInt64 = 0
+  var mouseGestureSettlement: MouseGestureSettlement?
+  var mouseReorderAnimationActive = false
   var persistentWidthDriftCounts: [WindowID: Int] = [:]
   var floatingWindowFrames: [WindowID: Rect] = [:]
   var scrollAnimations: [ScrollAnimationKey: ScrollAnimation] = [:]
@@ -195,6 +198,17 @@ final class Daemon: NSObject {
       needsDesktopSync = true
     }
     tickCount += 1
+    let now = ProcessInfo.processInfo.systemUptime
+    if let mouseGestureSettlement,
+      now >= mouseGestureSettlement.nextCheckAt
+    {
+      needsDesktopSync = true
+    }
+    if mouseReorderAnimationActive
+      && !platform.hasPendingAnimatedFrameWrites
+    {
+      mouseReorderAnimationActive = false
+    }
     let liveBorderGesture = platform.isLeftMouseButtonDown
     let mouseGestureSyncPending =
       needsDesktopSync

--- a/Sources/DefiDaemon/DefiDaemon.swift
+++ b/Sources/DefiDaemon/DefiDaemon.swift
@@ -110,6 +110,7 @@ final class Daemon: NSObject {
   var lastCommandDurationMS = 0.0
   var latestCommandInputTimestamp: TimeInterval = 0
   var deferredMouseFocusIntent: DeferredMouseFocusIntent?
+  var consumedMouseFocusIntentTimestamp: TimeInterval = 0
   var suppressNativeFocusUntil: TimeInterval = 0
   var ignoredRedundantNativeFocusCount = 0
   var pendingWindowRemovalFocusGuard: WindowRemovalFocusGuard?

--- a/Sources/DefiMacOS/HotKeys.swift
+++ b/Sources/DefiMacOS/HotKeys.swift
@@ -15,9 +15,19 @@ public enum HotKeyError: Error, CustomStringConvertible {
   }
 }
 
+public struct HotKeyInvocation: Equatable, Sendable {
+  public let command: String
+  public let timestamp: TimeInterval
+
+  public init(command: String, timestamp: TimeInterval) {
+    self.command = command
+    self.timestamp = timestamp
+  }
+}
+
 @MainActor
 public final class HotKeyManager {
-  public typealias Handler = @MainActor @Sendable (String) -> Void
+  public typealias Handler = @MainActor @Sendable (HotKeyInvocation) -> Void
 
   private let bindings: [Key: String]
   private let handler: Handler
@@ -76,10 +86,10 @@ public final class HotKeyManager {
     let context = HotKeyTapContext(
       bindings: bindings,
       userInputTracker: userInputTracker
-    ) { command in
+    ) { invocation in
       DispatchQueue.main.async {
         MainActor.assumeIsolated {
-          handler(command)
+          handler(invocation)
         }
       }
     }
@@ -126,7 +136,7 @@ private final class HotKeyTapContext: @unchecked Sendable {
 
   private let bindings: [Key: String]
   private let userInputTracker: UserInputTracker
-  private let deliver: @Sendable (String) -> Void
+  private let deliver: @Sendable (HotKeyInvocation) -> Void
   private let lock = NSLock()
   private let ready = DispatchSemaphore(value: 0)
   private var tap: CFMachPort?
@@ -138,7 +148,7 @@ private final class HotKeyTapContext: @unchecked Sendable {
   init(
     bindings: [Key: String],
     userInputTracker: UserInputTracker,
-    deliver: @escaping @Sendable (String) -> Void
+    deliver: @escaping @Sendable (HotKeyInvocation) -> Void
   ) {
     self.bindings = bindings
     self.userInputTracker = userInputTracker
@@ -187,6 +197,7 @@ private final class HotKeyTapContext: @unchecked Sendable {
       }
       return Unmanaged.passUnretained(event)
     }
+    let timestamp = Double(event.timestamp) / 1_000_000_000
     let isKeyDown = type == .keyDown
     if isKeyDown || type == .leftMouseDown {
       let code = CGKeyCode(event.getIntegerValueField(.keyboardEventKeycode))
@@ -205,7 +216,7 @@ private final class HotKeyTapContext: @unchecked Sendable {
         focusIntent = nil
       }
       userInputTracker.record(
-        timestamp: Double(event.timestamp) / 1_000_000_000,
+        timestamp: timestamp,
         focusIntent: focusIntent,
         closeIntent: isKeyDown && commandPressed
           && Self.closeWindowKeyCodes.contains(code)
@@ -222,7 +233,7 @@ private final class HotKeyTapContext: @unchecked Sendable {
     lock.lock()
     captured += 1
     lock.unlock()
-    deliver(command)
+    deliver(HotKeyInvocation(command: command, timestamp: timestamp))
     return nil
   }
 

--- a/Sources/DefiMacOS/MacOSPlatform+FrameApplication.swift
+++ b/Sources/DefiMacOS/MacOSPlatform+FrameApplication.swift
@@ -9,6 +9,10 @@ import OSLog
 @MainActor
 extension MacOSPlatform {
 
+  public func completedSize(for windowID: WindowID) -> CGSize? {
+    frameCoordinator.completedSize(for: windowID)
+  }
+
   public func apply(
     _ assignments: [FrameAssignment],
     hiddenWindowIDs: Set<WindowID> = [],

--- a/Sources/DefiMacOS/MacOSPlatform+Snapshot.swift
+++ b/Sources/DefiMacOS/MacOSPlatform+Snapshot.swift
@@ -152,7 +152,8 @@ extension MacOSPlatform {
 
     let nextWindowIDs = Set(nextElements.keys)
     let removedWindowIDs = Set(previousElements.keys).subtracting(nextWindowIDs)
-    newlyDiscoveredWindowIDs = hasCompletedWindowSnapshot
+    newlyDiscoveredWindowIDs =
+      hasCompletedWindowSnapshot
       ? nextWindowIDs.subtracting(previousElements.keys)
       : []
     if tracesWindowTopology || !newlyDiscoveredWindowIDs.isEmpty {
@@ -192,6 +193,7 @@ extension MacOSPlatform {
       button: .left
     )
     let mouseResizeGestureObserved = mouseResizeGesturePending
+    let mouseFocusReleaseObserved = mouseFocusReleasePending
     let externalResizeGestureActive =
       leftMouseButtonDown || mouseResizeGestureObserved
     var externallyChangedFrames: [WindowID: Rect] = [:]
@@ -260,6 +262,7 @@ extension MacOSPlatform {
     }
     frameEventPending = false
     mouseResizeGesturePending = false
+    mouseFocusReleasePending = false
     pendingFrameCorrections = Dictionary(
       uniqueKeysWithValues: targetMismatches.map { ($0.windowID, $0.actual) }
     )
@@ -313,6 +316,17 @@ extension MacOSPlatform {
       )
     }
     let userInput = userInputTracker.snapshot
+    let mouseFocusIntentWindowID: WindowID?
+    let mouseFocusIntentTimestamp: TimeInterval?
+    if let focusIntent = userInput.latestFocusIntent,
+      case .mouse(let windowID) = focusIntent.source
+    {
+      mouseFocusIntentWindowID = windowID
+      mouseFocusIntentTimestamp = focusIntent.timestamp
+    } else {
+      mouseFocusIntentWindowID = nil
+      mouseFocusIntentTimestamp = nil
+    }
     return DesktopSnapshot(
       monitors: monitors,
       windows: windows,
@@ -330,6 +344,9 @@ extension MacOSPlatform {
       externallyChangedFrames: externallyChangedFrames,
       leftMouseButtonDown: leftMouseButtonDown,
       mouseResizeGestureObserved: mouseResizeGestureObserved,
+      mouseFocusReleaseObserved: mouseFocusReleaseObserved,
+      mouseFocusIntentWindowID: mouseFocusIntentWindowID,
+      mouseFocusIntentTimestamp: mouseFocusIntentTimestamp,
       targetMismatchCount: targetMismatches.count,
       targetMismatches: targetMismatches
     )

--- a/Sources/DefiMacOS/MacOSPlatform+Snapshot.swift
+++ b/Sources/DefiMacOS/MacOSPlatform+Snapshot.swift
@@ -318,14 +318,23 @@ extension MacOSPlatform {
     let userInput = userInputTracker.snapshot
     let mouseFocusIntentWindowID: WindowID?
     let mouseFocusIntentTimestamp: TimeInterval?
+    let keyboardFocusIntentTimestamp: TimeInterval?
     if let focusIntent = userInput.latestFocusIntent,
       case .mouse(let windowID) = focusIntent.source
     {
       mouseFocusIntentWindowID = windowID
       mouseFocusIntentTimestamp = focusIntent.timestamp
+      keyboardFocusIntentTimestamp = nil
+    } else if let focusIntent = userInput.latestFocusIntent,
+      case .keyboard = focusIntent.source
+    {
+      mouseFocusIntentWindowID = nil
+      mouseFocusIntentTimestamp = nil
+      keyboardFocusIntentTimestamp = focusIntent.timestamp
     } else {
       mouseFocusIntentWindowID = nil
       mouseFocusIntentTimestamp = nil
+      keyboardFocusIntentTimestamp = nil
     }
     return DesktopSnapshot(
       monitors: monitors,
@@ -347,6 +356,7 @@ extension MacOSPlatform {
       mouseFocusReleaseObserved: mouseFocusReleaseObserved,
       mouseFocusIntentWindowID: mouseFocusIntentWindowID,
       mouseFocusIntentTimestamp: mouseFocusIntentTimestamp,
+      keyboardFocusIntentTimestamp: keyboardFocusIntentTimestamp,
       targetMismatchCount: targetMismatches.count,
       targetMismatches: targetMismatches
     )

--- a/Sources/DefiMacOS/MacOSPlatform+WindowBorderObservation.swift
+++ b/Sources/DefiMacOS/MacOSPlatform+WindowBorderObservation.swift
@@ -12,6 +12,7 @@ extension MacOSPlatform {
   public func startObserving(
     _ handler: @escaping () -> Void,
     displayConfigurationHandler: @escaping () -> Void = {},
+    mouseGestureStartedHandler: @escaping () -> Void = {},
     mouseGestureHandler: @escaping () -> Void = {}
   ) {
     guard eventMonitor == nil else { return }
@@ -97,7 +98,8 @@ extension MacOSPlatform {
       },
       borderStackingHandler: { [weak self] in
         self?.scheduleWindowBorderStackingRefresh()
-      }
+      },
+      mouseGestureStartedHandler: mouseGestureStartedHandler
     )
     monitor.start()
     eventMonitor = monitor

--- a/Sources/DefiMacOS/MacOSPlatform+WindowBorderObservation.swift
+++ b/Sources/DefiMacOS/MacOSPlatform+WindowBorderObservation.swift
@@ -53,7 +53,17 @@ extension MacOSPlatform {
         }
         if kind == .mouse {
           self?.mouseResizeGesturePending = true
-          self?.pendingFrameRequiresFullSnapshot = true
+          if let self,
+            let processID = mouseGestureRefreshProcessID(
+              latestFocusIntent: userInputTracker.snapshot.latestFocusIntent,
+              focusedWindowID: lastNativeFocusedWindowID,
+              processIDs: processIDs
+            )
+          {
+            pendingFrameProcessIDs.insert(processID)
+          } else {
+            self?.pendingFrameRequiresFullSnapshot = true
+          }
           if self?.isLeftMouseButtonDown == true {
             self?.frameCoordinator.suspendInitialSettlementRepairs()
           }

--- a/Sources/DefiMacOS/MacOSPlatform+WindowBorderObservation.swift
+++ b/Sources/DefiMacOS/MacOSPlatform+WindowBorderObservation.swift
@@ -57,6 +57,9 @@ extension MacOSPlatform {
             self?.frameCoordinator.suspendInitialSettlementRepairs()
           }
         }
+        if kind == .mouseRelease {
+          self?.mouseFocusReleasePending = true
+        }
         if kind == .focus {
           self?.userInputTracker.recordObservedFocus(
             windowID: nil,
@@ -69,7 +72,7 @@ extension MacOSPlatform {
         if kind == .screens {
           displayConfigurationHandler()
         }
-        if kind == .mouse {
+        if kind == .mouse || kind == .mouseRelease {
           mouseGestureHandler()
         }
         handler()

--- a/Sources/DefiMacOS/MacOSPlatform+WindowBorderObservation.swift
+++ b/Sources/DefiMacOS/MacOSPlatform+WindowBorderObservation.swift
@@ -72,7 +72,7 @@ extension MacOSPlatform {
         if kind == .screens {
           displayConfigurationHandler()
         }
-        if kind == .mouse || kind == .mouseRelease {
+        if platformEventCancelsMouseAnimation(kind) {
           mouseGestureHandler()
         }
         handler()

--- a/Sources/DefiMacOS/MacOSPlatform.swift
+++ b/Sources/DefiMacOS/MacOSPlatform.swift
@@ -40,6 +40,7 @@ public final class MacOSPlatform {
   var eventMonitor: PlatformEventMonitor?
   var frameEventPending = false
   var mouseResizeGesturePending = false
+  var mouseFocusReleasePending = false
   var nativeFocusEventPending = false
   var nativeFocusRetryCount = 0
   var lastFocusedWindowByProcess: [pid_t: WindowID] = [:]

--- a/Sources/DefiMacOS/PlatformEventMonitor.swift
+++ b/Sources/DefiMacOS/PlatformEventMonitor.swift
@@ -10,6 +10,7 @@ final class PlatformEventMonitor {
   private let frameHandler: (AXUIElement) -> Void
   private let liveFrameHandler: () -> Void
   private let borderStackingHandler: () -> Void
+  private let mouseGestureStartedHandler: () -> Void
   private var workspaceTokens: [NSObjectProtocol] = []
   private var screenTokens: [NSObjectProtocol] = []
   private var mouseMonitor: Any?
@@ -24,13 +25,15 @@ final class PlatformEventMonitor {
     userInputTracker: UserInputTracker = UserInputTracker(),
     frameHandler: @escaping (AXUIElement) -> Void = { _ in },
     liveFrameHandler: @escaping () -> Void = {},
-    borderStackingHandler: @escaping () -> Void = {}
+    borderStackingHandler: @escaping () -> Void = {},
+    mouseGestureStartedHandler: @escaping () -> Void = {}
   ) {
     self.handler = handler
     self.userInputTracker = userInputTracker
     self.frameHandler = frameHandler
     self.liveFrameHandler = liveFrameHandler
     self.borderStackingHandler = borderStackingHandler
+    self.mouseGestureStartedHandler = mouseGestureStartedHandler
   }
 
   func start() {
@@ -115,6 +118,9 @@ final class PlatformEventMonitor {
         let actions = self.mouseGestureNormalizer.actions(for: event.type)
         if actions.refreshBorderStacking {
           self.borderStackingHandler()
+        }
+        if actions.startsGesture {
+          self.mouseGestureStartedHandler()
         }
         switch actions.synchronization {
         case .gesture:

--- a/Sources/DefiMacOS/PlatformEventMonitor.swift
+++ b/Sources/DefiMacOS/PlatformEventMonitor.swift
@@ -66,9 +66,10 @@ final class PlatformEventMonitor {
         object: nil,
         queue: .main
       ) { [weak self] notification in
-        let processID = (notification.userInfo?[
-          NSWorkspace.applicationUserInfoKey
-        ] as? NSRunningApplication)?.processIdentifier
+        let processID =
+          (notification.userInfo?[
+            NSWorkspace.applicationUserInfoKey
+          ] as? NSRunningApplication)?.processIdentifier
         MainActor.assumeIsolated {
           self?.handler(.applicationTerminated, processID)
         }
@@ -97,9 +98,10 @@ final class PlatformEventMonitor {
       MainActor.assumeIsolated {
         guard let self else { return }
         if event.type == .leftMouseDown {
-          let rawWindowID = event.cgEvent?.getIntegerValueField(
-            .mouseEventWindowUnderMousePointerThatCanHandleThisEvent
-          ) ?? Int64(event.windowNumber)
+          let rawWindowID =
+            event.cgEvent?.getIntegerValueField(
+              .mouseEventWindowUnderMousePointerThatCanHandleThisEvent
+            ) ?? Int64(event.windowNumber)
           self.userInputTracker.record(
             timestamp: event.timestamp,
             focusIntent: .mouse(
@@ -114,8 +116,13 @@ final class PlatformEventMonitor {
         if actions.refreshBorderStacking {
           self.borderStackingHandler()
         }
-        if actions.synchronizeDesktop {
+        switch actions.synchronization {
+        case .gesture:
           self.handler(.mouse, nil)
+        case .clickRelease:
+          self.handler(.mouseRelease, nil)
+        case nil:
+          break
         }
       }
     }

--- a/Sources/DefiMacOS/PlatformEventNormalization.swift
+++ b/Sources/DefiMacOS/PlatformEventNormalization.swift
@@ -10,6 +10,7 @@ enum PlatformEventKind: Equatable {
   case frame
   case windows
   case mouse
+  case mouseRelease
   case screens
 }
 
@@ -137,18 +138,20 @@ public final class UserInputTracker: @unchecked Sendable {
       guard observedFocusIntentTimestamp == focusIntent.timestamp else {
         return nil
       }
-      guard let target = observedFocusTargets.reversed().first(where: {
-        if let excludingWindowID, $0.windowID == excludingWindowID {
-          return false
-        }
-        if $0.windowID == nil,
-          let excludingProcessID,
-          $0.processID == excludingProcessID
-        {
-          return false
-        }
-        return true
-      }) else {
+      guard
+        let target = observedFocusTargets.reversed().first(where: {
+          if let excludingWindowID, $0.windowID == excludingWindowID {
+            return false
+          }
+          if $0.windowID == nil,
+            let excludingProcessID,
+            $0.processID == excludingProcessID
+          {
+            return false
+          }
+          return true
+        })
+      else {
         return nil
       }
       return FocusRecoveryTarget(
@@ -196,7 +199,7 @@ func updatedWindowTopologyInputTimestamp(
   switch kind {
   case .windows, .applicationTerminated:
     return latestInputTimestamp
-  case .application, .focus, .frame, .mouse, .screens:
+  case .application, .focus, .frame, .mouse, .mouseRelease, .screens:
     return previousTimestamp
   }
 }
@@ -251,18 +254,24 @@ func windowSnapshotInvalidation(
     return processID.map(WindowSnapshotInvalidation.process) ?? .full
   case .application, .screens:
     return .full
-  case .focus, .frame, .mouse:
+  case .focus, .frame, .mouse, .mouseRelease:
     return .none
   }
 }
 
 struct MouseGestureEventNormalizer {
+  enum Synchronization: Equatable {
+    case gesture
+    case clickRelease
+  }
+
   struct Actions: Equatable {
     var refreshBorderStacking = false
-    var synchronizeDesktop = false
+    var synchronization: Synchronization?
   }
 
   private var pressed = false
+  private var dragged = false
   private var synchronizedDuringGesture = false
 
   mutating func actions(
@@ -271,20 +280,24 @@ struct MouseGestureEventNormalizer {
     switch eventType {
     case .leftMouseDown:
       pressed = true
+      dragged = false
       synchronizedDuringGesture = false
       return Actions(refreshBorderStacking: true)
     case .leftMouseDragged:
+      dragged = true
       guard synchronizedDuringGesture == false else {
         return Actions()
       }
       synchronizedDuringGesture = true
-      return Actions(synchronizeDesktop: true)
+      return Actions(synchronization: .gesture)
     case .leftMouseUp:
       defer {
         pressed = false
+        dragged = false
         synchronizedDuringGesture = false
       }
-      return Actions(synchronizeDesktop: pressed)
+      guard pressed else { return Actions() }
+      return Actions(synchronization: dragged ? .gesture : .clickRelease)
     default:
       return Actions()
     }

--- a/Sources/DefiMacOS/PlatformEventNormalization.swift
+++ b/Sources/DefiMacOS/PlatformEventNormalization.swift
@@ -14,6 +14,10 @@ enum PlatformEventKind: Equatable {
   case screens
 }
 
+func platformEventCancelsMouseAnimation(_ kind: PlatformEventKind) -> Bool {
+  kind == .mouse
+}
+
 enum WindowSnapshotInvalidation: Equatable {
   case none
   case process(pid_t)

--- a/Sources/DefiMacOS/PlatformEventNormalization.swift
+++ b/Sources/DefiMacOS/PlatformEventNormalization.swift
@@ -262,7 +262,7 @@ struct MouseGestureEventNormalizer {
     var synchronizeDesktop = false
   }
 
-  private var moved = false
+  private var pressed = false
   private var synchronizedDuringGesture = false
 
   mutating func actions(
@@ -270,11 +270,10 @@ struct MouseGestureEventNormalizer {
   ) -> Actions {
     switch eventType {
     case .leftMouseDown:
-      moved = false
+      pressed = true
       synchronizedDuringGesture = false
       return Actions(refreshBorderStacking: true)
     case .leftMouseDragged:
-      moved = true
       guard synchronizedDuringGesture == false else {
         return Actions()
       }
@@ -282,10 +281,10 @@ struct MouseGestureEventNormalizer {
       return Actions(synchronizeDesktop: true)
     case .leftMouseUp:
       defer {
-        moved = false
+        pressed = false
         synchronizedDuringGesture = false
       }
-      return Actions(synchronizeDesktop: moved)
+      return Actions(synchronizeDesktop: pressed)
     default:
       return Actions()
     }

--- a/Sources/DefiMacOS/PlatformEventNormalization.swift
+++ b/Sources/DefiMacOS/PlatformEventNormalization.swift
@@ -271,6 +271,7 @@ struct MouseGestureEventNormalizer {
 
   struct Actions: Equatable {
     var refreshBorderStacking = false
+    var startsGesture = false
     var synchronization: Synchronization?
   }
 
@@ -284,7 +285,7 @@ struct MouseGestureEventNormalizer {
     case .leftMouseDown:
       pressed = true
       dragged = false
-      return Actions(refreshBorderStacking: true)
+      return Actions(refreshBorderStacking: true, startsGesture: true)
     case .leftMouseDragged:
       dragged = true
       // Platform sync demand is a Boolean, so repeated drag events coalesce

--- a/Sources/DefiMacOS/PlatformEventNormalization.swift
+++ b/Sources/DefiMacOS/PlatformEventNormalization.swift
@@ -18,6 +18,28 @@ func platformEventCancelsMouseAnimation(_ kind: PlatformEventKind) -> Bool {
   kind == .mouse
 }
 
+func mouseGestureRefreshProcessID(
+  latestFocusIntent: UserInputTracker.FocusIntent?,
+  focusedWindowID: WindowID?,
+  processIDs: [WindowID: pid_t]
+) -> pid_t? {
+  let mouseWindowID: WindowID?
+  if let latestFocusIntent,
+    case .mouse(let windowID) = latestFocusIntent.source
+  {
+    mouseWindowID = windowID
+  } else {
+    mouseWindowID = nil
+  }
+
+  for windowID in [mouseWindowID, focusedWindowID].compactMap({ $0 }) {
+    if let processID = processIDs[windowID] {
+      return processID
+    }
+  }
+  return nil
+}
+
 enum WindowSnapshotInvalidation: Equatable {
   case none
   case process(pid_t)

--- a/Sources/DefiMacOS/PlatformEventNormalization.swift
+++ b/Sources/DefiMacOS/PlatformEventNormalization.swift
@@ -272,7 +272,6 @@ struct MouseGestureEventNormalizer {
 
   private var pressed = false
   private var dragged = false
-  private var synchronizedDuringGesture = false
 
   mutating func actions(
     for eventType: NSEvent.EventType
@@ -281,20 +280,16 @@ struct MouseGestureEventNormalizer {
     case .leftMouseDown:
       pressed = true
       dragged = false
-      synchronizedDuringGesture = false
       return Actions(refreshBorderStacking: true)
     case .leftMouseDragged:
       dragged = true
-      guard synchronizedDuringGesture == false else {
-        return Actions()
-      }
-      synchronizedDuringGesture = true
+      // Platform sync demand is a Boolean, so repeated drag events coalesce
+      // while still scheduling fresh snapshots after live reorder animations.
       return Actions(synchronization: .gesture)
     case .leftMouseUp:
       defer {
         pressed = false
         dragged = false
-        synchronizedDuringGesture = false
       }
       guard pressed else { return Actions() }
       return Actions(synchronization: dragged ? .gesture : .clickRelease)

--- a/Sources/DefiMacOS/PlatformModels.swift
+++ b/Sources/DefiMacOS/PlatformModels.swift
@@ -61,6 +61,9 @@ public struct DesktopSnapshot: Sendable {
   public let externallyChangedFrames: [WindowID: Rect]
   public let leftMouseButtonDown: Bool
   public let mouseResizeGestureObserved: Bool
+  public let mouseFocusReleaseObserved: Bool
+  public let mouseFocusIntentWindowID: WindowID?
+  public let mouseFocusIntentTimestamp: TimeInterval?
   public let targetMismatchCount: Int
   public let targetMismatches: [FrameMismatch]
 
@@ -75,6 +78,9 @@ public struct DesktopSnapshot: Sendable {
     externallyChangedFrames: [WindowID: Rect] = [:],
     leftMouseButtonDown: Bool = false,
     mouseResizeGestureObserved: Bool = false,
+    mouseFocusReleaseObserved: Bool = false,
+    mouseFocusIntentWindowID: WindowID? = nil,
+    mouseFocusIntentTimestamp: TimeInterval? = nil,
     targetMismatchCount: Int = 0,
     targetMismatches: [FrameMismatch] = []
   ) {
@@ -88,6 +94,9 @@ public struct DesktopSnapshot: Sendable {
     self.externallyChangedFrames = externallyChangedFrames
     self.leftMouseButtonDown = leftMouseButtonDown
     self.mouseResizeGestureObserved = mouseResizeGestureObserved
+    self.mouseFocusReleaseObserved = mouseFocusReleaseObserved
+    self.mouseFocusIntentWindowID = mouseFocusIntentWindowID
+    self.mouseFocusIntentTimestamp = mouseFocusIntentTimestamp
     self.targetMismatchCount = targetMismatchCount
     self.targetMismatches = targetMismatches
   }

--- a/Sources/DefiMacOS/PlatformModels.swift
+++ b/Sources/DefiMacOS/PlatformModels.swift
@@ -64,6 +64,7 @@ public struct DesktopSnapshot: Sendable {
   public let mouseFocusReleaseObserved: Bool
   public let mouseFocusIntentWindowID: WindowID?
   public let mouseFocusIntentTimestamp: TimeInterval?
+  public let keyboardFocusIntentTimestamp: TimeInterval?
   public let targetMismatchCount: Int
   public let targetMismatches: [FrameMismatch]
 
@@ -81,6 +82,7 @@ public struct DesktopSnapshot: Sendable {
     mouseFocusReleaseObserved: Bool = false,
     mouseFocusIntentWindowID: WindowID? = nil,
     mouseFocusIntentTimestamp: TimeInterval? = nil,
+    keyboardFocusIntentTimestamp: TimeInterval? = nil,
     targetMismatchCount: Int = 0,
     targetMismatches: [FrameMismatch] = []
   ) {
@@ -97,6 +99,7 @@ public struct DesktopSnapshot: Sendable {
     self.mouseFocusReleaseObserved = mouseFocusReleaseObserved
     self.mouseFocusIntentWindowID = mouseFocusIntentWindowID
     self.mouseFocusIntentTimestamp = mouseFocusIntentTimestamp
+    self.keyboardFocusIntentTimestamp = keyboardFocusIntentTimestamp
     self.targetMismatchCount = targetMismatchCount
     self.targetMismatches = targetMismatches
   }

--- a/Sources/DefiRuntime/FocusSelection.swift
+++ b/Sources/DefiRuntime/FocusSelection.swift
@@ -60,6 +60,14 @@ public func nativeFocusChangesSelection(
     || state.selectedWindowID(on: focusedMonitorID) != windowID
 }
 
+public func nativeFocusMutationIsReady(
+  nativeFocusChanged: Bool,
+  mouseGestureEnded: Bool,
+  leftMouseButtonDown: Bool
+) -> Bool {
+  !leftMouseButtonDown && (nativeFocusChanged || mouseGestureEnded)
+}
+
 public struct WindowRemovalFocusGuard: Equatable, Sendable {
   public let monitorID: MonitorID
   public let workspaceID: WorkspaceID

--- a/Sources/DefiRuntime/FocusSelection.swift
+++ b/Sources/DefiRuntime/FocusSelection.swift
@@ -103,14 +103,18 @@ public struct DeferredMouseFocusIntent: Equatable, Sendable {
 
 public func updatedDeferredMouseFocusIntent(
   current: DeferredMouseFocusIntent?,
+  consumedMouseFocusIntentTimestamp: Double = 0,
   mouseFocusIntentWindowID: WindowID?,
   mouseFocusIntentTimestamp: Double?,
   focusedWindowID: WindowID?,
   nativeFocusChanged: Bool,
   mouseInteractionEnded: Bool
 ) -> DeferredMouseFocusIntent? {
-  var intent = current
+  var intent = current.flatMap {
+    $0.timestamp > consumedMouseFocusIntentTimestamp ? $0 : nil
+  }
   if let timestamp = mouseFocusIntentTimestamp,
+    timestamp > consumedMouseFocusIntentTimestamp,
     intent.map({ timestamp > $0.timestamp }) ?? true
   {
     intent = DeferredMouseFocusIntent(

--- a/Sources/DefiRuntime/FocusSelection.swift
+++ b/Sources/DefiRuntime/FocusSelection.swift
@@ -64,9 +64,12 @@ public func nativeFocusMutationIsReady(
   nativeFocusChanged: Bool,
   mouseInteractionEnded: Bool,
   leftMouseButtonDown: Bool,
-  mouseReleaseFocusIntentCurrent: Bool
+  mouseReleaseFocusIntentCurrent: Bool,
+  keyboardFocusIntentCurrent: Bool
 ) -> Bool {
-  guard !leftMouseButtonDown else { return false }
+  if leftMouseButtonDown {
+    return nativeFocusChanged && keyboardFocusIntentCurrent
+  }
   if mouseInteractionEnded {
     return mouseReleaseFocusIntentCurrent
   }
@@ -87,6 +90,14 @@ public func mouseReleaseFocusIntentIsCurrent(
   }
   return mouseFocusIntentWindowID == focusedWindowID
     || (mouseFocusIntentWindowID == nil && nativeFocusChanged)
+}
+
+public func keyboardFocusIntentIsCurrent(
+  keyboardFocusIntentTimestamp: Double?,
+  latestCommandInputTimestamp: Double
+) -> Bool {
+  guard let keyboardFocusIntentTimestamp else { return false }
+  return keyboardFocusIntentTimestamp > latestCommandInputTimestamp
 }
 
 public func resolvedLatestCommandInputTimestamp(

--- a/Sources/DefiRuntime/FocusSelection.swift
+++ b/Sources/DefiRuntime/FocusSelection.swift
@@ -62,10 +62,31 @@ public func nativeFocusChangesSelection(
 
 public func nativeFocusMutationIsReady(
   nativeFocusChanged: Bool,
-  mouseGestureEnded: Bool,
-  leftMouseButtonDown: Bool
+  mouseInteractionEnded: Bool,
+  leftMouseButtonDown: Bool,
+  mouseReleaseFocusIntentCurrent: Bool
 ) -> Bool {
-  !leftMouseButtonDown && (nativeFocusChanged || mouseGestureEnded)
+  guard !leftMouseButtonDown else { return false }
+  if mouseInteractionEnded {
+    return mouseReleaseFocusIntentCurrent
+  }
+  return nativeFocusChanged
+}
+
+public func mouseReleaseFocusIntentIsCurrent(
+  focusedWindowID: WindowID,
+  mouseFocusIntentWindowID: WindowID?,
+  mouseFocusIntentTimestamp: Double?,
+  latestCommandInputTimestamp: Double,
+  nativeFocusChanged: Bool
+) -> Bool {
+  guard let mouseFocusIntentTimestamp,
+    mouseFocusIntentTimestamp > latestCommandInputTimestamp
+  else {
+    return false
+  }
+  return mouseFocusIntentWindowID == focusedWindowID
+    || (mouseFocusIntentWindowID == nil && nativeFocusChanged)
 }
 
 public struct WindowRemovalFocusGuard: Equatable, Sendable {

--- a/Sources/DefiRuntime/FocusSelection.swift
+++ b/Sources/DefiRuntime/FocusSelection.swift
@@ -89,6 +89,14 @@ public func mouseReleaseFocusIntentIsCurrent(
     || (mouseFocusIntentWindowID == nil && nativeFocusChanged)
 }
 
+public func resolvedLatestCommandInputTimestamp(
+  previousTimestamp: Double,
+  capturedInputTimestamp: Double?,
+  commandHandledAt: Double
+) -> Double {
+  max(previousTimestamp, capturedInputTimestamp ?? commandHandledAt)
+}
+
 public struct WindowRemovalFocusGuard: Equatable, Sendable {
   public let monitorID: MonitorID
   public let workspaceID: WorkspaceID

--- a/Sources/DefiRuntime/FocusSelection.swift
+++ b/Sources/DefiRuntime/FocusSelection.swift
@@ -64,16 +64,70 @@ public func nativeFocusMutationIsReady(
   nativeFocusChanged: Bool,
   mouseInteractionEnded: Bool,
   leftMouseButtonDown: Bool,
+  deferredMouseFocusPending: Bool? = nil,
+  deferredMouseFocusReady: Bool? = nil,
   mouseReleaseFocusIntentCurrent: Bool,
   keyboardFocusIntentCurrent: Bool
 ) -> Bool {
   if leftMouseButtonDown {
     return nativeFocusChanged && keyboardFocusIntentCurrent
   }
-  if mouseInteractionEnded {
-    return mouseReleaseFocusIntentCurrent
+  if keyboardFocusIntentCurrent && nativeFocusChanged {
+    return true
+  }
+  if deferredMouseFocusPending ?? mouseInteractionEnded {
+    return (deferredMouseFocusReady ?? mouseInteractionEnded)
+      && mouseReleaseFocusIntentCurrent
   }
   return nativeFocusChanged
+}
+
+public struct DeferredMouseFocusIntent: Equatable, Sendable {
+  public var timestamp: Double
+  public var windowID: WindowID?
+  public var focusObserved: Bool
+  public var mouseInteractionEnded: Bool
+
+  public init(
+    timestamp: Double,
+    windowID: WindowID?,
+    focusObserved: Bool = false,
+    mouseInteractionEnded: Bool = false
+  ) {
+    self.timestamp = timestamp
+    self.windowID = windowID
+    self.focusObserved = focusObserved
+    self.mouseInteractionEnded = mouseInteractionEnded
+  }
+}
+
+public func updatedDeferredMouseFocusIntent(
+  current: DeferredMouseFocusIntent?,
+  mouseFocusIntentWindowID: WindowID?,
+  mouseFocusIntentTimestamp: Double?,
+  focusedWindowID: WindowID?,
+  nativeFocusChanged: Bool,
+  mouseInteractionEnded: Bool
+) -> DeferredMouseFocusIntent? {
+  var intent = current
+  if let timestamp = mouseFocusIntentTimestamp,
+    intent.map({ timestamp > $0.timestamp }) ?? true
+  {
+    intent = DeferredMouseFocusIntent(
+      timestamp: timestamp,
+      windowID: mouseFocusIntentWindowID
+    )
+  }
+  guard var intent else { return nil }
+  if nativeFocusChanged, let focusedWindowID {
+    if intent.windowID == nil {
+      intent.windowID = focusedWindowID
+    }
+    intent.focusObserved = intent.windowID == focusedWindowID
+  }
+  intent.mouseInteractionEnded =
+    intent.mouseInteractionEnded || mouseInteractionEnded
+  return intent
 }
 
 public func mouseReleaseFocusIntentIsCurrent(

--- a/Sources/DefiRuntime/MouseReordering.swift
+++ b/Sources/DefiRuntime/MouseReordering.swift
@@ -17,6 +17,103 @@ public struct WorkspaceScrollAnchor: Equatable, Sendable {
   }
 }
 
+public struct MouseGestureSettlement: Equatable, Sendable {
+  public let generation: UInt64
+  public let windowID: WindowID
+  public let initialFrame: Rect
+  public var lastObservedFrame: Rect
+  public var observedPostReleaseChange: Bool
+  public var stableSince: Double?
+  public var nextCheckAt: Double
+  public let expiresAt: Double
+
+  public init(
+    generation: UInt64,
+    windowID: WindowID,
+    initialFrame: Rect,
+    releasedFrame: Rect,
+    now: Double,
+    maximumDuration: Double,
+    pollInterval: Double = 0.05
+  ) {
+    self.generation = generation
+    self.windowID = windowID
+    self.initialFrame = initialFrame
+    lastObservedFrame = releasedFrame
+    observedPostReleaseChange = false
+    stableSince = nil
+    nextCheckAt = now + pollInterval
+    expiresAt = now + maximumDuration
+  }
+}
+
+public struct MouseGestureSettlementUpdate: Equatable, Sendable {
+  public let settlement: MouseGestureSettlement
+  public let shouldFinish: Bool
+
+  public init(
+    settlement: MouseGestureSettlement,
+    shouldFinish: Bool
+  ) {
+    self.settlement = settlement
+    self.shouldFinish = shouldFinish
+  }
+}
+
+public func mouseGestureAnimationCancellationIsNeeded(
+  mouseReorderAnimationActive: Bool,
+  scrollAnimationActive: Bool,
+  animatedWritesPending: Bool
+) -> Bool {
+  !mouseReorderAnimationActive
+    && (scrollAnimationActive || animatedWritesPending)
+}
+
+public func mouseGestureSettlementMaximumDuration(
+  latencySensitive: Bool
+) -> Double {
+  latencySensitive ? 0.8 : 0.25
+}
+
+public func advanceMouseGestureSettlement(
+  _ current: MouseGestureSettlement,
+  actualFrame: Rect,
+  now: Double,
+  animationPending: Bool,
+  frameTolerance: Double = 1,
+  pollInterval: Double = 0.05,
+  quietDuration: Double = 0.05
+) -> MouseGestureSettlementUpdate {
+  var next = current
+  let frameChanged =
+    abs(actualFrame.x - current.lastObservedFrame.x) > frameTolerance
+    || abs(actualFrame.y - current.lastObservedFrame.y) > frameTolerance
+    || abs(actualFrame.width - current.lastObservedFrame.width) > frameTolerance
+    || abs(actualFrame.height - current.lastObservedFrame.height) > frameTolerance
+  if frameChanged {
+    next.lastObservedFrame = actualFrame
+    next.observedPostReleaseChange = true
+    next.stableSince = now
+  }
+  let converged = next.observedPostReleaseChange
+    && now >= (next.stableSince ?? now) + quietDuration
+  let timedOut = now >= next.expiresAt
+  let shouldFinish = (converged || timedOut) && !animationPending
+  if shouldFinish {
+    next.nextCheckAt = now
+  } else if animationPending && (converged || timedOut) {
+    next.nextCheckAt = now + pollInterval
+  } else if let stableSince = next.stableSince {
+    next.nextCheckAt = min(stableSince + quietDuration, next.expiresAt)
+  } else {
+    next.nextCheckAt = min(now + pollInterval, next.expiresAt)
+  }
+  return MouseGestureSettlementUpdate(
+    settlement: next,
+    shouldFinish: shouldFinish
+  )
+}
+
 public func workspaceScrollAnchor(
   containing windowID: WindowID,
   state: RuntimeState

--- a/Sources/DefiRuntime/MouseReordering.swift
+++ b/Sources/DefiRuntime/MouseReordering.swift
@@ -1,0 +1,259 @@
+import DefiCore
+import DefiModel
+
+public struct WorkspaceScrollAnchor: Equatable, Sendable {
+  public let monitorID: MonitorID
+  public let workspaceID: WorkspaceID
+  public let scrollOffset: Double
+
+  public init(
+    monitorID: MonitorID,
+    workspaceID: WorkspaceID,
+    scrollOffset: Double
+  ) {
+    self.monitorID = monitorID
+    self.workspaceID = workspaceID
+    self.scrollOffset = scrollOffset
+  }
+}
+
+public func workspaceScrollAnchor(
+  containing windowID: WindowID,
+  state: RuntimeState
+) -> WorkspaceScrollAnchor? {
+  guard let location = state.location(containing: windowID),
+    let monitor = state.monitors.first(where: { $0.id == location.monitorID }),
+    let workspace = monitor.workspaces.first(where: {
+      $0.id == location.workspaceID
+    })
+  else {
+    return nil
+  }
+  return WorkspaceScrollAnchor(
+    monitorID: location.monitorID,
+    workspaceID: location.workspaceID,
+    scrollOffset: workspace.scrollOffset
+  )
+}
+
+public func restoreWorkspaceScroll(
+  _ anchor: WorkspaceScrollAnchor,
+  state: inout RuntimeState
+) {
+  guard
+    let monitorIndex = state.monitors.firstIndex(where: {
+      $0.id == anchor.monitorID
+    }),
+    let workspaceIndex = state.monitors[monitorIndex].workspaces.firstIndex(
+      where: { $0.id == anchor.workspaceID }
+    )
+  else {
+    return
+  }
+  state.monitors[monitorIndex].workspaces[workspaceIndex].scrollOffset =
+    anchor.scrollOffset
+  state.monitors[monitorIndex].workspaces[workspaceIndex].targetScrollOffset =
+    anchor.scrollOffset
+}
+
+public func mouseGestureTiledWindowID(
+  translatedWindowID: WindowID?,
+  activeWindowID: WindowID?,
+  focusedWindowID: WindowID?,
+  state: RuntimeState
+) -> WindowID? {
+  for candidate in [translatedWindowID, activeWindowID, focusedWindowID] {
+    guard let candidate,
+      state.windows[candidate]?.floating == false,
+      let location = state.location(containing: candidate),
+      state.monitors.first(where: { $0.id == location.monitorID })?
+        .activeWorkspace == location.workspaceID
+    else {
+      continue
+    }
+    return candidate
+  }
+  return nil
+}
+
+public func mouseTranslatedTiledWindowID(
+  externallyChangedFrames: [WindowID: Rect],
+  state: RuntimeState,
+  viewports: [MonitorID: Rect],
+  sizeTolerance: Double = 2,
+  positionTolerance: Double = 2
+) -> WindowID? {
+  for monitor in state.monitors {
+    guard let viewport = viewports[monitor.id],
+      let workspace = monitor.workspaces.first(where: {
+        $0.id == monitor.activeWorkspace
+      })
+    else {
+      continue
+    }
+    let windows = workspace.columns
+      .flatMap(\.windows)
+      .compactMap { state.windows[$0] }
+    let targets = Dictionary(
+      uniqueKeysWithValues: computeLayout(
+        workspace: workspace,
+        viewport: viewport,
+        windows: windows,
+        settings: state.layout
+      ).frames.map { ($0.windowID, $0.frame) }
+    )
+    for column in workspace.columns {
+      for windowID in column.windows {
+        guard let actual = externallyChangedFrames[windowID],
+          let target = targets[windowID],
+          abs(actual.width - target.width) <= sizeTolerance,
+          abs(actual.height - target.height) <= sizeTolerance,
+          abs(actual.x - target.x) > positionTolerance
+            || abs(actual.y - target.y) > positionTolerance
+        else {
+          continue
+        }
+        return windowID
+      }
+    }
+  }
+  return nil
+}
+
+public func mouseFrameWasTranslated(
+  from initialFrame: Rect,
+  to actualFrame: Rect,
+  sizeTolerance: Double = 2,
+  positionTolerance: Double = 2
+) -> Bool {
+  abs(actualFrame.width - initialFrame.width) <= sizeTolerance
+    && abs(actualFrame.height - initialFrame.height) <= sizeTolerance
+    && (abs(actualFrame.x - initialFrame.x) > positionTolerance
+      || abs(actualFrame.y - initialFrame.y) > positionTolerance)
+}
+
+@discardableResult
+public func reorderTiledWindowAfterMouseDrag(
+  _ windowID: WindowID,
+  actualFrame: Rect,
+  initialFrame: Rect? = nil,
+  state: inout RuntimeState,
+  viewports: [MonitorID: Rect]
+) -> Bool {
+  guard
+    let monitorIndex = state.monitors.firstIndex(where: { monitor in
+      monitor.workspaces.contains(where: { workspace in
+        workspace.id == monitor.activeWorkspace
+          && workspace.columns.contains(where: { $0.windows.contains(windowID) })
+      })
+    }),
+    let viewport = viewports[state.monitors[monitorIndex].id],
+    let workspaceIndex = state.monitors[monitorIndex].workspaces.firstIndex(
+      where: { $0.id == state.monitors[monitorIndex].activeWorkspace }
+    ),
+    let sourceColumnIndex = state.monitors[monitorIndex].workspaces[workspaceIndex]
+      .columns.firstIndex(where: { $0.windows.contains(windowID) })
+  else {
+    return false
+  }
+
+  var workspace = state.monitors[monitorIndex].workspaces[workspaceIndex]
+  let windows = workspace.columns
+    .flatMap(\.windows)
+    .compactMap { state.windows[$0] }
+  let frames = Dictionary(
+    uniqueKeysWithValues: computeLayout(
+      workspace: workspace,
+      viewport: viewport,
+      windows: windows,
+      settings: state.layout
+    ).frames.map { ($0.windowID, $0.frame) }
+  )
+
+  guard let sourceFrame = frames[windowID]
+  else {
+    return false
+  }
+  let sizeReferenceFrame = initialFrame ?? sourceFrame
+  guard abs(actualFrame.width - sizeReferenceFrame.width) <= 2,
+    abs(actualFrame.height - sizeReferenceFrame.height) <= 2
+  else {
+    return false
+  }
+  let sourceCenterX = sourceFrame.x + sourceFrame.width / 2
+  let draggedCenterX = actualFrame.x + actualFrame.width / 2
+  var horizontalTargetIndex = sourceColumnIndex
+  if sourceColumnIndex + 1 < workspace.columns.count,
+    let nextCenterX = centerX(
+      for: workspace.columns[sourceColumnIndex + 1],
+      frames: frames
+    ),
+    draggedCenterX > (sourceCenterX + nextCenterX) / 2
+  {
+    horizontalTargetIndex += 1
+  } else if sourceColumnIndex > 0,
+    let previousCenterX = centerX(
+      for: workspace.columns[sourceColumnIndex - 1],
+      frames: frames
+    ),
+    draggedCenterX < (previousCenterX + sourceCenterX) / 2
+  {
+    horizontalTargetIndex -= 1
+  }
+  if horizontalTargetIndex != sourceColumnIndex {
+    var column = workspace.columns.remove(at: sourceColumnIndex)
+    if let focusedWindow = column.windows.firstIndex(of: windowID) {
+      column.focusedWindow = focusedWindow
+    }
+    workspace.columns.insert(column, at: horizontalTargetIndex)
+    workspace.focusedColumn = horizontalTargetIndex
+    workspace.focusedLayer = .tiled
+    state.monitors[monitorIndex].workspaces[workspaceIndex] = workspace
+    synchronizeScrollOffsets(state: &state, viewports: viewports)
+    return true
+  }
+
+  guard
+    let sourceWindowIndex = workspace.columns[sourceColumnIndex]
+      .windows.firstIndex(of: windowID),
+    workspace.columns[sourceColumnIndex].windows.count > 1
+  else {
+    return false
+  }
+  let draggedCenterY = actualFrame.y + actualFrame.height / 2
+  let remainingWindows = workspace.columns[sourceColumnIndex].windows.enumerated().filter {
+    $0.offset != sourceWindowIndex
+  }
+  let verticalInsertionIndex = insertionIndex(
+    coordinate: draggedCenterY,
+    centers: remainingWindows.compactMap { _, candidateID in
+      frames[candidateID].map { $0.y + $0.height / 2 }
+    }
+  )
+  guard verticalInsertionIndex != sourceWindowIndex else { return false }
+
+  workspace.columns[sourceColumnIndex].windows.remove(at: sourceWindowIndex)
+  workspace.columns[sourceColumnIndex].windows.insert(
+    windowID,
+    at: verticalInsertionIndex
+  )
+  workspace.columns[sourceColumnIndex].focusedWindow = verticalInsertionIndex
+  workspace.focusedColumn = sourceColumnIndex
+  workspace.focusedLayer = .tiled
+  state.monitors[monitorIndex].workspaces[workspaceIndex] = workspace
+  synchronizeScrollOffsets(state: &state, viewports: viewports)
+  return true
+}
+
+private func insertionIndex(coordinate: Double, centers: [Double]) -> Int {
+  centers.firstIndex(where: { coordinate < $0 }) ?? centers.count
+}
+
+private func centerX(
+  for column: Column,
+  frames: [WindowID: Rect]
+) -> Double? {
+  column.windows.compactMap { windowID in
+    frames[windowID].map { $0.x + $0.width / 2 }
+  }.first
+}

--- a/Sources/DefiRuntime/MouseReordering.swift
+++ b/Sources/DefiRuntime/MouseReordering.swift
@@ -105,6 +105,20 @@ public func resolvedMouseGestureInitialFrame(
   return previousObservedFrames[gestureWindowID] ?? actualFrame
 }
 
+public func resolvedMouseGestureOriginFrame(
+  observedFrame: Rect,
+  displayedX: Double?,
+  displayedY: Double?
+) -> Rect {
+  guard let displayedX, let displayedY else { return observedFrame }
+  return Rect(
+    x: displayedX,
+    y: displayedY,
+    width: observedFrame.width,
+    height: observedFrame.height
+  )
+}
+
 public func mouseTranslatedTiledWindowID(
   candidateWindowIDs: [WindowID],
   externallyChangedFrames: [WindowID: Rect],

--- a/Sources/DefiRuntime/MouseReordering.swift
+++ b/Sources/DefiRuntime/MouseReordering.swift
@@ -225,7 +225,6 @@ public func reorderTiledWindowAfterMouseDrag(
   else {
     return false
   }
-  let sourceCenterX = sourceFrame.x + sourceFrame.width / 2
   let draggedCenterX = actualFrame.x + actualFrame.width / 2
   var horizontalTargetIndex = sourceColumnIndex
   if sourceColumnIndex + 1 < workspace.columns.count,
@@ -233,7 +232,7 @@ public func reorderTiledWindowAfterMouseDrag(
       for: workspace.columns[sourceColumnIndex + 1],
       frames: frames
     ),
-    draggedCenterX > (sourceCenterX + nextCenterX) / 2
+    draggedCenterX > nextCenterX
   {
     horizontalTargetIndex += 1
   } else if sourceColumnIndex > 0,
@@ -241,7 +240,7 @@ public func reorderTiledWindowAfterMouseDrag(
       for: workspace.columns[sourceColumnIndex - 1],
       frames: frames
     ),
-    draggedCenterX < (previousCenterX + sourceCenterX) / 2
+    draggedCenterX < previousCenterX
   {
     horizontalTargetIndex -= 1
   }

--- a/Sources/DefiRuntime/MouseReordering.swift
+++ b/Sources/DefiRuntime/MouseReordering.swift
@@ -59,10 +59,16 @@ public func restoreWorkspaceScroll(
 public func mouseGestureTiledWindowID(
   translatedWindowID: WindowID?,
   activeWindowID: WindowID?,
+  mouseFocusIntentWindowID: WindowID?,
   focusedWindowID: WindowID?,
   state: RuntimeState
 ) -> WindowID? {
-  for candidate in [translatedWindowID, activeWindowID, focusedWindowID] {
+  for candidate in [
+    activeWindowID,
+    mouseFocusIntentWindowID,
+    translatedWindowID,
+    focusedWindowID,
+  ] {
     guard let candidate,
       state.windows[candidate]?.floating == false,
       let location = state.location(containing: candidate),
@@ -76,18 +82,46 @@ public func mouseGestureTiledWindowID(
   return nil
 }
 
+public func resolvedMouseGestureInitialFrame(
+  currentInitialFrame: Rect?,
+  gestureWindowID: WindowID?,
+  activeWindowID: WindowID?,
+  translatedWindowID: WindowID?,
+  leftMouseButtonDown: Bool,
+  previousObservedFrames: [WindowID: Rect],
+  actualFrame: Rect?
+) -> Rect? {
+  let startsMouseGesture =
+    leftMouseButtonDown
+    && gestureWindowID != activeWindowID
+  let recoversReleaseOnlyGesture =
+    currentInitialFrame == nil
+    && gestureWindowID == translatedWindowID
+  guard startsMouseGesture || recoversReleaseOnlyGesture,
+    let gestureWindowID
+  else {
+    return currentInitialFrame
+  }
+  return previousObservedFrames[gestureWindowID] ?? actualFrame
+}
+
 public func mouseTranslatedTiledWindowID(
+  candidateWindowIDs: [WindowID],
   externallyChangedFrames: [WindowID: Rect],
   state: RuntimeState,
   viewports: [MonitorID: Rect],
   sizeTolerance: Double = 2,
   positionTolerance: Double = 2
 ) -> WindowID? {
-  for monitor in state.monitors {
-    guard let viewport = viewports[monitor.id],
+  for windowID in candidateWindowIDs {
+    guard let location = state.location(containing: windowID),
+      let monitor = state.monitors.first(where: { $0.id == location.monitorID }),
+      location.workspaceID == monitor.activeWorkspace,
+      let viewport = viewports[monitor.id],
       let workspace = monitor.workspaces.first(where: {
-        $0.id == monitor.activeWorkspace
-      })
+        $0.id == location.workspaceID
+      }),
+      workspace.columns.contains(where: { $0.windows.contains(windowID) })
     else {
       continue
     }
@@ -102,20 +136,16 @@ public func mouseTranslatedTiledWindowID(
         settings: state.layout
       ).frames.map { ($0.windowID, $0.frame) }
     )
-    for column in workspace.columns {
-      for windowID in column.windows {
-        guard let actual = externallyChangedFrames[windowID],
-          let target = targets[windowID],
-          abs(actual.width - target.width) <= sizeTolerance,
-          abs(actual.height - target.height) <= sizeTolerance,
-          abs(actual.x - target.x) > positionTolerance
-            || abs(actual.y - target.y) > positionTolerance
-        else {
-          continue
-        }
-        return windowID
-      }
+    guard let actual = externallyChangedFrames[windowID],
+      let target = targets[windowID],
+      abs(actual.width - target.width) <= sizeTolerance,
+      abs(actual.height - target.height) <= sizeTolerance,
+      abs(actual.x - target.x) > positionTolerance
+        || abs(actual.y - target.y) > positionTolerance
+    else {
+      continue
     }
+    return windowID
   }
   return nil
 }

--- a/Sources/DefiRuntime/MouseReordering.swift
+++ b/Sources/DefiRuntime/MouseReordering.swift
@@ -75,6 +75,15 @@ public func mouseGestureSettlementMaximumDuration(
   latencySensitive ? 0.8 : 0.25
 }
 
+public func mouseGestureWidthLearningFrame(
+  externallyChangedFrame: Rect?,
+  actualFrame: Rect?,
+  postReleaseSettlementActive: Bool
+) -> Rect? {
+  externallyChangedFrame
+    ?? (postReleaseSettlementActive ? actualFrame : nil)
+}
+
 public func advanceMouseGestureSettlement(
   _ current: MouseGestureSettlement,
   actualFrame: Rect,

--- a/Sources/DefiRuntime/MouseReordering.swift
+++ b/Sources/DefiRuntime/MouseReordering.swift
@@ -108,14 +108,15 @@ public func resolvedMouseGestureInitialFrame(
 public func resolvedMouseGestureOriginFrame(
   observedFrame: Rect,
   displayedX: Double?,
-  displayedY: Double?
+  displayedY: Double?,
+  displayedWidth: Double? = nil,
+  displayedHeight: Double? = nil
 ) -> Rect {
-  guard let displayedX, let displayedY else { return observedFrame }
   return Rect(
-    x: displayedX,
-    y: displayedY,
-    width: observedFrame.width,
-    height: observedFrame.height
+    x: displayedX ?? observedFrame.x,
+    y: displayedY ?? observedFrame.y,
+    width: displayedWidth ?? observedFrame.width,
+    height: displayedHeight ?? observedFrame.height
   )
 }
 
@@ -287,6 +288,73 @@ public func reorderTiledWindowAfterMouseDrag(
   state.monitors[monitorIndex].workspaces[workspaceIndex] = workspace
   synchronizeScrollOffsets(state: &state, viewports: viewports)
   return true
+}
+
+@discardableResult
+public func reorderTiledWindowAfterCompletedMouseDrag(
+  _ windowID: WindowID,
+  actualFrame: Rect,
+  initialFrame: Rect? = nil,
+  state: inout RuntimeState,
+  viewports: [MonitorID: Rect]
+) -> Bool {
+  let maximumReorders = state.monitors.lazy
+    .flatMap(\.workspaces)
+    .map(\.columns.count)
+    .max() ?? 0
+  var reordered = false
+  for _ in 0..<maximumReorders {
+    let sourceColumnIndex = activeColumnIndex(containing: windowID, state: state)
+    guard reorderTiledWindowAfterMouseDrag(
+      windowID,
+      actualFrame: actualFrame,
+      initialFrame: initialFrame,
+      state: &state,
+      viewports: viewports
+    ) else {
+      break
+    }
+    reordered = true
+    if activeColumnIndex(containing: windowID, state: state) == sourceColumnIndex {
+      break
+    }
+  }
+  return reordered
+}
+
+public func desktopSynchronizationIsReady(
+  scrollAnimationActive: Bool,
+  animatedWritesPending: Bool,
+  slowLanePending: Bool,
+  mouseGestureSyncPending: Bool,
+  needsDesktopSync: Bool,
+  periodicSyncDue: Bool
+) -> Bool {
+  guard !scrollAnimationActive, !slowLanePending,
+    needsDesktopSync || periodicSyncDue
+  else {
+    return false
+  }
+  return !animatedWritesPending || (mouseGestureSyncPending && needsDesktopSync)
+}
+
+private func activeColumnIndex(
+  containing windowID: WindowID,
+  state: RuntimeState
+) -> Int? {
+  for monitor in state.monitors {
+    guard let workspace = monitor.workspaces.first(where: {
+      $0.id == monitor.activeWorkspace
+    }) else {
+      continue
+    }
+    if let index = workspace.columns.firstIndex(where: {
+      $0.windows.contains(windowID)
+    }) {
+      return index
+    }
+  }
+  return nil
 }
 
 private func insertionIndex(coordinate: Double, centers: [Double]) -> Int {

--- a/Sources/DefiRuntime/MouseReordering.swift
+++ b/Sources/DefiRuntime/MouseReordering.swift
@@ -56,6 +56,18 @@ public func restoreWorkspaceScroll(
     anchor.scrollOffset
 }
 
+public func resolvedMouseGestureScrollAnchor(
+  current: WorkspaceScrollAnchor?,
+  gestureWindowID: WindowID?,
+  mouseGestureActive: Bool,
+  state: RuntimeState
+) -> WorkspaceScrollAnchor? {
+  guard mouseGestureActive else { return nil }
+  return current ?? gestureWindowID.flatMap {
+    workspaceScrollAnchor(containing: $0, state: state)
+  }
+}
+
 public func mouseGestureTiledWindowID(
   translatedWindowID: WindowID?,
   activeWindowID: WindowID?,
@@ -329,7 +341,8 @@ public func desktopSynchronizationIsReady(
   needsDesktopSync: Bool,
   periodicSyncDue: Bool
 ) -> Bool {
-  guard !scrollAnimationActive, !slowLanePending,
+  guard !scrollAnimationActive,
+    !slowLanePending || mouseGestureSyncPending,
     needsDesktopSync || periodicSyncDue
   else {
     return false

--- a/Tests/DefiMacOSTests/DesktopE2ETests.swift
+++ b/Tests/DefiMacOSTests/DesktopE2ETests.swift
@@ -456,9 +456,9 @@ final class DesktopE2ETests: XCTestCase {
       modifierCombinations: ["hyper": "Alt + Cmd + Ctrl"],
       keys: ["hyper-left": "focus-column left"]
     )
-    var received: [String] = []
-    let manager = try HotKeyManager(config: config) { command in
-      received.append(command)
+    var received: [HotKeyInvocation] = []
+    let manager = try HotKeyManager(config: config) { invocation in
+      received.append(invocation)
     }
     try manager.start()
     let eventCount = 8
@@ -495,6 +495,8 @@ final class DesktopE2ETests: XCTestCase {
     )
     pumpRunLoop(for: 0.2)
     XCTAssertEqual(received.count, eventCount)
+    XCTAssertTrue(received.allSatisfy { $0.command == "focus-column left" })
+    XCTAssertTrue(received.allSatisfy { $0.timestamp > 0 })
     XCTAssertEqual(manager.tapReenableCount, 0)
   }
 

--- a/Tests/DefiMacOSTests/PlatformEventTests.swift
+++ b/Tests/DefiMacOSTests/PlatformEventTests.swift
@@ -289,7 +289,7 @@ struct PlatformEventTests {
   }
 
   @Test
-  func draggedGestureSynchronizesOnFirstMovementAndMouseUp() {
+  func draggedGestureKeepsSynchronizingUntilMouseUp() {
     var normalizer = MouseGestureEventNormalizer()
     let mouseDown = normalizer.actions(
       for: .leftMouseDown
@@ -310,7 +310,7 @@ struct PlatformEventTests {
     #expect(mouseDown.refreshBorderStacking)
     #expect(mouseDown.synchronization == nil)
     #expect(firstMouseDragged.synchronization == .gesture)
-    #expect(secondMouseDragged == MouseGestureEventNormalizer.Actions())
+    #expect(secondMouseDragged.synchronization == .gesture)
     #expect(firstMouseUp.synchronization == .gesture)
     #expect(secondMouseUp == MouseGestureEventNormalizer.Actions())
   }

--- a/Tests/DefiMacOSTests/PlatformEventTests.swift
+++ b/Tests/DefiMacOSTests/PlatformEventTests.swift
@@ -285,7 +285,7 @@ struct PlatformEventTests {
           refreshBorderStacking: true
         )
     )
-    #expect(mouseUp.synchronizeDesktop)
+    #expect(mouseUp.synchronization == .clickRelease)
   }
 
   @Test
@@ -308,10 +308,10 @@ struct PlatformEventTests {
     )
 
     #expect(mouseDown.refreshBorderStacking)
-    #expect(mouseDown.synchronizeDesktop == false)
-    #expect(firstMouseDragged.synchronizeDesktop)
+    #expect(mouseDown.synchronization == nil)
+    #expect(firstMouseDragged.synchronization == .gesture)
     #expect(secondMouseDragged == MouseGestureEventNormalizer.Actions())
-    #expect(firstMouseUp.synchronizeDesktop)
+    #expect(firstMouseUp.synchronization == .gesture)
     #expect(secondMouseUp == MouseGestureEventNormalizer.Actions())
   }
 

--- a/Tests/DefiMacOSTests/PlatformEventTests.swift
+++ b/Tests/DefiMacOSTests/PlatformEventTests.swift
@@ -282,7 +282,8 @@ struct PlatformEventTests {
     #expect(
       mouseDown
         == MouseGestureEventNormalizer.Actions(
-          refreshBorderStacking: true
+          refreshBorderStacking: true,
+          startsGesture: true
         )
     )
     #expect(mouseUp.synchronization == .clickRelease)
@@ -315,6 +316,19 @@ struct PlatformEventTests {
     #expect(secondMouseDragged.synchronization == .gesture)
     #expect(firstMouseUp.synchronization == .gesture)
     #expect(secondMouseUp == MouseGestureEventNormalizer.Actions())
+  }
+
+  @Test
+  func coalescedNextMouseDownStartsFreshGesture() {
+    var normalizer = MouseGestureEventNormalizer()
+    _ = normalizer.actions(for: .leftMouseDown)
+    _ = normalizer.actions(for: .leftMouseDragged)
+    _ = normalizer.actions(for: .leftMouseUp)
+
+    let nextMouseDown = normalizer.actions(for: .leftMouseDown)
+
+    #expect(nextMouseDown.startsGesture)
+    #expect(nextMouseDown.synchronization == nil)
   }
 
   @Test

--- a/Tests/DefiMacOSTests/PlatformEventTests.swift
+++ b/Tests/DefiMacOSTests/PlatformEventTests.swift
@@ -286,6 +286,8 @@ struct PlatformEventTests {
         )
     )
     #expect(mouseUp.synchronization == .clickRelease)
+    #expect(platformEventCancelsMouseAnimation(.mouseRelease) == false)
+    #expect(platformEventCancelsMouseAnimation(.mouse))
   }
 
   @Test

--- a/Tests/DefiMacOSTests/PlatformEventTests.swift
+++ b/Tests/DefiMacOSTests/PlatformEventTests.swift
@@ -332,6 +332,50 @@ struct PlatformEventTests {
   }
 
   @Test
+  func mouseGestureRefreshesClickedWindowProcess() {
+    let clickedWindowID = WindowID(rawValue: 10)
+    let focusedWindowID = WindowID(rawValue: 20)
+
+    #expect(
+      mouseGestureRefreshProcessID(
+        latestFocusIntent: .init(
+          timestamp: 1,
+          source: .mouse(windowID: clickedWindowID)
+        ),
+        focusedWindowID: focusedWindowID,
+        processIDs: [clickedWindowID: 100, focusedWindowID: 200]
+      ) == 100
+    )
+  }
+
+  @Test
+  func mouseGestureFallsBackToFocusedProcessWhenClickIsUnknown() {
+    let focusedWindowID = WindowID(rawValue: 20)
+
+    #expect(
+      mouseGestureRefreshProcessID(
+        latestFocusIntent: .init(
+          timestamp: 1,
+          source: .mouse(windowID: WindowID(rawValue: 10))
+        ),
+        focusedWindowID: focusedWindowID,
+        processIDs: [focusedWindowID: 200]
+      ) == 200
+    )
+  }
+
+  @Test
+  func mouseGestureRequiresFullRefreshWithoutKnownProcess() {
+    #expect(
+      mouseGestureRefreshProcessID(
+        latestFocusIntent: nil,
+        focusedWindowID: WindowID(rawValue: 20),
+        processIDs: [:]
+      ) == nil
+    )
+  }
+
+  @Test
   func borderStackingRefreshIsLatestSelectionWins() throws {
     var state = WindowBorderStackingRefreshState()
     let firstWindow = WindowID(rawValue: 1)

--- a/Tests/DefiMacOSTests/PlatformEventTests.swift
+++ b/Tests/DefiMacOSTests/PlatformEventTests.swift
@@ -272,7 +272,7 @@ struct PlatformEventTests {
   }
 
   @Test
-  func simpleClickDoesNotSynchronizeDesktop() {
+  func simpleClickSynchronizesDesktopOnRelease() {
     var normalizer = MouseGestureEventNormalizer()
     let mouseDown = normalizer.actions(
       for: .leftMouseDown
@@ -285,7 +285,7 @@ struct PlatformEventTests {
           refreshBorderStacking: true
         )
     )
-    #expect(mouseUp == MouseGestureEventNormalizer.Actions())
+    #expect(mouseUp.synchronizeDesktop)
   }
 
   @Test

--- a/Tests/DefiRuntimeTests/MouseReorderingTests.swift
+++ b/Tests/DefiRuntimeTests/MouseReorderingTests.swift
@@ -236,6 +236,21 @@ final class MouseReorderingTests: XCTestCase {
     )
   }
 
+  func testMouseGestureOriginUsesDisplayedAnimationSize() {
+    let observedFrame = Rect(x: 0, y: 20, width: 784, height: 684)
+
+    XCTAssertEqual(
+      resolvedMouseGestureOriginFrame(
+        observedFrame: observedFrame,
+        displayedX: 320,
+        displayedY: 40,
+        displayedWidth: 640,
+        displayedHeight: 600
+      ),
+      Rect(x: 320, y: 40, width: 640, height: 600)
+    )
+  }
+
   func testLiveDragCanCrossMultipleColumnsAcrossUpdates() throws {
     var state = try makeState(windowCount: 3)
     let draggedID = WindowID(rawValue: 1)
@@ -272,6 +287,59 @@ final class MouseReorderingTests: XCTestCase {
         [WindowID(rawValue: 3)],
         [WindowID(rawValue: 1)],
       ]
+    )
+  }
+
+  func testReleaseOnlyDragCrossesMultipleColumnsInOneSync() throws {
+    var state = try makeState(windowCount: 4)
+    let draggedID = WindowID(rawValue: 1)
+    let target = try targetFrame(for: draggedID, state: state)
+
+    XCTAssertTrue(
+      reorderTiledWindowAfterCompletedMouseDrag(
+        draggedID,
+        actualFrame: Rect(
+          x: 2_500,
+          y: target.y,
+          width: target.width,
+          height: target.height
+        ),
+        initialFrame: target,
+        state: &state,
+        viewports: [monitorID: viewport]
+      )
+    )
+    XCTAssertEqual(
+      state.monitors[0].workspaces[0].columns.map(\.windows),
+      [
+        [WindowID(rawValue: 2)],
+        [WindowID(rawValue: 3)],
+        [WindowID(rawValue: 4)],
+        [WindowID(rawValue: 1)],
+      ]
+    )
+  }
+
+  func testLiveMouseSyncBypassesPendingReorderAnimation() {
+    XCTAssertTrue(
+      desktopSynchronizationIsReady(
+        scrollAnimationActive: false,
+        animatedWritesPending: true,
+        slowLanePending: false,
+        mouseGestureSyncPending: true,
+        needsDesktopSync: true,
+        periodicSyncDue: false
+      )
+    )
+    XCTAssertFalse(
+      desktopSynchronizationIsReady(
+        scrollAnimationActive: false,
+        animatedWritesPending: true,
+        slowLanePending: false,
+        mouseGestureSyncPending: false,
+        needsDesktopSync: true,
+        periodicSyncDue: false
+      )
     )
   }
 

--- a/Tests/DefiRuntimeTests/MouseReorderingTests.swift
+++ b/Tests/DefiRuntimeTests/MouseReorderingTests.swift
@@ -518,6 +518,35 @@ final class MouseReorderingTests: XCTestCase {
     XCTAssertEqual(mouseGestureSettlementMaximumDuration(latencySensitive: true), 0.8)
   }
 
+  func testPostReleaseSettlementUsesLateFrameForWidthLearning() {
+    let external = Rect(x: 0, y: 0, width: 600, height: 700)
+    let late = Rect(x: 0, y: 0, width: 800, height: 700)
+
+    XCTAssertEqual(
+      mouseGestureWidthLearningFrame(
+        externallyChangedFrame: external,
+        actualFrame: late,
+        postReleaseSettlementActive: true
+      ),
+      external
+    )
+    XCTAssertEqual(
+      mouseGestureWidthLearningFrame(
+        externallyChangedFrame: nil,
+        actualFrame: late,
+        postReleaseSettlementActive: true
+      ),
+      late
+    )
+    XCTAssertNil(
+      mouseGestureWidthLearningFrame(
+        externallyChangedFrame: nil,
+        actualFrame: late,
+        postReleaseSettlementActive: false
+      )
+    )
+  }
+
   func testResizeIsNotClassifiedAsTranslation() throws {
     let state = try makeState(windowCount: 1)
     let windowID = WindowID(rawValue: 1)

--- a/Tests/DefiRuntimeTests/MouseReorderingTests.swift
+++ b/Tests/DefiRuntimeTests/MouseReorderingTests.swift
@@ -73,7 +73,7 @@ final class MouseReorderingTests: XCTestCase {
       reorderTiledWindowAfterMouseDrag(
         draggedID,
         actualFrame: Rect(
-          x: target.x - 500,
+          x: target.x - 900,
           y: target.y,
           width: target.width,
           height: target.height
@@ -117,7 +117,7 @@ final class MouseReorderingTests: XCTestCase {
     let draggedID = WindowID(rawValue: 1)
     let target = try targetFrame(for: draggedID, state: state)
     let draggedFrame = Rect(
-      x: target.x + 500,
+      x: target.x + 900,
       y: target.y,
       width: target.width,
       height: target.height
@@ -137,6 +137,43 @@ final class MouseReorderingTests: XCTestCase {
         draggedID,
         actualFrame: draggedFrame,
         initialFrame: target,
+        state: &state,
+        viewports: [monitorID: viewport]
+      )
+    )
+  }
+
+  func testUnequalWidthColumnsDoNotOscillateAtSamePointerPosition() throws {
+    var state = try makeState(windowCount: 2)
+    state.monitors[0].workspaces[0].columns[0].width = .pixels(300)
+    state.monitors[0].workspaces[0].columns[1].width = .pixels(700)
+    let draggedID = WindowID(rawValue: 1)
+    let initialFrame = try targetFrame(for: draggedID, state: state)
+    let neighborFrame = try targetFrame(
+      for: WindowID(rawValue: 2),
+      state: state
+    )
+    let draggedFrame = Rect(
+      x: neighborFrame.x + neighborFrame.width / 2 - initialFrame.width / 2 + 1,
+      y: initialFrame.y,
+      width: initialFrame.width,
+      height: initialFrame.height
+    )
+
+    XCTAssertTrue(
+      reorderTiledWindowAfterMouseDrag(
+        draggedID,
+        actualFrame: draggedFrame,
+        initialFrame: initialFrame,
+        state: &state,
+        viewports: [monitorID: viewport]
+      )
+    )
+    XCTAssertFalse(
+      reorderTiledWindowAfterMouseDrag(
+        draggedID,
+        actualFrame: draggedFrame,
+        initialFrame: initialFrame,
         state: &state,
         viewports: [monitorID: viewport]
       )

--- a/Tests/DefiRuntimeTests/MouseReorderingTests.swift
+++ b/Tests/DefiRuntimeTests/MouseReorderingTests.swift
@@ -200,6 +200,38 @@ final class MouseReorderingTests: XCTestCase {
     XCTAssertEqual(state.monitors[0].workspaces[0].targetScrollOffset, 0.25)
   }
 
+  func testMouseGestureScrollAnchorSurvivesNonCrossingUpdates() throws {
+    var state = try makeState(windowCount: 2)
+    let draggedID = WindowID(rawValue: 2)
+    state.monitors[0].workspaces[0].scrollOffset = 0.25
+    state.monitors[0].workspaces[0].targetScrollOffset = 0.25
+    let initialAnchor = resolvedMouseGestureScrollAnchor(
+      current: nil,
+      gestureWindowID: draggedID,
+      mouseGestureActive: true,
+      state: state
+    )
+
+    state.monitors[0].workspaces[0].scrollOffset = 0.8
+    state.monitors[0].workspaces[0].targetScrollOffset = 0.8
+    let preservedAnchor = resolvedMouseGestureScrollAnchor(
+      current: initialAnchor,
+      gestureWindowID: draggedID,
+      mouseGestureActive: true,
+      state: state
+    )
+
+    XCTAssertEqual(preservedAnchor?.scrollOffset, 0.25)
+    XCTAssertNil(
+      resolvedMouseGestureScrollAnchor(
+        current: preservedAnchor,
+        gestureWindowID: draggedID,
+        mouseGestureActive: false,
+        state: state
+      )
+    )
+  }
+
   func testFocusedTiledWindowStartsMouseGestureBeforeFrameMoves() throws {
     let state = try makeState(windowCount: 2)
     let focusedID = WindowID(rawValue: 2)
@@ -374,6 +406,16 @@ final class MouseReorderingTests: XCTestCase {
         animatedWritesPending: true,
         slowLanePending: false,
         mouseGestureSyncPending: false,
+        needsDesktopSync: true,
+        periodicSyncDue: false
+      )
+    )
+    XCTAssertTrue(
+      desktopSynchronizationIsReady(
+        scrollAnimationActive: false,
+        animatedWritesPending: false,
+        slowLanePending: true,
+        mouseGestureSyncPending: true,
         needsDesktopSync: true,
         periodicSyncDue: false
       )

--- a/Tests/DefiRuntimeTests/MouseReorderingTests.swift
+++ b/Tests/DefiRuntimeTests/MouseReorderingTests.swift
@@ -1,0 +1,346 @@
+import DefiConfig
+import DefiCore
+import DefiModel
+import DefiRuntime
+import XCTest
+
+final class MouseReorderingTests: XCTestCase {
+  private let monitorID = MonitorID(rawValue: 1)
+  private let viewport = Rect(x: 0, y: 0, width: 1_000, height: 700)
+
+  func testHorizontalDragReordersColumnsAfterCrossingNeighborCenter() throws {
+    var state = try makeState(windowCount: 3)
+    let draggedID = WindowID(rawValue: 1)
+    let target = try targetFrame(for: draggedID, state: state)
+
+    XCTAssertTrue(
+      reorderTiledWindowAfterMouseDrag(
+        draggedID,
+        actualFrame: Rect(
+          x: 900,
+          y: target.y,
+          width: target.width,
+          height: target.height
+        ),
+        state: &state,
+        viewports: [monitorID: viewport]
+      )
+    )
+    XCTAssertEqual(
+      state.monitors[0].workspaces[0].columns.map(\.windows),
+      [
+        [WindowID(rawValue: 2)],
+        [WindowID(rawValue: 1)],
+        [WindowID(rawValue: 3)],
+      ]
+    )
+    XCTAssertEqual(state.monitors[0].workspaces[0].focusedColumn, 1)
+  }
+
+  func testVerticalDragReordersWindowsWithinStack() throws {
+    var state = try makeState(windowCount: 2)
+    try reduce(.joinWindow(.left), on: monitorID, state: &state)
+    let draggedID = WindowID(rawValue: 1)
+    let target = try targetFrame(for: draggedID, state: state)
+
+    XCTAssertTrue(
+      reorderTiledWindowAfterMouseDrag(
+        draggedID,
+        actualFrame: Rect(
+          x: target.x,
+          y: 500,
+          width: target.width,
+          height: target.height
+        ),
+        state: &state,
+        viewports: [monitorID: viewport]
+      )
+    )
+    XCTAssertEqual(
+      state.monitors[0].workspaces[0].columns[0].windows,
+      [WindowID(rawValue: 2), WindowID(rawValue: 1)]
+    )
+    XCTAssertEqual(state.monitors[0].workspaces[0].columns[0].focusedWindow, 1)
+  }
+
+  func testHorizontalDragLeftReordersWithOffscreenPreviousColumn() throws {
+    var state = try makeState(windowCount: 2)
+    state.monitors[0].workspaces[0].scrollOffset = 0.8
+    let draggedID = WindowID(rawValue: 2)
+    let target = try targetFrame(for: draggedID, state: state)
+
+    XCTAssertTrue(
+      reorderTiledWindowAfterMouseDrag(
+        draggedID,
+        actualFrame: Rect(
+          x: target.x - 500,
+          y: target.y,
+          width: target.width,
+          height: target.height
+        ),
+        state: &state,
+        viewports: [monitorID: viewport]
+      )
+    )
+    XCTAssertEqual(
+      state.monitors[0].workspaces[0].columns.map(\.windows),
+      [[WindowID(rawValue: 2)], [WindowID(rawValue: 1)]]
+    )
+  }
+
+  func testSmallHorizontalDragKeepsColumnOrder() throws {
+    var state = try makeState(windowCount: 2)
+    let draggedID = WindowID(rawValue: 1)
+    let target = try targetFrame(for: draggedID, state: state)
+
+    XCTAssertFalse(
+      reorderTiledWindowAfterMouseDrag(
+        draggedID,
+        actualFrame: Rect(
+          x: target.x + 100,
+          y: target.y,
+          width: target.width,
+          height: target.height
+        ),
+        state: &state,
+        viewports: [monitorID: viewport]
+      )
+    )
+    XCTAssertEqual(
+      state.monitors[0].workspaces[0].columns.map(\.windows),
+      [[WindowID(rawValue: 1)], [WindowID(rawValue: 2)]]
+    )
+  }
+
+  func testLiveHorizontalSwapDoesNotOscillateAtSamePointerPosition() throws {
+    var state = try makeState(windowCount: 2)
+    let draggedID = WindowID(rawValue: 1)
+    let target = try targetFrame(for: draggedID, state: state)
+    let draggedFrame = Rect(
+      x: target.x + 500,
+      y: target.y,
+      width: target.width,
+      height: target.height
+    )
+
+    XCTAssertTrue(
+      reorderTiledWindowAfterMouseDrag(
+        draggedID,
+        actualFrame: draggedFrame,
+        initialFrame: target,
+        state: &state,
+        viewports: [monitorID: viewport]
+      )
+    )
+    XCTAssertFalse(
+      reorderTiledWindowAfterMouseDrag(
+        draggedID,
+        actualFrame: draggedFrame,
+        initialFrame: target,
+        state: &state,
+        viewports: [monitorID: viewport]
+      )
+    )
+  }
+
+  func testScrollAnchorPreservesViewportAfterReorderFocusChanges() throws {
+    var state = try makeState(windowCount: 2)
+    let firstID = WindowID(rawValue: 1)
+    state.monitors[0].workspaces[0].scrollOffset = 0.25
+    state.monitors[0].workspaces[0].targetScrollOffset = 0.25
+    let anchor = try XCTUnwrap(
+      workspaceScrollAnchor(containing: firstID, state: state)
+    )
+
+    focusWindow(WindowID(rawValue: 2), state: &state)
+    synchronizeScrollOffsets(
+      state: &state,
+      viewports: [monitorID: viewport]
+    )
+    restoreWorkspaceScroll(anchor, state: &state)
+
+    XCTAssertEqual(state.monitors[0].workspaces[0].scrollOffset, 0.25)
+    XCTAssertEqual(state.monitors[0].workspaces[0].targetScrollOffset, 0.25)
+  }
+
+  func testFocusedTiledWindowStartsMouseGestureBeforeFrameMoves() throws {
+    let state = try makeState(windowCount: 2)
+    let focusedID = WindowID(rawValue: 2)
+
+    XCTAssertEqual(
+      mouseGestureTiledWindowID(
+        translatedWindowID: nil,
+        activeWindowID: nil,
+        focusedWindowID: focusedID,
+        state: state
+      ),
+      focusedID
+    )
+  }
+
+  func testTranslatedWindowReplacesStaleGestureCandidate() throws {
+    let state = try makeState(windowCount: 2)
+    let translatedID = WindowID(rawValue: 2)
+
+    XCTAssertEqual(
+      mouseGestureTiledWindowID(
+        translatedWindowID: translatedID,
+        activeWindowID: WindowID(rawValue: 1),
+        focusedWindowID: WindowID(rawValue: 1),
+        state: state
+      ),
+      translatedID
+    )
+  }
+
+  func testLiveDragCanCrossMultipleColumnsAcrossUpdates() throws {
+    var state = try makeState(windowCount: 3)
+    let draggedID = WindowID(rawValue: 1)
+    let target = try targetFrame(for: draggedID, state: state)
+    let draggedFrame = Rect(
+      x: 1_700,
+      y: target.y,
+      width: target.width,
+      height: target.height
+    )
+
+    XCTAssertTrue(
+      reorderTiledWindowAfterMouseDrag(
+        draggedID,
+        actualFrame: draggedFrame,
+        initialFrame: target,
+        state: &state,
+        viewports: [monitorID: viewport]
+      )
+    )
+    XCTAssertTrue(
+      reorderTiledWindowAfterMouseDrag(
+        draggedID,
+        actualFrame: draggedFrame,
+        initialFrame: target,
+        state: &state,
+        viewports: [monitorID: viewport]
+      )
+    )
+    XCTAssertEqual(
+      state.monitors[0].workspaces[0].columns.map(\.windows),
+      [
+        [WindowID(rawValue: 2)],
+        [WindowID(rawValue: 3)],
+        [WindowID(rawValue: 1)],
+      ]
+    )
+  }
+
+  func testResizeIsNotClassifiedAsTranslation() throws {
+    let state = try makeState(windowCount: 1)
+    let windowID = WindowID(rawValue: 1)
+    let target = try targetFrame(for: windowID, state: state)
+
+    XCTAssertNil(
+      mouseTranslatedTiledWindowID(
+        externallyChangedFrames: [
+          windowID: Rect(
+            x: target.x,
+            y: target.y,
+            width: target.width + 100,
+            height: target.height
+          )
+        ],
+        state: state,
+        viewports: [monitorID: viewport]
+      )
+    )
+  }
+
+  func testResizeWithPositionChangeDoesNotReorderColumn() throws {
+    var state = try makeState(windowCount: 2)
+    let windowID = WindowID(rawValue: 1)
+    let target = try targetFrame(for: windowID, state: state)
+
+    XCTAssertFalse(
+      reorderTiledWindowAfterMouseDrag(
+        windowID,
+        actualFrame: Rect(
+          x: target.x + 500,
+          y: target.y,
+          width: target.width + 100,
+          height: target.height
+        ),
+        state: &state,
+        viewports: [monitorID: viewport]
+      )
+    )
+    XCTAssertEqual(
+      state.monitors[0].workspaces[0].columns.map(\.windows),
+      [[WindowID(rawValue: 1)], [WindowID(rawValue: 2)]]
+    )
+  }
+
+  func testTranslationCandidateFindsMovedTiledWindow() throws {
+    let state = try makeState(windowCount: 1)
+    let windowID = WindowID(rawValue: 1)
+    let target = try targetFrame(for: windowID, state: state)
+
+    XCTAssertEqual(
+      mouseTranslatedTiledWindowID(
+        externallyChangedFrames: [
+          windowID: Rect(
+            x: target.x + 100,
+            y: target.y,
+            width: target.width,
+            height: target.height
+          )
+        ],
+        state: state,
+        viewports: [monitorID: viewport]
+      ),
+      windowID
+    )
+  }
+
+  func testTranslationCandidateIgnoresFloatingWindows() throws {
+    var state = try makeState(windowCount: 1)
+    try reduce(.toggleFloating, on: monitorID, state: &state)
+    let windowID = WindowID(rawValue: 1)
+
+    XCTAssertNil(
+      mouseTranslatedTiledWindowID(
+        externallyChangedFrames: [
+          windowID: Rect(x: 200, y: 100, width: 600, height: 500)
+        ],
+        state: state,
+        viewports: [monitorID: viewport]
+      )
+    )
+  }
+
+  private func makeState(windowCount: Int) throws -> RuntimeState {
+    let config = Config()
+    var state = RuntimeState(config: config)
+    state.attachMonitor(monitorID)
+    for rawID in 1...windowCount {
+      let window = Window(
+        id: WindowID(rawValue: UInt64(rawID)),
+        appID: "editor",
+        title: "Window \(rawID)",
+        frame: Rect(x: 0, y: 0, width: 784, height: 684),
+        monitorID: monitorID
+      )
+      try discoverWindow(window, decision: RuleDecision(), state: &state)
+    }
+    return state
+  }
+
+  private func targetFrame(for windowID: WindowID, state: RuntimeState) throws -> Rect {
+    let workspace = state.monitors[0].workspaces[0]
+    return try XCTUnwrap(
+      computeLayout(
+        workspace: workspace,
+        viewport: viewport,
+        windows: workspace.columns.flatMap(\.windows).compactMap { state.windows[$0] },
+        settings: state.layout
+      ).frames.first(where: { $0.windowID == windowID })?.frame
+    )
+  }
+}

--- a/Tests/DefiRuntimeTests/MouseReorderingTests.swift
+++ b/Tests/DefiRuntimeTests/MouseReorderingTests.swift
@@ -422,6 +422,102 @@ final class MouseReorderingTests: XCTestCase {
     )
   }
 
+  func testMouseReorderAnimationSurvivesLaterDragSamples() {
+    XCTAssertFalse(
+      mouseGestureAnimationCancellationIsNeeded(
+        mouseReorderAnimationActive: true,
+        scrollAnimationActive: false,
+        animatedWritesPending: true
+      )
+    )
+    XCTAssertTrue(
+      mouseGestureAnimationCancellationIsNeeded(
+        mouseReorderAnimationActive: false,
+        scrollAnimationActive: true,
+        animatedWritesPending: true
+      )
+    )
+  }
+
+  func testPostReleaseSettlementWaitsForStableLateFrame() {
+    let initial = Rect(x: 0, y: 0, width: 500, height: 700)
+    let released = Rect(x: 300, y: 0, width: 500, height: 700)
+    let late = Rect(x: 700, y: 0, width: 500, height: 700)
+    let settlement = MouseGestureSettlement(
+      generation: 4,
+      windowID: WindowID(rawValue: 1),
+      initialFrame: initial,
+      releasedFrame: released,
+      now: 10,
+      maximumDuration: 0.8
+    )
+
+    let changed = advanceMouseGestureSettlement(
+      settlement,
+      actualFrame: late,
+      now: 10.1,
+      animationPending: false
+    )
+    XCTAssertFalse(changed.shouldFinish)
+    XCTAssertTrue(changed.settlement.observedPostReleaseChange)
+
+    let stable = advanceMouseGestureSettlement(
+      changed.settlement,
+      actualFrame: late,
+      now: 10.16,
+      animationPending: false
+    )
+    XCTAssertTrue(stable.shouldFinish)
+  }
+
+  func testPostReleaseSettlementWaitsForReorderAnimation() {
+    let frame = Rect(x: 300, y: 0, width: 500, height: 700)
+    let settlement = MouseGestureSettlement(
+      generation: 4,
+      windowID: WindowID(rawValue: 1),
+      initialFrame: Rect(x: 0, y: 0, width: 500, height: 700),
+      releasedFrame: frame,
+      now: 10,
+      maximumDuration: 0.25
+    )
+
+    let update = advanceMouseGestureSettlement(
+      settlement,
+      actualFrame: frame,
+      now: 10.3,
+      animationPending: true
+    )
+
+    XCTAssertFalse(update.shouldFinish)
+    XCTAssertEqual(update.settlement.nextCheckAt, 10.35, accuracy: 0.000_1)
+  }
+
+  func testPostReleaseSettlementFinishesAtDeadlineWithoutLateFrame() {
+    let frame = Rect(x: 300, y: 0, width: 500, height: 700)
+    let settlement = MouseGestureSettlement(
+      generation: 4,
+      windowID: WindowID(rawValue: 1),
+      initialFrame: Rect(x: 0, y: 0, width: 500, height: 700),
+      releasedFrame: frame,
+      now: 10,
+      maximumDuration: 0.25
+    )
+
+    let update = advanceMouseGestureSettlement(
+      settlement,
+      actualFrame: frame,
+      now: 10.25,
+      animationPending: false
+    )
+
+    XCTAssertTrue(update.shouldFinish)
+  }
+
+  func testSlowPostReleaseSettlementGetsLongerDeadline() {
+    XCTAssertEqual(mouseGestureSettlementMaximumDuration(latencySensitive: false), 0.25)
+    XCTAssertEqual(mouseGestureSettlementMaximumDuration(latencySensitive: true), 0.8)
+  }
+
   func testResizeIsNotClassifiedAsTranslation() throws {
     let state = try makeState(windowCount: 1)
     let windowID = WindowID(rawValue: 1)

--- a/Tests/DefiRuntimeTests/MouseReorderingTests.swift
+++ b/Tests/DefiRuntimeTests/MouseReorderingTests.swift
@@ -171,6 +171,7 @@ final class MouseReorderingTests: XCTestCase {
       mouseGestureTiledWindowID(
         translatedWindowID: nil,
         activeWindowID: nil,
+        mouseFocusIntentWindowID: focusedID,
         focusedWindowID: focusedID,
         state: state
       ),
@@ -178,18 +179,39 @@ final class MouseReorderingTests: XCTestCase {
     )
   }
 
-  func testTranslatedWindowReplacesStaleGestureCandidate() throws {
+  func testActiveGestureWindowRejectsUnrelatedTranslatedCandidate() throws {
     let state = try makeState(windowCount: 2)
     let translatedID = WindowID(rawValue: 2)
+    let activeID = WindowID(rawValue: 1)
 
     XCTAssertEqual(
       mouseGestureTiledWindowID(
         translatedWindowID: translatedID,
-        activeWindowID: WindowID(rawValue: 1),
-        focusedWindowID: WindowID(rawValue: 1),
+        activeWindowID: activeID,
+        mouseFocusIntentWindowID: activeID,
+        focusedWindowID: activeID,
         state: state
       ),
-      translatedID
+      activeID
+    )
+  }
+
+  func testReleaseOnlyGestureRecoversPreviousObservedFrame() {
+    let windowID = WindowID(rawValue: 2)
+    let previousFrame = Rect(x: 800, y: 0, width: 784, height: 684)
+    let releasedFrame = Rect(x: 200, y: 0, width: 784, height: 684)
+
+    XCTAssertEqual(
+      resolvedMouseGestureInitialFrame(
+        currentInitialFrame: nil,
+        gestureWindowID: windowID,
+        activeWindowID: nil,
+        translatedWindowID: windowID,
+        leftMouseButtonDown: false,
+        previousObservedFrames: [windowID: previousFrame],
+        actualFrame: releasedFrame
+      ),
+      previousFrame
     )
   }
 
@@ -239,6 +261,7 @@ final class MouseReorderingTests: XCTestCase {
 
     XCTAssertNil(
       mouseTranslatedTiledWindowID(
+        candidateWindowIDs: [windowID],
         externallyChangedFrames: [
           windowID: Rect(
             x: target.x,
@@ -284,6 +307,7 @@ final class MouseReorderingTests: XCTestCase {
 
     XCTAssertEqual(
       mouseTranslatedTiledWindowID(
+        candidateWindowIDs: [windowID],
         externallyChangedFrames: [
           windowID: Rect(
             x: target.x + 100,
@@ -299,6 +323,37 @@ final class MouseReorderingTests: XCTestCase {
     )
   }
 
+  func testTranslationCandidateIgnoresUnrelatedMismatch() throws {
+    let state = try makeState(windowCount: 2)
+    let firstID = WindowID(rawValue: 1)
+    let secondID = WindowID(rawValue: 2)
+    let firstTarget = try targetFrame(for: firstID, state: state)
+    let secondTarget = try targetFrame(for: secondID, state: state)
+
+    XCTAssertEqual(
+      mouseTranslatedTiledWindowID(
+        candidateWindowIDs: [secondID],
+        externallyChangedFrames: [
+          firstID: Rect(
+            x: firstTarget.x + 300,
+            y: firstTarget.y,
+            width: firstTarget.width,
+            height: firstTarget.height
+          ),
+          secondID: Rect(
+            x: secondTarget.x - 300,
+            y: secondTarget.y,
+            width: secondTarget.width,
+            height: secondTarget.height
+          ),
+        ],
+        state: state,
+        viewports: [monitorID: viewport]
+      ),
+      secondID
+    )
+  }
+
   func testTranslationCandidateIgnoresFloatingWindows() throws {
     var state = try makeState(windowCount: 1)
     try reduce(.toggleFloating, on: monitorID, state: &state)
@@ -306,6 +361,7 @@ final class MouseReorderingTests: XCTestCase {
 
     XCTAssertNil(
       mouseTranslatedTiledWindowID(
+        candidateWindowIDs: [windowID],
         externallyChangedFrames: [
           windowID: Rect(x: 200, y: 100, width: 600, height: 500)
         ],

--- a/Tests/DefiRuntimeTests/MouseReorderingTests.swift
+++ b/Tests/DefiRuntimeTests/MouseReorderingTests.swift
@@ -215,6 +215,27 @@ final class MouseReorderingTests: XCTestCase {
     )
   }
 
+  func testMouseGestureOriginUsesDisplayedAnimationPosition() {
+    let observedFrame = Rect(x: 0, y: 20, width: 784, height: 684)
+
+    XCTAssertEqual(
+      resolvedMouseGestureOriginFrame(
+        observedFrame: observedFrame,
+        displayedX: 320,
+        displayedY: 40
+      ),
+      Rect(x: 320, y: 40, width: 784, height: 684)
+    )
+    XCTAssertEqual(
+      resolvedMouseGestureOriginFrame(
+        observedFrame: observedFrame,
+        displayedX: nil,
+        displayedY: nil
+      ),
+      observedFrame
+    )
+  }
+
   func testLiveDragCanCrossMultipleColumnsAcrossUpdates() throws {
     var state = try makeState(windowCount: 3)
     let draggedID = WindowID(rawValue: 1)

--- a/Tests/DefiRuntimeTests/NativeFocusTests.swift
+++ b/Tests/DefiRuntimeTests/NativeFocusTests.swift
@@ -140,6 +140,56 @@ struct NativeFocusTests {
   }
 
   @Test
+  func dockClickWaitsForObservedManagedFocusAfterRelease() {
+    let focusedWindowID = WindowID(rawValue: 2)
+    let released = updatedDeferredMouseFocusIntent(
+      current: nil,
+      mouseFocusIntentWindowID: nil,
+      mouseFocusIntentTimestamp: 12,
+      focusedWindowID: WindowID(rawValue: 1),
+      nativeFocusChanged: false,
+      mouseInteractionEnded: true
+    )
+    #expect(released?.mouseInteractionEnded == true)
+    #expect(released?.focusObserved == false)
+
+    let observed = updatedDeferredMouseFocusIntent(
+      current: released,
+      mouseFocusIntentWindowID: nil,
+      mouseFocusIntentTimestamp: 12,
+      focusedWindowID: focusedWindowID,
+      nativeFocusChanged: true,
+      mouseInteractionEnded: false
+    )
+    #expect(observed?.windowID == focusedWindowID)
+    #expect(observed?.focusObserved == true)
+    #expect(
+      mouseReleaseFocusIntentIsCurrent(
+        focusedWindowID: focusedWindowID,
+        mouseFocusIntentWindowID: observed?.windowID,
+        mouseFocusIntentTimestamp: observed?.timestamp,
+        latestCommandInputTimestamp: 11,
+        nativeFocusChanged: observed?.focusObserved == true
+      )
+    )
+  }
+
+  @Test
+  func delayedMouseFocusCannotBypassNewerCommandAfterReleaseMarker() {
+    #expect(
+      nativeFocusMutationIsReady(
+        nativeFocusChanged: true,
+        mouseInteractionEnded: false,
+        leftMouseButtonDown: false,
+        deferredMouseFocusPending: true,
+        deferredMouseFocusReady: true,
+        mouseReleaseFocusIntentCurrent: false,
+        keyboardFocusIntentCurrent: false
+      ) == false
+    )
+  }
+
+  @Test
   func queuedHotKeyKeepsCapturedInputOrder() {
     #expect(
       resolvedLatestCommandInputTimestamp(

--- a/Tests/DefiRuntimeTests/NativeFocusTests.swift
+++ b/Tests/DefiRuntimeTests/NativeFocusTests.swift
@@ -175,6 +175,21 @@ struct NativeFocusTests {
   }
 
   @Test
+  func consumedMouseFocusIntentIsNotRecreatedByPeriodicSnapshot() {
+    #expect(
+      updatedDeferredMouseFocusIntent(
+        current: nil,
+        consumedMouseFocusIntentTimestamp: 12,
+        mouseFocusIntentWindowID: WindowID(rawValue: 2),
+        mouseFocusIntentTimestamp: 12,
+        focusedWindowID: WindowID(rawValue: 2),
+        nativeFocusChanged: false,
+        mouseInteractionEnded: false
+      ) == nil
+    )
+  }
+
+  @Test
   func delayedMouseFocusCannotBypassNewerCommandAfterReleaseMarker() {
     #expect(
       nativeFocusMutationIsReady(

--- a/Tests/DefiRuntimeTests/NativeFocusTests.swift
+++ b/Tests/DefiRuntimeTests/NativeFocusTests.swift
@@ -48,15 +48,17 @@ struct NativeFocusTests {
     #expect(
       nativeFocusMutationIsReady(
         nativeFocusChanged: true,
-        mouseGestureEnded: false,
-        leftMouseButtonDown: true
+        mouseInteractionEnded: false,
+        leftMouseButtonDown: true,
+        mouseReleaseFocusIntentCurrent: false
       ) == false
     )
     #expect(
       nativeFocusMutationIsReady(
         nativeFocusChanged: false,
-        mouseGestureEnded: true,
-        leftMouseButtonDown: false
+        mouseInteractionEnded: true,
+        leftMouseButtonDown: false,
+        mouseReleaseFocusIntentCurrent: true
       )
     )
   }
@@ -66,8 +68,44 @@ struct NativeFocusTests {
     #expect(
       nativeFocusMutationIsReady(
         nativeFocusChanged: true,
-        mouseGestureEnded: false,
-        leftMouseButtonDown: false
+        mouseInteractionEnded: false,
+        leftMouseButtonDown: false,
+        mouseReleaseFocusIntentCurrent: false
+      )
+    )
+  }
+
+  @Test
+  func newerCommandRejectsDeferredMouseReleaseFocus() {
+    let focusedWindowID = WindowID(rawValue: 2)
+    #expect(
+      mouseReleaseFocusIntentIsCurrent(
+        focusedWindowID: focusedWindowID,
+        mouseFocusIntentWindowID: focusedWindowID,
+        mouseFocusIntentTimestamp: 10,
+        latestCommandInputTimestamp: 11,
+        nativeFocusChanged: true
+      ) == false
+    )
+    #expect(
+      nativeFocusMutationIsReady(
+        nativeFocusChanged: true,
+        mouseInteractionEnded: true,
+        leftMouseButtonDown: false,
+        mouseReleaseFocusIntentCurrent: false
+      ) == false
+    )
+  }
+
+  @Test
+  func currentMouseReleaseAcceptsObservedFocusWithoutWindowHint() {
+    #expect(
+      mouseReleaseFocusIntentIsCurrent(
+        focusedWindowID: WindowID(rawValue: 2),
+        mouseFocusIntentWindowID: nil,
+        mouseFocusIntentTimestamp: 12,
+        latestCommandInputTimestamp: 11,
+        nativeFocusChanged: true
       )
     )
   }

--- a/Tests/DefiRuntimeTests/NativeFocusTests.swift
+++ b/Tests/DefiRuntimeTests/NativeFocusTests.swift
@@ -44,6 +44,35 @@ struct NativeFocusTests {
   }
 
   @Test
+  func mouseDownDefersNativeFocusMutationUntilRelease() {
+    #expect(
+      nativeFocusMutationIsReady(
+        nativeFocusChanged: true,
+        mouseGestureEnded: false,
+        leftMouseButtonDown: true
+      ) == false
+    )
+    #expect(
+      nativeFocusMutationIsReady(
+        nativeFocusChanged: false,
+        mouseGestureEnded: true,
+        leftMouseButtonDown: false
+      )
+    )
+  }
+
+  @Test
+  func nonMouseNativeFocusMutatesImmediately() {
+    #expect(
+      nativeFocusMutationIsReady(
+        nativeFocusChanged: true,
+        mouseGestureEnded: false,
+        leftMouseButtonDown: false
+      )
+    )
+  }
+
+  @Test
   func selectedWindowOnDifferentActiveMonitorChangesSelection() throws {
     var state = try makeState()
     let selected = WindowID(rawValue: 1)

--- a/Tests/DefiRuntimeTests/NativeFocusTests.swift
+++ b/Tests/DefiRuntimeTests/NativeFocusTests.swift
@@ -111,6 +111,31 @@ struct NativeFocusTests {
   }
 
   @Test
+  func queuedHotKeyKeepsCapturedInputOrder() {
+    #expect(
+      resolvedLatestCommandInputTimestamp(
+        previousTimestamp: 0,
+        capturedInputTimestamp: 10,
+        commandHandledAt: 12
+      ) == 10
+    )
+    #expect(
+      resolvedLatestCommandInputTimestamp(
+        previousTimestamp: 11,
+        capturedInputTimestamp: 10,
+        commandHandledAt: 12
+      ) == 11
+    )
+    #expect(
+      resolvedLatestCommandInputTimestamp(
+        previousTimestamp: 11,
+        capturedInputTimestamp: nil,
+        commandHandledAt: 12
+      ) == 12
+    )
+  }
+
+  @Test
   func selectedWindowOnDifferentActiveMonitorChangesSelection() throws {
     var state = try makeState()
     let selected = WindowID(rawValue: 1)

--- a/Tests/DefiRuntimeTests/NativeFocusTests.swift
+++ b/Tests/DefiRuntimeTests/NativeFocusTests.swift
@@ -50,7 +50,8 @@ struct NativeFocusTests {
         nativeFocusChanged: true,
         mouseInteractionEnded: false,
         leftMouseButtonDown: true,
-        mouseReleaseFocusIntentCurrent: false
+        mouseReleaseFocusIntentCurrent: false,
+        keyboardFocusIntentCurrent: false
       ) == false
     )
     #expect(
@@ -58,7 +59,8 @@ struct NativeFocusTests {
         nativeFocusChanged: false,
         mouseInteractionEnded: true,
         leftMouseButtonDown: false,
-        mouseReleaseFocusIntentCurrent: true
+        mouseReleaseFocusIntentCurrent: true,
+        keyboardFocusIntentCurrent: false
       )
     )
   }
@@ -70,7 +72,33 @@ struct NativeFocusTests {
         nativeFocusChanged: true,
         mouseInteractionEnded: false,
         leftMouseButtonDown: false,
-        mouseReleaseFocusIntentCurrent: false
+        mouseReleaseFocusIntentCurrent: false,
+        keyboardFocusIntentCurrent: false
+      )
+    )
+  }
+
+  @Test
+  func keyboardFocusMutatesWhileMouseIsHeld() {
+    #expect(
+      keyboardFocusIntentIsCurrent(
+        keyboardFocusIntentTimestamp: 12,
+        latestCommandInputTimestamp: 11
+      )
+    )
+    #expect(
+      keyboardFocusIntentIsCurrent(
+        keyboardFocusIntentTimestamp: 10,
+        latestCommandInputTimestamp: 11
+      ) == false
+    )
+    #expect(
+      nativeFocusMutationIsReady(
+        nativeFocusChanged: true,
+        mouseInteractionEnded: false,
+        leftMouseButtonDown: true,
+        mouseReleaseFocusIntentCurrent: false,
+        keyboardFocusIntentCurrent: true
       )
     )
   }
@@ -92,7 +120,8 @@ struct NativeFocusTests {
         nativeFocusChanged: true,
         mouseInteractionEnded: true,
         leftMouseButtonDown: false,
-        mouseReleaseFocusIntentCurrent: false
+        mouseReleaseFocusIntentCurrent: false,
+        keyboardFocusIntentCurrent: false
       ) == false
     )
   }


### PR DESCRIPTION
## Why

Allow tiled windows to be reordered with native title-bar dragging without focus jumps, viewport shifts, or snap-back.

## Changes

- Track grabbed tiled window from mouse-down through release.
- Prevent layout writes from fighting active drag.
- Reorder columns and stacked windows live when crossing neighboring centers.
- Animate surrounding columns using existing movement pipeline.
- Preserve viewport and support multi-column dragging without oscillation.
- Keep mouse resize width learning independent.
- Add runtime, focus, event-normalization tests and documentation.

## How to test

- `swift build`
- `swift test`
- `./script/build_and_run.sh --verify`
- `./script/test_desktop.sh`
- Drag adjacent tiled window across one or several columns.
- Drag vertically inside stacked column.
- Confirm simple clicks and mouse resizing still behave normally.
