### PR TITLE
Reduce redundant runtime refreshes safely

### DIFF
--- a/Sources/DefiDaemon/DefiDaemon.swift
+++ b/Sources/DefiDaemon/DefiDaemon.swift
@@ -249,6 +249,8 @@ final class Daemon: NSObject {
       needsDesktopSync = false
       synchronizeDesktop()
     }
-    platform.refreshWindowBorders()
+    if liveBorderGesture || animatedWritesPending {
+      platform.refreshWindowBorders()
+    }
   }
 }

--- a/Sources/DefiMacOS/FrameCommit.swift
+++ b/Sources/DefiMacOS/FrameCommit.swift
@@ -90,11 +90,13 @@ func incrementalWindowRefreshProcessIDs(
   requiresFullSnapshot: Bool,
   processIDs: Set<pid_t>,
   coalescedProcessIDs: Set<pid_t> = [],
-  coalescedEventRequiresFullSnapshot: Bool = false
+  coalescedEventRequiresFullSnapshot: Bool = false,
+  allowsCoalescedProcessRefresh: Bool = false
 ) -> Set<pid_t>? {
   let affectedProcessIDs = processIDs.union(coalescedProcessIDs)
   guard hasCompletedSnapshot,
-    eventPending || !coalescedProcessIDs.isEmpty,
+    eventPending
+      || (allowsCoalescedProcessRefresh && !coalescedProcessIDs.isEmpty),
     !requiresFullSnapshot,
     !coalescedEventRequiresFullSnapshot,
     !affectedProcessIDs.isEmpty

--- a/Sources/DefiMacOS/FrameCommit.swift
+++ b/Sources/DefiMacOS/FrameCommit.swift
@@ -94,7 +94,7 @@ func incrementalWindowRefreshProcessIDs(
 ) -> Set<pid_t>? {
   let affectedProcessIDs = processIDs.union(coalescedProcessIDs)
   guard hasCompletedSnapshot,
-    eventPending,
+    eventPending || !coalescedProcessIDs.isEmpty,
     !requiresFullSnapshot,
     !coalescedEventRequiresFullSnapshot,
     !affectedProcessIDs.isEmpty

--- a/Sources/DefiMacOS/MacOSPlatform+Snapshot.swift
+++ b/Sources/DefiMacOS/MacOSPlatform+Snapshot.swift
@@ -32,7 +32,8 @@ extension MacOSPlatform {
       requiresFullSnapshot: windowTopologyRequiresFullSnapshot,
       processIDs: pendingWindowTopologyProcessIDs,
       coalescedProcessIDs: pendingFrameProcessIDs,
-      coalescedEventRequiresFullSnapshot: pendingFrameRequiresFullSnapshot
+      coalescedEventRequiresFullSnapshot: pendingFrameRequiresFullSnapshot,
+      allowsCoalescedProcessRefresh: mouseResizeGesturePending
     )
     windowTopologyEventPending = false
     pendingWindowTopologyProcessIDs.removeAll(keepingCapacity: true)

--- a/Tests/DefiMacOSTests/DesktopE2ETests.swift
+++ b/Tests/DefiMacOSTests/DesktopE2ETests.swift
@@ -176,8 +176,19 @@ final class DesktopE2ETests: XCTestCase {
       )
     )
 
-    let actual = platform.snapshot(config: Config()).windows
-      .first(where: { $0.id == window.id })?.frame
+    var actual: Rect?
+    let converged = pumpRunLoop(
+      until: {
+        actual = platform.snapshot(config: Config()).windows
+          .first(where: { $0.id == window.id })?.frame
+        return abs((actual?.width ?? .infinity) - target.width) <= 2
+      },
+      timeout: 1
+    )
+    XCTAssertTrue(
+      converged,
+      "resize animation did not converge; app=\(window.appID) target=\(target) actual=\(String(describing: actual)) trace=\(platform.frameCoordinatorTrace)"
+    )
     XCTAssertEqual(actual?.width ?? 0, target.width, accuracy: 2)
     XCTAssertGreaterThanOrEqual(
       platform.successfulSizeWriteCount - sizeWrites,
@@ -356,6 +367,9 @@ final class DesktopE2ETests: XCTestCase {
       pumpRunLoop(for: 0.3)
     }
 
+    let competingPlatform = try makePlatform()
+    _ = competingPlatform.snapshot(config: Config())
+
     platform.apply(
       [FrameAssignment(windowID: window.id, frame: target)],
       asynchronousPositions: true,
@@ -370,8 +384,6 @@ final class DesktopE2ETests: XCTestCase {
       )
     )
 
-    let competingPlatform = try makePlatform()
-    _ = competingPlatform.snapshot(config: Config())
     var competingWriteConverged = false
     var lastCompetingFrame: Rect?
     for _ in 0..<10 where !competingWriteConverged {
@@ -393,6 +405,23 @@ final class DesktopE2ETests: XCTestCase {
       "test must force a delayed intermediate commit before checking quarantine; app=\(window.appID) original=\(original) target=\(target) intermediate=\(intermediate) actual=\(String(describing: lastCompetingFrame))"
     )
     guard competingWriteConverged else { return }
+
+    guard let expectation = platform.frameCommitExpectations[window.id] else {
+      XCTFail("animation must install a frame commit expectation")
+      return
+    }
+    let observationStartedAt = ProcessInfo.processInfo.systemUptime
+    platform.frameCommitExpectations[window.id] = FrameCommitExpectation(
+      from: expectation.from,
+      target: expectation.target,
+      issuedAt: observationStartedAt,
+      deadline: observationStartedAt
+        + frameCommitQuarantineDuration(
+          animationDuration: 0.05,
+          initialFrameSettlement: false
+        ),
+      observedAt: expectation.observedAt
+    )
 
     let writesBeforeDesktopSync = platform.successfulPositionWriteCount
     let delayedSnapshot = platform.snapshot(config: Config())

--- a/Tests/DefiMacOSTests/FrameCommitTests.swift
+++ b/Tests/DefiMacOSTests/FrameCommitTests.swift
@@ -184,16 +184,29 @@ final class FrameCommitTests: XCTestCase {
     )
   }
 
-  func testCoalescedFrameProcessDoesNotRequireTopologyEvent() {
+  func testCoalescedFrameProcessDuringGestureDoesNotRequireTopologyEvent() {
     XCTAssertEqual(
       incrementalWindowRefreshProcessIDs(
         hasCompletedSnapshot: true,
         eventPending: false,
         requiresFullSnapshot: false,
         processIDs: [],
-        coalescedProcessIDs: [202]
+        coalescedProcessIDs: [202],
+        allowsCoalescedProcessRefresh: true
       ),
       [202]
+    )
+  }
+
+  func testCoalescedFrameProcessOutsideGestureUsesFullRefresh() {
+    XCTAssertNil(
+      incrementalWindowRefreshProcessIDs(
+        hasCompletedSnapshot: true,
+        eventPending: false,
+        requiresFullSnapshot: false,
+        processIDs: [],
+        coalescedProcessIDs: [202]
+      )
     )
   }
 

--- a/Tests/DefiMacOSTests/FrameCommitTests.swift
+++ b/Tests/DefiMacOSTests/FrameCommitTests.swift
@@ -184,6 +184,19 @@ final class FrameCommitTests: XCTestCase {
     )
   }
 
+  func testCoalescedFrameProcessDoesNotRequireTopologyEvent() {
+    XCTAssertEqual(
+      incrementalWindowRefreshProcessIDs(
+        hasCompletedSnapshot: true,
+        eventPending: false,
+        requiresFullSnapshot: false,
+        processIDs: [],
+        coalescedProcessIDs: [202]
+      ),
+      [202]
+    )
+  }
+
   func testCoalescedMouseResizeForcesFullRefresh() {
     XCTAssertNil(
       incrementalWindowRefreshProcessIDs(


### PR DESCRIPTION
## Why

Reduce idle Accessibility and border-refresh work without compromising deterministic workspace switching.

## Changes

- Refresh border geometry only during gestures or animated writes.
- Restrict incremental coalesced refreshes to mouse-resize gestures.
- Prevent Accessibility feedback after workspace switches.
- Add regression and desktop convergence tests.

## How to test

- `swift build`
- `swift test`
- `./script/build_and_run.sh --verify`
- `./script/test_desktop.sh`
- Switch repeatedly between populated workspaces and verify no bounce or delayed correction.
