### PR TITLE
Fix border stacking below picture-in-picture windows

### DIFF
--- a/Sources/DefiMacOS/MacOSPlatform+Snapshot.swift
+++ b/Sources/DefiMacOS/MacOSPlatform+Snapshot.swift
@@ -46,7 +46,8 @@ extension MacOSPlatform {
     let cgWindows = copyCGWindows()
     windowBorderStacking = copyWindowBorderStacking(
       targetWindowID: borderManager.activeWindowID,
-      monitorFrames: lastMonitorFrames
+      monitorFrames: lastMonitorFrames,
+      knownWindowIDs: Set(elements.keys)
     )
     let previousElements = elements
     let previousProcessIDs = processIDs

--- a/Sources/DefiMacOS/MacOSPlatform+Snapshot.swift
+++ b/Sources/DefiMacOS/MacOSPlatform+Snapshot.swift
@@ -44,7 +44,10 @@ extension MacOSPlatform {
     let monitors = discoverMonitors()
     lastMonitorFrames = monitors.map(\.frame)
     let cgWindows = copyCGWindows()
-    frontmostNormalWindowID = copyFrontmostNormalWindowID()
+    windowBorderStacking = copyWindowBorderStacking(
+      targetWindowID: borderManager.activeWindowID,
+      monitorFrames: lastMonitorFrames
+    )
     let previousElements = elements
     let previousProcessIDs = processIDs
     let previousWindowsByProcess = Dictionary(

--- a/Sources/DefiMacOS/MacOSPlatform+Snapshot.swift
+++ b/Sources/DefiMacOS/MacOSPlatform+Snapshot.swift
@@ -44,11 +44,6 @@ extension MacOSPlatform {
     let monitors = discoverMonitors()
     lastMonitorFrames = monitors.map(\.frame)
     let cgWindows = copyCGWindows()
-    windowBorderStacking = copyWindowBorderStacking(
-      targetWindowID: borderManager.activeWindowID,
-      monitorFrames: lastMonitorFrames,
-      knownWindowIDs: Set(elements.keys)
-    )
     let previousElements = elements
     let previousProcessIDs = processIDs
     let previousWindowsByProcess = Dictionary(

--- a/Sources/DefiMacOS/MacOSPlatform+WindowBorderObservation.swift
+++ b/Sources/DefiMacOS/MacOSPlatform+WindowBorderObservation.swift
@@ -153,11 +153,14 @@ extension MacOSPlatform {
     else {
       return
     }
-    let frontmostWindowID = copyFrontmostNormalWindowID()
-    frontmostNormalWindowID = frontmostWindowID
+    let stacking = copyWindowBorderStacking(
+      targetWindowID: request.windowID,
+      monitorFrames: lastMonitorFrames
+    )
+    windowBorderStacking = stacking
     borderManager.updateActiveStacking(
       for: request.windowID,
-      isFrontmost: frontmostWindowID == request.windowID
+      stacking: stacking
     )
   }
 
@@ -187,14 +190,18 @@ extension MacOSPlatform {
 
   public func prepareWindowBorderSelection(_ selectedWindowID: WindowID?) {
     desiredSelectedWindowID = selectedWindowID
-    frontmostNormalWindowID = copyFrontmostNormalWindowID()
+    let stacking = copyWindowBorderStacking(
+      targetWindowID: selectedWindowID,
+      monitorFrames: lastMonitorFrames
+    )
+    windowBorderStacking = stacking
     let selectedFrame = selectedWindowID.flatMap { windowID in
       resolvedBorderFrame(for: windowID)
     }
     borderManager.prepareForSelection(
       selectedWindowID,
       displayedFrame: selectedFrame,
-      activeWindowIsFrontmost: selectedWindowID == frontmostNormalWindowID
+      stacking: stacking
     )
     let freshFrames: [WindowID: Rect] = Dictionary(
       uniqueKeysWithValues: borderManager.liveGeometryWindowIDs.compactMap { windowID in
@@ -261,7 +268,7 @@ extension MacOSPlatform {
     borderManager.sync(
       plan,
       displayedFrames: displayedFrames,
-      activeWindowIsFrontmost: plan.active?.windowID == frontmostNormalWindowID
+      stacking: resolvedWindowBorderStacking(for: plan.active?.windowID)
     )
     let finalDisplayedFrames: [WindowID: Rect] = Dictionary(
       uniqueKeysWithValues: borderManager.liveGeometryWindowIDs.compactMap { windowID in
@@ -281,6 +288,20 @@ extension MacOSPlatform {
       frames: finalDisplayedFrames,
       style: borderStyle
     )
+  }
+
+  private func resolvedWindowBorderStacking(
+    for targetWindowID: WindowID?
+  ) -> WindowBorderStacking {
+    if windowBorderStacking.targetWindowID == targetWindowID {
+      return windowBorderStacking
+    }
+    let stacking = copyWindowBorderStacking(
+      targetWindowID: targetWindowID,
+      monitorFrames: lastMonitorFrames
+    )
+    windowBorderStacking = stacking
+    return stacking
   }
 
   private func refreshWindowBorderGeometry(for element: AXUIElement) {

--- a/Sources/DefiMacOS/MacOSPlatform+WindowBorderObservation.swift
+++ b/Sources/DefiMacOS/MacOSPlatform+WindowBorderObservation.swift
@@ -155,7 +155,8 @@ extension MacOSPlatform {
     }
     let stacking = copyWindowBorderStacking(
       targetWindowID: request.windowID,
-      monitorFrames: lastMonitorFrames
+      monitorFrames: lastMonitorFrames,
+      knownWindowIDs: Set(elements.keys)
     )
     windowBorderStacking = stacking
     borderManager.updateActiveStacking(
@@ -192,7 +193,8 @@ extension MacOSPlatform {
     desiredSelectedWindowID = selectedWindowID
     let stacking = copyWindowBorderStacking(
       targetWindowID: selectedWindowID,
-      monitorFrames: lastMonitorFrames
+      monitorFrames: lastMonitorFrames,
+      knownWindowIDs: Set(elements.keys)
     )
     windowBorderStacking = stacking
     let selectedFrame = selectedWindowID.flatMap { windowID in
@@ -298,7 +300,8 @@ extension MacOSPlatform {
     }
     let stacking = copyWindowBorderStacking(
       targetWindowID: targetWindowID,
-      monitorFrames: lastMonitorFrames
+      monitorFrames: lastMonitorFrames,
+      knownWindowIDs: Set(elements.keys)
     )
     windowBorderStacking = stacking
     return stacking

--- a/Sources/DefiMacOS/MacOSPlatform.swift
+++ b/Sources/DefiMacOS/MacOSPlatform.swift
@@ -56,7 +56,7 @@ public final class MacOSPlatform {
   var lastNativeFocusedWindowID: WindowID?
   var borderHiddenWindowIDs = Set<WindowID>()
   var borderLiveWindowID: WindowID?
-  var frontmostNormalWindowID: WindowID?
+  var windowBorderStacking = WindowBorderStacking.inactive(for: nil)
   var borderStackingRefreshState = WindowBorderStackingRefreshState()
   var borderStackingRefreshTask: Task<Void, Never>?
   var borderStyle = WindowBorderStyle(

--- a/Sources/DefiMacOS/Platform.swift
+++ b/Sources/DefiMacOS/Platform.swift
@@ -85,28 +85,33 @@ func framesByWindowID(
   )
 }
 
-func copyFrontmostNormalWindowID() -> WindowID? {
+func copyWindowBorderStacking(
+  targetWindowID: WindowID?,
+  monitorFrames: [Rect]
+) -> WindowBorderStacking {
   guard
     let info = CGWindowListCopyWindowInfo(
       [.optionOnScreenOnly, .excludeDesktopElements],
       kCGNullWindowID
     ) as? [[CFString: Any]]
   else {
-    return nil
+    return .inactive(for: targetWindowID)
   }
   let ownProcessID = ProcessInfo.processInfo.processIdentifier
-  let entries = info.compactMap { item -> NormalWindowStackEntry? in
+  let entries = info.compactMap { item -> WindowStackEntry? in
     guard
-      (item[kCGWindowLayer] as? NSNumber)?.intValue == 0,
-      (item[kCGWindowOwnerPID] as? NSNumber)?.int32Value != ownProcessID,
+      let layer = item[kCGWindowLayer] as? NSNumber,
+      let processID = item[kCGWindowOwnerPID] as? NSNumber,
       let number = item[kCGWindowNumber] as? NSNumber,
       let bounds = item[kCGWindowBounds] as? [String: Any],
       let cgRect = CGRect(dictionaryRepresentation: bounds as CFDictionary)
     else {
       return nil
     }
-    return NormalWindowStackEntry(
+    return WindowStackEntry(
       windowID: WindowID(rawValue: number.uint64Value),
+      processID: processID.int32Value,
+      layer: layer.intValue,
       frame: Rect(
         x: cgRect.minX,
         y: cgRect.minY,
@@ -115,7 +120,13 @@ func copyFrontmostNormalWindowID() -> WindowID? {
       )
     )
   }
-  return frontmostBorderOccludingWindowID(in: entries)
+  return windowBorderStacking(
+    targetWindowID: targetWindowID,
+    ownProcessID: ownProcessID,
+    floatingLevel: NSWindow.Level.floating.rawValue,
+    entries: entries,
+    monitorFrames: monitorFrames
+  )
 }
 
 func bestCGWindow(

--- a/Sources/DefiMacOS/Platform.swift
+++ b/Sources/DefiMacOS/Platform.swift
@@ -87,7 +87,8 @@ func framesByWindowID(
 
 func copyWindowBorderStacking(
   targetWindowID: WindowID?,
-  monitorFrames: [Rect]
+  monitorFrames: [Rect],
+  knownWindowIDs: Set<WindowID>
 ) -> WindowBorderStacking {
   guard
     let info = CGWindowListCopyWindowInfo(
@@ -125,7 +126,8 @@ func copyWindowBorderStacking(
     ownProcessID: ownProcessID,
     floatingLevel: NSWindow.Level.floating.rawValue,
     entries: entries,
-    monitorFrames: monitorFrames
+    monitorFrames: monitorFrames,
+    knownWindowIDs: knownWindowIDs
   )
 }
 

--- a/Sources/DefiMacOS/PlatformEventNormalization.swift
+++ b/Sources/DefiMacOS/PlatformEventNormalization.swift
@@ -373,18 +373,88 @@ struct WindowBorderStackingRefreshState {
   }
 }
 
-struct NormalWindowStackEntry: Equatable {
+struct WindowStackEntry: Equatable, Sendable {
   let windowID: WindowID
+  let processID: pid_t
+  let layer: Int
   let frame: Rect
+}
+
+struct WindowBorderStacking: Equatable, Sendable {
+  let targetWindowID: WindowID?
+  let activeWindowIsFrontmost: Bool
+  let upperBoundWindowID: WindowID?
+  let upperBoundLevel: Int?
+
+  static func inactive(for targetWindowID: WindowID?) -> Self {
+    Self(
+      targetWindowID: targetWindowID,
+      activeWindowIsFrontmost: false,
+      upperBoundWindowID: nil,
+      upperBoundLevel: nil
+    )
+  }
 }
 
 private let minimumBorderOccludingWindowArea = 2_048.0
 
-func frontmostBorderOccludingWindowID(
-  in entries: [NormalWindowStackEntry]
-) -> WindowID? {
-  // AppKit and Electron can create tiny normal-level helper surfaces on mouse-down.
-  entries.first { entry in
-    entry.frame.width * entry.frame.height >= minimumBorderOccludingWindowArea
+func windowBorderStacking(
+  targetWindowID: WindowID?,
+  ownProcessID: pid_t,
+  floatingLevel: Int,
+  entries: [WindowStackEntry],
+  monitorFrames: [Rect] = []
+) -> WindowBorderStacking {
+  let externalEntries = entries.filter { $0.processID != ownProcessID }
+  let targetMonitorFrames: [Rect]
+  if let targetWindowID,
+    let targetFrame = externalEntries.first(where: {
+      $0.windowID == targetWindowID
+    })?.frame
+  {
+    targetMonitorFrames = monitorFrames.filter {
+      framesIntersect($0, targetFrame)
+    }
+  } else {
+    targetMonitorFrames = monitorFrames
+  }
+  let relevantEntries = externalEntries.filter { entry in
+    targetMonitorFrames.isEmpty
+      || targetMonitorFrames.contains { framesIntersect($0, entry.frame) }
+  }
+  let targetProcessID = relevantEntries.first(where: {
+    $0.windowID == targetWindowID
+  })?.processID
+  // Same-process normal-level helpers belong to the selected app's window group.
+  // Treating them as an occluder demotes the border during mouse-down and makes it blink.
+  let frontmostNormalWindowID = relevantEntries.first { entry in
+    entry.layer == NSWindow.Level.normal.rawValue
+      && entry.frame.width * entry.frame.height >= minimumBorderOccludingWindowArea
+      && (entry.windowID == targetWindowID || entry.processID != targetProcessID)
   }?.windowID
+  guard let targetWindowID,
+    frontmostNormalWindowID == targetWindowID,
+    let targetIndex = relevantEntries.firstIndex(where: {
+      $0.windowID == targetWindowID
+    })
+  else {
+    return .inactive(for: targetWindowID)
+  }
+  let upperBound = relevantEntries[..<targetIndex].last { entry in
+    entry.layer > NSWindow.Level.normal.rawValue
+      && entry.layer <= floatingLevel
+  }
+  return WindowBorderStacking(
+    targetWindowID: targetWindowID,
+    activeWindowIsFrontmost: true,
+    upperBoundWindowID: upperBound?.windowID,
+    upperBoundLevel: upperBound?.layer
+  )
+}
+
+private func framesIntersect(_ lhs: Rect, _ rhs: Rect) -> Bool {
+  lhs.x + lhs.width > rhs.x
+    && lhs.x < rhs.x + rhs.width
+    && lhs.y + lhs.height > rhs.y
+    && lhs.y < rhs.y + rhs.height
 }

--- a/Sources/DefiMacOS/PlatformEventNormalization.swift
+++ b/Sources/DefiMacOS/PlatformEventNormalization.swift
@@ -403,7 +403,8 @@ func windowBorderStacking(
   ownProcessID: pid_t,
   floatingLevel: Int,
   entries: [WindowStackEntry],
-  monitorFrames: [Rect] = []
+  monitorFrames: [Rect] = [],
+  knownWindowIDs: Set<WindowID> = []
 ) -> WindowBorderStacking {
   let externalEntries = entries.filter { $0.processID != ownProcessID }
   let targetMonitorFrames: [Rect]
@@ -425,12 +426,14 @@ func windowBorderStacking(
   let targetProcessID = relevantEntries.first(where: {
     $0.windowID == targetWindowID
   })?.processID
-  // Same-process normal-level helpers belong to the selected app's window group.
-  // Treating them as an occluder demotes the border during mouse-down and makes it blink.
+  // Untracked same-process helpers can appear during mouse-down. Known windows remain
+  // occluders so a selected window's border cannot cover its app's dialogs.
   let frontmostNormalWindowID = relevantEntries.first { entry in
     entry.layer == NSWindow.Level.normal.rawValue
       && entry.frame.width * entry.frame.height >= minimumBorderOccludingWindowArea
-      && (entry.windowID == targetWindowID || entry.processID != targetProcessID)
+      && (entry.windowID == targetWindowID
+        || entry.processID != targetProcessID
+        || knownWindowIDs.contains(entry.windowID))
   }?.windowID
   guard let targetWindowID,
     frontmostNormalWindowID == targetWindowID,

--- a/Sources/DefiMacOS/WindowBorderManager.swift
+++ b/Sources/DefiMacOS/WindowBorderManager.swift
@@ -48,26 +48,28 @@ final class WindowBorderManager {
 
   func updateActiveStacking(
     for expectedActiveWindowID: WindowID,
-    isFrontmost: Bool
+    stacking: WindowBorderStacking
   ) {
     guard activeWindowID == expectedActiveWindowID,
+      stacking.targetWindowID == expectedActiveWindowID,
       let overlay = overlays[expectedActiveWindowID]
     else {
       return
     }
-    overlay.setFrontmost(isFrontmost)
+    overlay.setStacking(stacking)
   }
 
   func prepareForSelection(
     _ windowID: WindowID?,
     displayedFrame: Rect?,
-    activeWindowIsFrontmost: Bool = false
+    stacking: WindowBorderStacking? = nil
   ) {
+    let activeStacking = stacking ?? .inactive(for: windowID)
     if activeWindowID == windowID {
       if let windowID {
         updateActiveStacking(
           for: windowID,
-          isFrontmost: activeWindowIsFrontmost
+          stacking: activeStacking
         )
       }
       return
@@ -81,7 +83,7 @@ final class WindowBorderManager {
       let overlay = overlays[previousActiveWindowID],
       overlay.isVisible
     {
-      overlay.setFrontmost(false)
+      overlay.setStacking(.inactive(for: previousActiveWindowID))
       if style.inactiveEnabled {
         overlay.updateAppearance(to: style.inactiveColor)
       } else {
@@ -100,7 +102,7 @@ final class WindowBorderManager {
       } else {
         overlay = reusableOrNewOverlay(for: windowID)
       }
-      overlay.setFrontmost(activeWindowIsFrontmost)
+      overlay.setStacking(activeStacking)
       _ = overlay.syncGeometry(
         frame: displayedFrame,
         width: style.width,
@@ -140,11 +142,15 @@ final class WindowBorderManager {
   func sync(
     _ plan: WindowBorderRenderPlan,
     displayedFrames: [WindowID: Rect],
-    activeWindowIsFrontmost: Bool
+    stacking: WindowBorderStacking
   ) {
     let trackedWindowIDs = Set(plan.tracked.map(\.windowID))
     if let activeWindowID = plan.active?.windowID {
-      overlays[activeWindowID]?.setFrontmost(activeWindowIsFrontmost)
+      overlays[activeWindowID]?.setStacking(
+        stacking.targetWindowID == activeWindowID
+          ? stacking
+          : .inactive(for: activeWindowID)
+      )
     }
     guard plan != lastPlan || displayedFrames != lastDisplayedFrames else {
       skippedPlans += 1
@@ -167,7 +173,11 @@ final class WindowBorderManager {
 
     if let assignment = plan.active {
       if let overlay = overlays[assignment.windowID] {
-        overlay.setFrontmost(activeWindowIsFrontmost)
+        overlay.setStacking(
+          stacking.targetWindowID == assignment.windowID
+            ? stacking
+            : .inactive(for: assignment.windowID)
+        )
         overlay.sync(
           frame: displayedFrames[assignment.windowID] ?? assignment.frame,
           width: plan.style.width,
@@ -180,7 +190,7 @@ final class WindowBorderManager {
 
     for assignment in plan.inactive {
       guard let overlay = overlays[assignment.windowID] else { continue }
-      overlay.setFrontmost(false)
+      overlay.setStacking(.inactive(for: assignment.windowID))
       overlay.sync(
         frame: displayedFrames[assignment.windowID] ?? assignment.frame,
         width: plan.style.width,

--- a/Sources/DefiMacOS/WindowBorderOverlay.swift
+++ b/Sources/DefiMacOS/WindowBorderOverlay.swift
@@ -111,6 +111,10 @@ final class BorderOverlay {
     segments.values.map(\.windowLevelRawValue)
   }
 
+  var upperBoundWindowNumbers: [Int?] {
+    segments.values.map(\.upperBoundWindowNumber)
+  }
+
   init(windowID: WindowID) {
     let targetWindowNumber = Int(windowID.rawValue)
     segments = Dictionary(
@@ -224,9 +228,9 @@ final class BorderOverlay {
     }
   }
 
-  func setFrontmost(_ frontmost: Bool) {
+  func setStacking(_ stacking: WindowBorderStacking) {
     for segment in segments.values {
-      segment.setFrontmost(frontmost)
+      segment.setStacking(stacking)
     }
   }
 
@@ -277,6 +281,7 @@ private final class BorderSegment {
   private(set) var frame: Rect?
   private var backingScale = 1.0
   private var orderedIn = false
+  private(set) var upperBoundWindowNumber: Int?
 
   var windowNumber: Int { panel.windowNumber }
   var windowLevelRawValue: Int { panel.level.rawValue }
@@ -409,16 +414,25 @@ private final class BorderSegment {
   func ensureOrderedIn() {
     guard !orderedIn else { return }
     panel.alphaValue = 0
-    panel.order(.above, relativeTo: targetWindowNumber)
+    orderForCurrentStacking()
     orderedIn = true
   }
 
-  func setFrontmost(_ frontmost: Bool) {
-    let level: NSWindow.Level = frontmost ? .floating : .normal
-    guard panel.level != level else { return }
+  func setStacking(_ stacking: WindowBorderStacking) {
+    let level = resolvedBorderWindowLevel(for: stacking)
+    let upperBoundWindowNumber = stacking.upperBoundWindowID.flatMap {
+      Int(exactly: $0.rawValue)
+    }
+    guard
+      panel.level != level
+        || self.upperBoundWindowNumber != upperBoundWindowNumber
+    else {
+      return
+    }
     panel.level = level
-    if frontmost == false, orderedIn {
-      panel.order(.above, relativeTo: targetWindowNumber)
+    self.upperBoundWindowNumber = upperBoundWindowNumber
+    if orderedIn {
+      orderForCurrentStacking()
     }
   }
 
@@ -427,7 +441,7 @@ private final class BorderSegment {
     panel.setFrame(appKitRect(for: frame), display: false)
     ensureOrderedIn()
     panel.alphaValue = 1
-    panel.order(.above, relativeTo: targetWindowNumber)
+    orderForCurrentStacking()
   }
 
   func compactBacking() {
@@ -448,6 +462,14 @@ private final class BorderSegment {
     frame = nil
     backingScale = 1
     orderedIn = false
+  }
+
+  private func orderForCurrentStacking() {
+    if let upperBoundWindowNumber {
+      panel.order(.below, relativeTo: upperBoundWindowNumber)
+    } else {
+      panel.order(.above, relativeTo: targetWindowNumber)
+    }
   }
 
   private func appKitRect(for frame: Rect) -> CGRect {
@@ -471,4 +493,16 @@ private final class BorderSegment {
       $0.frame.contains(appKitCenter)
     }?.backingScaleFactor ?? 1
   }
+}
+
+private func resolvedBorderWindowLevel(
+  for stacking: WindowBorderStacking
+) -> NSWindow.Level {
+  guard stacking.activeWindowIsFrontmost else { return .normal }
+  return NSWindow.Level(
+    rawValue: min(
+      stacking.upperBoundLevel ?? NSWindow.Level.floating.rawValue,
+      NSWindow.Level.floating.rawValue
+    )
+  )
 }

--- a/Tests/DefiMacOSTests/PlatformEventTests.swift
+++ b/Tests/DefiMacOSTests/PlatformEventTests.swift
@@ -652,7 +652,7 @@ struct PlatformEventTests {
   }
 
   @Test
-  func sameProcessAuxiliaryWindowCannotDemotePictureInPictureBorder() {
+  func untrackedSameProcessAuxiliaryCannotDemotePictureInPictureBorder() {
     let pictureInPicture = WindowID(rawValue: 1)
     let auxiliaryWindow = WindowID(rawValue: 2)
     let focusedWindow = WindowID(rawValue: 3)
@@ -688,6 +688,38 @@ struct PlatformEventTests {
     #expect(result.activeWindowIsFrontmost)
     #expect(result.upperBoundWindowID == pictureInPicture)
     #expect(result.upperBoundLevel == NSWindow.Level.floating.rawValue)
+  }
+
+  @Test
+  func trackedSameProcessDialogStaysAboveSelectedWindowBorder() {
+    let dialog = WindowID(rawValue: 1)
+    let focusedWindow = WindowID(rawValue: 2)
+    let monitor = Rect(x: 0, y: 0, width: 2_560, height: 1_440)
+
+    let result = windowBorderStacking(
+      targetWindowID: focusedWindow,
+      ownProcessID: 99,
+      floatingLevel: NSWindow.Level.floating.rawValue,
+      entries: [
+        WindowStackEntry(
+          windowID: dialog,
+          processID: 8,
+          layer: NSWindow.Level.normal.rawValue,
+          frame: Rect(x: 900, y: 400, width: 640, height: 480)
+        ),
+        WindowStackEntry(
+          windowID: focusedWindow,
+          processID: 8,
+          layer: NSWindow.Level.normal.rawValue,
+          frame: Rect(x: 514, y: 34, width: 2_042, height: 1_354)
+        ),
+      ],
+      monitorFrames: [monitor],
+      knownWindowIDs: [dialog, focusedWindow]
+    )
+
+    #expect(result.activeWindowIsFrontmost == false)
+    #expect(result.upperBoundWindowID == nil)
   }
 
   @Test

--- a/Tests/DefiMacOSTests/PlatformEventTests.swift
+++ b/Tests/DefiMacOSTests/PlatformEventTests.swift
@@ -457,20 +457,28 @@ struct PlatformEventTests {
     let auxiliaryWindow = WindowID(rawValue: 1)
     let focusedWindow = WindowID(rawValue: 2)
 
-    let result = frontmostBorderOccludingWindowID(
-      in: [
-        NormalWindowStackEntry(
+    let result = windowBorderStacking(
+      targetWindowID: focusedWindow,
+      ownProcessID: 99,
+      floatingLevel: NSWindow.Level.floating.rawValue,
+      entries: [
+        WindowStackEntry(
           windowID: auxiliaryWindow,
+          processID: 7,
+          layer: NSWindow.Level.normal.rawValue,
           frame: Rect(x: 8, y: 40, width: 66, height: 20)
         ),
-        NormalWindowStackEntry(
+        WindowStackEntry(
           windowID: focusedWindow,
+          processID: 8,
+          layer: NSWindow.Level.normal.rawValue,
           frame: Rect(x: 2, y: 34, width: 2_044, height: 1_354)
         ),
       ]
     )
 
-    #expect(result == focusedWindow)
+    #expect(result.activeWindowIsFrontmost)
+    #expect(result.upperBoundWindowID == nil)
   }
 
   @Test
@@ -478,19 +486,239 @@ struct PlatformEventTests {
     let dialog = WindowID(rawValue: 1)
     let focusedWindow = WindowID(rawValue: 2)
 
-    let result = frontmostBorderOccludingWindowID(
-      in: [
-        NormalWindowStackEntry(
+    let result = windowBorderStacking(
+      targetWindowID: focusedWindow,
+      ownProcessID: 99,
+      floatingLevel: NSWindow.Level.floating.rawValue,
+      entries: [
+        WindowStackEntry(
           windowID: dialog,
+          processID: 7,
+          layer: NSWindow.Level.normal.rawValue,
           frame: Rect(x: 400, y: 300, width: 640, height: 480)
         ),
-        NormalWindowStackEntry(
+        WindowStackEntry(
           windowID: focusedWindow,
+          processID: 8,
+          layer: NSWindow.Level.normal.rawValue,
           frame: Rect(x: 2, y: 34, width: 2_044, height: 1_354)
         ),
       ]
     )
 
-    #expect(result == dialog)
+    #expect(result.activeWindowIsFrontmost == false)
+    #expect(result.upperBoundWindowID == nil)
+  }
+
+  @Test
+  func floatingPictureInPictureBoundsFrontmostBorder() {
+    let pictureInPicture = WindowID(rawValue: 1)
+    let focusedWindow = WindowID(rawValue: 2)
+
+    let result = windowBorderStacking(
+      targetWindowID: focusedWindow,
+      ownProcessID: 99,
+      floatingLevel: NSWindow.Level.floating.rawValue,
+      entries: [
+        WindowStackEntry(
+          windowID: pictureInPicture,
+          processID: 7,
+          layer: NSWindow.Level.floating.rawValue,
+          frame: Rect(x: 1_400, y: 700, width: 420, height: 390)
+        ),
+        WindowStackEntry(
+          windowID: focusedWindow,
+          processID: 7,
+          layer: NSWindow.Level.normal.rawValue,
+          frame: Rect(x: 2, y: 34, width: 2_044, height: 1_354)
+        ),
+      ]
+    )
+
+    #expect(result.activeWindowIsFrontmost)
+    #expect(result.upperBoundWindowID == pictureInPicture)
+    #expect(result.upperBoundLevel == NSWindow.Level.floating.rawValue)
+  }
+
+  @Test
+  func backmostFloatingOccluderBoundsBorderBelowEveryFloatingWindow() {
+    let frontPictureInPicture = WindowID(rawValue: 1)
+    let backPictureInPicture = WindowID(rawValue: 2)
+    let ownBorderSurface = WindowID(rawValue: 3)
+    let focusedWindow = WindowID(rawValue: 4)
+
+    let result = windowBorderStacking(
+      targetWindowID: focusedWindow,
+      ownProcessID: 99,
+      floatingLevel: NSWindow.Level.floating.rawValue,
+      entries: [
+        WindowStackEntry(
+          windowID: frontPictureInPicture,
+          processID: 7,
+          layer: NSWindow.Level.floating.rawValue,
+          frame: Rect(x: 200, y: 200, width: 400, height: 300)
+        ),
+        WindowStackEntry(
+          windowID: backPictureInPicture,
+          processID: 8,
+          layer: NSWindow.Level.floating.rawValue,
+          frame: Rect(x: 900, y: 600, width: 400, height: 300)
+        ),
+        WindowStackEntry(
+          windowID: ownBorderSurface,
+          processID: 99,
+          layer: NSWindow.Level.floating.rawValue,
+          frame: Rect(x: 2, y: 34, width: 20, height: 1_354)
+        ),
+        WindowStackEntry(
+          windowID: focusedWindow,
+          processID: 7,
+          layer: NSWindow.Level.normal.rawValue,
+          frame: Rect(x: 2, y: 34, width: 2_044, height: 1_354)
+        ),
+      ]
+    )
+
+    #expect(result.activeWindowIsFrontmost)
+    #expect(result.upperBoundWindowID == backPictureInPicture)
+  }
+
+  @Test
+  func higherLevelWindowNeedsNoExplicitFloatingUpperBound() {
+    let systemWindow = WindowID(rawValue: 1)
+    let focusedWindow = WindowID(rawValue: 2)
+
+    let result = windowBorderStacking(
+      targetWindowID: focusedWindow,
+      ownProcessID: 99,
+      floatingLevel: NSWindow.Level.floating.rawValue,
+      entries: [
+        WindowStackEntry(
+          windowID: systemWindow,
+          processID: 7,
+          layer: NSWindow.Level.statusBar.rawValue,
+          frame: Rect(x: 0, y: 0, width: 2_560, height: 30)
+        ),
+        WindowStackEntry(
+          windowID: focusedWindow,
+          processID: 8,
+          layer: NSWindow.Level.normal.rawValue,
+          frame: Rect(x: 2, y: 34, width: 2_044, height: 1_354)
+        ),
+      ]
+    )
+
+    #expect(result.activeWindowIsFrontmost)
+    #expect(result.upperBoundWindowID == nil)
+  }
+
+  @Test
+  func offscreenAuxiliaryWindowCannotDemotePictureInPictureBorder() {
+    let pictureInPicture = WindowID(rawValue: 1)
+    let parkedAuxiliaryWindow = WindowID(rawValue: 2)
+    let focusedWindow = WindowID(rawValue: 3)
+    let monitor = Rect(x: 0, y: 0, width: 2_560, height: 1_440)
+
+    let result = windowBorderStacking(
+      targetWindowID: focusedWindow,
+      ownProcessID: 99,
+      floatingLevel: NSWindow.Level.floating.rawValue,
+      entries: [
+        WindowStackEntry(
+          windowID: pictureInPicture,
+          processID: 7,
+          layer: NSWindow.Level.floating.rawValue,
+          frame: Rect(x: 1_819, y: 981, width: 418, height: 390)
+        ),
+        WindowStackEntry(
+          windowID: parkedAuxiliaryWindow,
+          processID: 8,
+          layer: NSWindow.Level.normal.rawValue,
+          frame: Rect(x: 4_283, y: 469, width: 360, height: 287)
+        ),
+        WindowStackEntry(
+          windowID: focusedWindow,
+          processID: 8,
+          layer: NSWindow.Level.normal.rawValue,
+          frame: Rect(x: 514, y: 34, width: 2_042, height: 1_354)
+        ),
+      ],
+      monitorFrames: [monitor]
+    )
+
+    #expect(result.activeWindowIsFrontmost)
+    #expect(result.upperBoundWindowID == pictureInPicture)
+    #expect(result.upperBoundLevel == NSWindow.Level.floating.rawValue)
+  }
+
+  @Test
+  func sameProcessAuxiliaryWindowCannotDemotePictureInPictureBorder() {
+    let pictureInPicture = WindowID(rawValue: 1)
+    let auxiliaryWindow = WindowID(rawValue: 2)
+    let focusedWindow = WindowID(rawValue: 3)
+    let monitor = Rect(x: 0, y: 0, width: 2_560, height: 1_440)
+
+    let result = windowBorderStacking(
+      targetWindowID: focusedWindow,
+      ownProcessID: 99,
+      floatingLevel: NSWindow.Level.floating.rawValue,
+      entries: [
+        WindowStackEntry(
+          windowID: pictureInPicture,
+          processID: 8,
+          layer: NSWindow.Level.floating.rawValue,
+          frame: Rect(x: 357, y: 730, width: 418, height: 390)
+        ),
+        WindowStackEntry(
+          windowID: auxiliaryWindow,
+          processID: 8,
+          layer: NSWindow.Level.normal.rawValue,
+          frame: Rect(x: 2_200, y: 469, width: 360, height: 287)
+        ),
+        WindowStackEntry(
+          windowID: focusedWindow,
+          processID: 8,
+          layer: NSWindow.Level.normal.rawValue,
+          frame: Rect(x: 514, y: 34, width: 2_042, height: 1_354)
+        ),
+      ],
+      monitorFrames: [monitor]
+    )
+
+    #expect(result.activeWindowIsFrontmost)
+    #expect(result.upperBoundWindowID == pictureInPicture)
+    #expect(result.upperBoundLevel == NSWindow.Level.floating.rawValue)
+  }
+
+  @Test
+  func normalWindowOnAnotherMonitorCannotDemoteBorder() {
+    let otherMonitorWindow = WindowID(rawValue: 1)
+    let focusedWindow = WindowID(rawValue: 2)
+    let firstMonitor = Rect(x: 0, y: 0, width: 2_560, height: 1_440)
+    let secondMonitor = Rect(x: 2_560, y: 0, width: 1_920, height: 1_080)
+
+    let result = windowBorderStacking(
+      targetWindowID: focusedWindow,
+      ownProcessID: 99,
+      floatingLevel: NSWindow.Level.floating.rawValue,
+      entries: [
+        WindowStackEntry(
+          windowID: otherMonitorWindow,
+          processID: 7,
+          layer: NSWindow.Level.normal.rawValue,
+          frame: Rect(x: 2_600, y: 40, width: 1_800, height: 1_000)
+        ),
+        WindowStackEntry(
+          windowID: focusedWindow,
+          processID: 8,
+          layer: NSWindow.Level.normal.rawValue,
+          frame: Rect(x: 514, y: 34, width: 2_042, height: 1_354)
+        ),
+      ],
+      monitorFrames: [firstMonitor, secondMonitor]
+    )
+
+    #expect(result.activeWindowIsFrontmost)
+    #expect(result.upperBoundWindowID == nil)
   }
 }

--- a/Tests/DefiMacOSTests/WindowBorderTests.swift
+++ b/Tests/DefiMacOSTests/WindowBorderTests.swift
@@ -297,7 +297,7 @@ struct WindowBorderTests {
     manager.sync(
       firstPlan,
       displayedFrames: [first: frame],
-      activeWindowIsFrontmost: true
+      stacking: frontmostStacking(for: first)
     )
     #expect(manager.performance.allocated == 1)
 
@@ -341,7 +341,7 @@ struct WindowBorderTests {
     manager.sync(
       plan,
       displayedFrames: frames,
-      activeWindowIsFrontmost: true
+      stacking: frontmostStacking(for: windowIDs[0])
     )
 
     #expect(manager.performance.allocated == 3)
@@ -350,24 +350,66 @@ struct WindowBorderTests {
 
   @Test @MainActor
   func borderPanelsFloatOnlyWhileActiveWindowIsFrontmost() {
-    let overlay = BorderOverlay(windowID: WindowID(rawValue: 1))
+    let target = WindowID(rawValue: 1)
+    let pictureInPicture = WindowID(rawValue: 2)
+    let overlay = BorderOverlay(windowID: target)
 
     #expect(
       overlay.windowLevelRawValues.allSatisfy {
         $0 == NSWindow.Level.normal.rawValue
       }
     )
-    overlay.setFrontmost(true)
+    overlay.setStacking(frontmostStacking(for: target))
     #expect(
       overlay.windowLevelRawValues.allSatisfy {
         $0 == NSWindow.Level.floating.rawValue
       }
     )
-    overlay.setFrontmost(false)
+    overlay.setStacking(.inactive(for: target))
     #expect(
       overlay.windowLevelRawValues.allSatisfy {
         $0 == NSWindow.Level.normal.rawValue
       }
+    )
+
+    overlay.setStacking(
+      WindowBorderStacking(
+        targetWindowID: target,
+        activeWindowIsFrontmost: true,
+        upperBoundWindowID: pictureInPicture,
+        upperBoundLevel: NSWindow.Level.floating.rawValue
+      )
+    )
+    #expect(
+      overlay.windowLevelRawValues.allSatisfy {
+        $0 == NSWindow.Level.floating.rawValue
+      }
+    )
+    #expect(
+      overlay.upperBoundWindowNumbers.allSatisfy {
+        $0 == Int(pictureInPicture.rawValue)
+      }
+    )
+
+    overlay.setStacking(frontmostStacking(for: target))
+    #expect(
+      overlay.windowLevelRawValues.allSatisfy {
+        $0 == NSWindow.Level.floating.rawValue
+      }
+    )
+    #expect(
+      overlay.upperBoundWindowNumbers.allSatisfy { $0 == nil }
+    )
+  }
+
+  private func frontmostStacking(
+    for windowID: WindowID
+  ) -> WindowBorderStacking {
+    WindowBorderStacking(
+      targetWindowID: windowID,
+      activeWindowIsFrontmost: true,
+      upperBoundWindowID: nil,
+      upperBoundLevel: nil
     )
   }
 }


### PR DESCRIPTION
## Why

- Active borders could render above picture-in-picture windows.
- Same-process auxiliary windows created during clicks could demote the border and cause flickering.

## Changes

- Derive monitor-local stacking from WindowServer.
- Keep the active border above its target but below floating occluders.
- Ignore Defi-owned surfaces and same-process auxiliary windows.
- Preserve cross-process dialogs and per-monitor isolation.
- Add regression coverage for PiP, clicks, multiple monitors, and stale stacking.

## How to test

- `swift build`
- `swift test`
- `./script/build_and_run.sh --verify`
- `./script/test_desktop.sh`
- Enable captured decorations, place a PiP over the focused window, then click repeatedly inside the focused window.