### PR TITLE
Fix focus jumps caused by transient AX window omissions

### DIFF
--- a/Sources/DefiMacOS/MacOSPlatform+FrameApplication.swift
+++ b/Sources/DefiMacOS/MacOSPlatform+FrameApplication.swift
@@ -369,12 +369,10 @@ extension MacOSPlatform {
   }
 
   public func hasPendingFrameTransition(_ windowID: WindowID) -> Bool {
-    guard let target = targetFrames[windowID],
-      let observed = latestObservedFrames[windowID]
-    else {
-      return false
-    }
-    return !approximatelyEqual(observed, target)
+    frameTransitionIsPending(
+      target: targetFrames[windowID],
+      observed: latestObservedFrames[windowID]
+    )
   }
 
   public func acceptObservedFrame(_ frame: Rect, for windowID: WindowID) {
@@ -534,4 +532,10 @@ extension MacOSPlatform {
     )
   }
 
+}
+
+func frameTransitionIsPending(target: Rect?, observed: Rect?) -> Bool {
+  guard let target else { return false }
+  guard let observed else { return true }
+  return !approximatelyEqual(observed, target)
 }

--- a/Sources/DefiMacOS/MacOSPlatform+Snapshot.swift
+++ b/Sources/DefiMacOS/MacOSPlatform+Snapshot.swift
@@ -56,7 +56,7 @@ extension MacOSPlatform {
     var nextApplications: [pid_t: AXUIElement] = [:]
     var applicationWindows: [pid_t: [AXUIElement]] = [:]
     var windows: [Window] = []
-    var retainedWindowIDs = Set<WindowID>()
+    var nextRetainedWindowIDs = Set<WindowID>()
 
     for application in NSWorkspace.shared.runningApplications
     where application.processIdentifier != ProcessInfo.processInfo.processIdentifier
@@ -91,6 +91,12 @@ extension MacOSPlatform {
           applicationWindows[application.processIdentifier] =
             cachedApplicationWindows
           windows.append(contentsOf: cachedWindows)
+          nextRetainedWindowIDs.formUnion(
+            retainedWindowIDsForCachedWindows(
+              cachedWindows,
+              previousRetainedWindowIDs: retainedWindowIDs
+            )
+          )
           for (windowID, element) in cachedElements {
             nextElements[windowID] = element
             nextProcessIDs[windowID] = application.processIdentifier
@@ -188,7 +194,7 @@ extension MacOSPlatform {
         cgWindows: cgWindows,
         cachedMinimizedState: cachedMinimizedState
       )
-      retainedWindowIDs.formUnion(processRetainedWindowIDs)
+      nextRetainedWindowIDs.formUnion(processRetainedWindowIDs)
       if !processRetainedWindowIDs.isEmpty {
         let retainedIDs = processRetainedWindowIDs.sorted {
           $0.rawValue < $1.rawValue
@@ -216,7 +222,7 @@ extension MacOSPlatform {
     let nextWindowIDs = Set(nextElements.keys)
     let freshObservationIDs = freshWindowObservationIDs(
       windows: windows,
-      retainedWindowIDs: retainedWindowIDs
+      retainedWindowIDs: nextRetainedWindowIDs
     )
     let removedWindowIDs = Set(previousElements.keys).subtracting(nextWindowIDs)
     newlyDiscoveredWindowIDs =
@@ -242,6 +248,7 @@ extension MacOSPlatform {
     applicationWindowCounts = applicationWindows.mapValues(\.count)
     lastSnapshotWindows = windows
     lastApplicationWindowElements = applicationWindows
+    retainedWindowIDs = nextRetainedWindowIDs
     enhancedUIByProcess = enhancedUIByProcess.filter { nextApplications[$0.key] != nil }
     eventMonitor?.refresh(applications: applicationWindows)
     targetFrames = targetFrames.filter { nextElements[$0.key] != nil }
@@ -447,4 +454,11 @@ func freshWindowObservationIDs(
   retainedWindowIDs: Set<WindowID>
 ) -> Set<WindowID> {
   Set(windows.lazy.map(\.id)).subtracting(retainedWindowIDs)
+}
+
+func retainedWindowIDsForCachedWindows(
+  _ windows: [Window],
+  previousRetainedWindowIDs: Set<WindowID>
+) -> Set<WindowID> {
+  previousRetainedWindowIDs.intersection(windows.lazy.map(\.id))
 }

--- a/Sources/DefiMacOS/MacOSPlatform+Snapshot.swift
+++ b/Sources/DefiMacOS/MacOSPlatform+Snapshot.swift
@@ -97,31 +97,47 @@ extension MacOSPlatform {
           continue
         }
       }
-      guard let appWindows = copyElements(appElement, attribute: kAXWindowsAttribute)
-      else {
-        continue
+      let appWindows = copyElements(appElement, attribute: kAXWindowsAttribute)
+      if let appWindows {
+        applicationWindows[application.processIdentifier] = appWindows
+      } else if let cachedApplicationWindows =
+        lastApplicationWindowElements[application.processIdentifier]
+      {
+        applicationWindows[application.processIdentifier] = cachedApplicationWindows
       }
-      applicationWindows[application.processIdentifier] = appWindows
       var usedCGWindowIDs = Set<CGWindowID>()
+      var ignoredPreviousWindowIDs = Set<WindowID>()
 
-      for element in appWindows {
+      for element in appWindows ?? [] {
         let previousWindowID = previousElements.first { windowID, previousElement in
           previousProcessIDs[windowID] == application.processIdentifier
             && CFEqual(previousElement, element)
         }?.key
-        guard
-          let (candidate, cgWindowID, decision) = makeWindow(
-            element: element,
-            processID: application.processIdentifier,
-            appID: appID,
-            config: config,
-            cgWindows: cgWindows,
-            monitors: monitors,
-            preferredWindowID: previousWindowID,
-            excluding: usedCGWindowIDs
-          )
-        else {
+        let discovery = makeWindow(
+          element: element,
+          processID: application.processIdentifier,
+          appID: appID,
+          config: config,
+          cgWindows: cgWindows,
+          monitors: monitors,
+          preferredWindowID: previousWindowID,
+          excluding: usedCGWindowIDs
+        )
+        let candidate: Window
+        let cgWindowID: CGWindowID
+        let decision: RuleDecision
+        switch discovery {
+        case .unavailable:
           continue
+        case .ignored:
+          if let previousWindowID {
+            ignoredPreviousWindowIDs.insert(previousWindowID)
+          }
+          continue
+        case .discovered(let discovered, let discoveredCGWindowID, let ruleDecision):
+          candidate = discovered
+          cgWindowID = discoveredCGWindowID
+          decision = ruleDecision
         }
         let previousDisposition = previousWindowID.map {
           floatingWindowIDs.contains($0) ? WindowDisposition.floating : .tiled
@@ -148,6 +164,36 @@ extension MacOSPlatform {
         windows.append(tracked)
         nextElements[tracked.id] = element
         nextProcessIDs[tracked.id] = application.processIdentifier
+      }
+
+      let previousWindows = previousWindowsByProcess[application.processIdentifier] ?? []
+      let retainedWindowIDs = cachedWindowIDsToRetain(
+        processID: application.processIdentifier,
+        previousWindows: previousWindows,
+        discoveredWindowIDs: Set(nextElements.keys),
+        ignoredWindowIDs: ignoredPreviousWindowIDs,
+        cgWindows: cgWindows
+      )
+      if !retainedWindowIDs.isEmpty {
+        let retainedIDs = retainedWindowIDs.sorted {
+          $0.rawValue < $1.rawValue
+        }.map { String($0.rawValue) }.joined(separator: ",")
+        frameCoordinator.recordTrace(
+          "window-cache-retained pid=\(application.processIdentifier) windows=[\(retainedIDs)]"
+        )
+      }
+      for previousWindow in previousWindows where retainedWindowIDs.contains(previousWindow.id) {
+        guard let previousElement = previousElements[previousWindow.id] else {
+          continue
+        }
+        windows.append(previousWindow)
+        nextElements[previousWindow.id] = previousElement
+        nextProcessIDs[previousWindow.id] = application.processIdentifier
+        if applicationWindows[application.processIdentifier]?.contains(where: {
+          CFEqual($0, previousElement)
+        }) != true {
+          applicationWindows[application.processIdentifier, default: []].append(previousElement)
+        }
       }
     }
 

--- a/Sources/DefiMacOS/MacOSPlatform+Snapshot.swift
+++ b/Sources/DefiMacOS/MacOSPlatform+Snapshot.swift
@@ -171,16 +171,22 @@ extension MacOSPlatform {
       }
 
       let previousWindows = previousWindowsByProcess[application.processIdentifier] ?? []
+      let cachedMinimizedState: ((WindowID) -> Bool?)?
+      if appWindows == nil {
+        cachedMinimizedState = nil
+      } else {
+        cachedMinimizedState = { windowID in
+          guard let element = previousElements[windowID] else { return nil }
+          return self.value(element, attribute: kAXMinimizedAttribute, as: Bool.self)
+        }
+      }
       let processRetainedWindowIDs = cachedWindowIDsToRetain(
         processID: application.processIdentifier,
         previousWindows: previousWindows,
         discoveredWindowIDs: Set(nextElements.keys),
         ignoredWindowIDs: ignoredPreviousWindowIDs,
         cgWindows: cgWindows,
-        cachedMinimizedState: { windowID in
-          guard let element = previousElements[windowID] else { return nil }
-          return value(element, attribute: kAXMinimizedAttribute, as: Bool.self)
-        }
+        cachedMinimizedState: cachedMinimizedState
       )
       retainedWindowIDs.formUnion(processRetainedWindowIDs)
       if !processRetainedWindowIDs.isEmpty {

--- a/Sources/DefiMacOS/MacOSPlatform+Snapshot.swift
+++ b/Sources/DefiMacOS/MacOSPlatform+Snapshot.swift
@@ -56,6 +56,7 @@ extension MacOSPlatform {
     var nextApplications: [pid_t: AXUIElement] = [:]
     var applicationWindows: [pid_t: [AXUIElement]] = [:]
     var windows: [Window] = []
+    var retainedWindowIDs = Set<WindowID>()
 
     for application in NSWorkspace.shared.runningApplications
     where application.processIdentifier != ProcessInfo.processInfo.processIdentifier
@@ -150,6 +151,9 @@ extension MacOSPlatform {
           previousDisposition: previousDisposition
         )
         guard disposition != .ignored else {
+          if let previousWindowID {
+            ignoredPreviousWindowIDs.insert(previousWindowID)
+          }
           continue
         }
         guard usedCGWindowIDs.insert(cgWindowID).inserted else {
@@ -167,22 +171,28 @@ extension MacOSPlatform {
       }
 
       let previousWindows = previousWindowsByProcess[application.processIdentifier] ?? []
-      let retainedWindowIDs = cachedWindowIDsToRetain(
+      let processRetainedWindowIDs = cachedWindowIDsToRetain(
         processID: application.processIdentifier,
         previousWindows: previousWindows,
         discoveredWindowIDs: Set(nextElements.keys),
         ignoredWindowIDs: ignoredPreviousWindowIDs,
-        cgWindows: cgWindows
+        cgWindows: cgWindows,
+        cachedMinimizedState: { windowID in
+          guard let element = previousElements[windowID] else { return nil }
+          return value(element, attribute: kAXMinimizedAttribute, as: Bool.self)
+        }
       )
-      if !retainedWindowIDs.isEmpty {
-        let retainedIDs = retainedWindowIDs.sorted {
+      retainedWindowIDs.formUnion(processRetainedWindowIDs)
+      if !processRetainedWindowIDs.isEmpty {
+        let retainedIDs = processRetainedWindowIDs.sorted {
           $0.rawValue < $1.rawValue
         }.map { String($0.rawValue) }.joined(separator: ",")
         frameCoordinator.recordTrace(
           "window-cache-retained pid=\(application.processIdentifier) windows=[\(retainedIDs)]"
         )
       }
-      for previousWindow in previousWindows where retainedWindowIDs.contains(previousWindow.id) {
+      for previousWindow in previousWindows
+      where processRetainedWindowIDs.contains(previousWindow.id) {
         guard let previousElement = previousElements[previousWindow.id] else {
           continue
         }
@@ -198,6 +208,10 @@ extension MacOSPlatform {
     }
 
     let nextWindowIDs = Set(nextElements.keys)
+    let freshObservationIDs = freshWindowObservationIDs(
+      windows: windows,
+      retainedWindowIDs: retainedWindowIDs
+    )
     let removedWindowIDs = Set(previousElements.keys).subtracting(nextWindowIDs)
     newlyDiscoveredWindowIDs =
       hasCompletedWindowSnapshot
@@ -226,7 +240,9 @@ extension MacOSPlatform {
     eventMonitor?.refresh(applications: applicationWindows)
     targetFrames = targetFrames.filter { nextElements[$0.key] != nil }
     pendingFrameCorrections = pendingFrameCorrections.filter { nextElements[$0.key] != nil }
-    latestObservedFrames = latestObservedFrames.filter { nextElements[$0.key] != nil }
+    latestObservedFrames = latestObservedFrames.filter {
+      freshObservationIDs.contains($0.key)
+    }
     frameCommitExpectations = frameCommitExpectations.filter {
       nextElements[$0.key] != nil
     }
@@ -247,7 +263,7 @@ extension MacOSPlatform {
     var targetMismatches: [FrameMismatch] = []
     var deferredMismatchCount = 0
     var settledCommitLatenciesMS: [Double] = []
-    for window in windows {
+    for window in windows where freshObservationIDs.contains(window.id) {
       latestObservedFrames[window.id] = window.frame
       if var expectation = frameCommitExpectations[window.id],
         let target = targetFrames[window.id]
@@ -418,4 +434,11 @@ extension MacOSPlatform {
     )
   }
 
+}
+
+func freshWindowObservationIDs(
+  windows: [Window],
+  retainedWindowIDs: Set<WindowID>
+) -> Set<WindowID> {
+  Set(windows.lazy.map(\.id)).subtracting(retainedWindowIDs)
 }

--- a/Sources/DefiMacOS/MacOSPlatform+WindowDiscovery.swift
+++ b/Sources/DefiMacOS/MacOSPlatform+WindowDiscovery.swift
@@ -304,17 +304,19 @@ func cachedWindowIDsToRetain(
   previousWindows: [Window],
   discoveredWindowIDs: Set<WindowID>,
   ignoredWindowIDs: Set<WindowID>,
-  cgWindows: [CGWindowRecord]
+  cgWindows: [CGWindowRecord],
+  cachedMinimizedState: (WindowID) -> Bool?
 ) -> Set<WindowID> {
   let liveWindowIDs = Set(
     cgWindows.lazy
       .filter { $0.processID == processID }
       .map { WindowID(rawValue: UInt64($0.id)) }
   )
-  return Set(previousWindows.map(\.id))
+  let retainedWindowIDs = Set(previousWindows.map(\.id))
     .intersection(liveWindowIDs)
     .subtracting(discoveredWindowIDs)
     .subtracting(ignoredWindowIDs)
+  return Set(retainedWindowIDs.filter { cachedMinimizedState($0) != true })
 }
 
 func consistentFocusedProcessID(

--- a/Sources/DefiMacOS/MacOSPlatform+WindowDiscovery.swift
+++ b/Sources/DefiMacOS/MacOSPlatform+WindowDiscovery.swift
@@ -6,6 +6,18 @@ import DefiCore
 import DefiModel
 import OSLog
 
+enum WindowGeometryDiscovery: Equatable {
+  case unavailable
+  case ignored
+  case usable(Rect)
+}
+
+enum WindowDiscoveryResult {
+  case unavailable
+  case ignored
+  case discovered(Window, CGWindowID, RuleDecision)
+}
+
 @MainActor
 extension MacOSPlatform {
 
@@ -49,13 +61,19 @@ extension MacOSPlatform {
     monitors: [MonitorSnapshot],
     preferredWindowID: WindowID?,
     excluding usedCGWindowIDs: Set<CGWindowID>
-  ) -> (Window, CGWindowID, RuleDecision)? {
-    guard value(element, attribute: kAXMinimizedAttribute, as: Bool.self) != true,
-      let frame = frame(of: element),
-      frame.width >= 80,
-      frame.height >= 60
-    else {
-      return nil
+  ) -> WindowDiscoveryResult {
+    let geometry = windowGeometryDiscovery(
+      minimized: value(element, attribute: kAXMinimizedAttribute, as: Bool.self),
+      frame: frame(of: element)
+    )
+    let frame: Rect
+    switch geometry {
+    case .unavailable:
+      return .unavailable
+    case .ignored:
+      return .ignored
+    case .usable(let usableFrame):
+      frame = usableFrame
     }
     let title = value(element, attribute: kAXTitleAttribute, as: String.self) ?? ""
     let role = value(element, attribute: kAXRoleAttribute, as: String.self)
@@ -88,10 +106,10 @@ extension MacOSPlatform {
         preferredWindowID: preferredWindowID
       )
     else {
-      return nil
+      return .ignored
     }
     let monitorID = monitor(containing: frame, monitors: monitors)?.id
-    return (
+    return .discovered(
       Window(
         id: WindowID(rawValue: UInt64(resolvedWindowID)),
         appID: appID,
@@ -263,6 +281,40 @@ extension MacOSPlatform {
   func copyElements(_ element: AXUIElement, attribute: String) -> [AXUIElement]? {
     copyAttribute(element, name: attribute) as? [AXUIElement]
   }
+}
+
+func windowGeometryDiscovery(
+  minimized: Bool?,
+  frame: Rect?
+) -> WindowGeometryDiscovery {
+  if minimized == true {
+    return .ignored
+  }
+  guard let frame else {
+    return .unavailable
+  }
+  guard frame.width >= 80, frame.height >= 60 else {
+    return .ignored
+  }
+  return .usable(frame)
+}
+
+func cachedWindowIDsToRetain(
+  processID: pid_t,
+  previousWindows: [Window],
+  discoveredWindowIDs: Set<WindowID>,
+  ignoredWindowIDs: Set<WindowID>,
+  cgWindows: [CGWindowRecord]
+) -> Set<WindowID> {
+  let liveWindowIDs = Set(
+    cgWindows.lazy
+      .filter { $0.processID == processID }
+      .map { WindowID(rawValue: UInt64($0.id)) }
+  )
+  return Set(previousWindows.map(\.id))
+    .intersection(liveWindowIDs)
+    .subtracting(discoveredWindowIDs)
+    .subtracting(ignoredWindowIDs)
 }
 
 func consistentFocusedProcessID(

--- a/Sources/DefiMacOS/MacOSPlatform+WindowDiscovery.swift
+++ b/Sources/DefiMacOS/MacOSPlatform+WindowDiscovery.swift
@@ -64,7 +64,7 @@ extension MacOSPlatform {
   ) -> WindowDiscoveryResult {
     let geometry = windowGeometryDiscovery(
       minimized: value(element, attribute: kAXMinimizedAttribute, as: Bool.self),
-      frame: frame(of: element)
+      frame: { self.frame(of: element) }
     )
     let frame: Rect
     switch geometry {
@@ -285,12 +285,12 @@ extension MacOSPlatform {
 
 func windowGeometryDiscovery(
   minimized: Bool?,
-  frame: Rect?
+  frame: () -> Rect?
 ) -> WindowGeometryDiscovery {
   if minimized == true {
     return .ignored
   }
-  guard let frame else {
+  guard let frame = frame() else {
     return .unavailable
   }
   guard frame.width >= 80, frame.height >= 60 else {
@@ -305,7 +305,7 @@ func cachedWindowIDsToRetain(
   discoveredWindowIDs: Set<WindowID>,
   ignoredWindowIDs: Set<WindowID>,
   cgWindows: [CGWindowRecord],
-  cachedMinimizedState: (WindowID) -> Bool?
+  cachedMinimizedState: ((WindowID) -> Bool?)?
 ) -> Set<WindowID> {
   let liveWindowIDs = Set(
     cgWindows.lazy
@@ -316,6 +316,7 @@ func cachedWindowIDsToRetain(
     .intersection(liveWindowIDs)
     .subtracting(discoveredWindowIDs)
     .subtracting(ignoredWindowIDs)
+  guard let cachedMinimizedState else { return retainedWindowIDs }
   return Set(retainedWindowIDs.filter { cachedMinimizedState($0) != true })
 }
 

--- a/Sources/DefiMacOS/MacOSPlatform.swift
+++ b/Sources/DefiMacOS/MacOSPlatform.swift
@@ -33,6 +33,7 @@ public final class MacOSPlatform {
   var pendingFrameRequiresFullSnapshot = false
   var lastSnapshotWindows: [Window] = []
   var lastApplicationWindowElements: [pid_t: [AXUIElement]] = [:]
+  var retainedWindowIDs = Set<WindowID>()
   var deferredFrameCommitMismatchCount = 0
   var observedFrameCommitCount = 0
   var maximumObservedFrameCommitLatencyMS = 0.0

--- a/Tests/DefiMacOSTests/FrameCommitTransitionTests.swift
+++ b/Tests/DefiMacOSTests/FrameCommitTransitionTests.swift
@@ -50,4 +50,15 @@ struct FrameCommitTransitionTests {
       ) == false
     )
   }
+
+  @Test
+  func targetWithoutFreshObservationRemainsPending() {
+    #expect(frameTransitionIsPending(target: expectation.target, observed: nil))
+    #expect(
+      frameTransitionIsPending(
+        target: expectation.target,
+        observed: expectation.target
+      ) == false
+    )
+  }
 }

--- a/Tests/DefiMacOSTests/WindowSnapshotStabilityTests.swift
+++ b/Tests/DefiMacOSTests/WindowSnapshotStabilityTests.swift
@@ -1,0 +1,102 @@
+import ApplicationServices
+import DefiModel
+import Testing
+
+@testable import DefiMacOS
+
+struct WindowSnapshotStabilityTests {
+  private let processID: pid_t = 42
+  private let frame = Rect(x: 4, y: 34, width: 1_200, height: 800)
+
+  @Test func transientGeometryFailureRemainsUnavailable() {
+    #expect(
+      windowGeometryDiscovery(minimized: false, frame: nil) == .unavailable
+    )
+  }
+
+  @Test func minimizedAndAuxiliarySizedWindowsRemainIgnored() {
+    #expect(
+      windowGeometryDiscovery(minimized: true, frame: frame) == .ignored
+    )
+    #expect(
+      windowGeometryDiscovery(
+        minimized: false,
+        frame: Rect(x: 0, y: 0, width: 79, height: 60)
+      ) == .ignored
+    )
+  }
+
+  @Test func usableWindowGeometryRemainsDiscoverable() {
+    #expect(
+      windowGeometryDiscovery(minimized: false, frame: frame) == .usable(frame)
+    )
+  }
+
+  @Test func existingCGWindowSurvivesTransientAccessibilityOmission() {
+    let window = makeWindow(id: 42)
+
+    #expect(
+      cachedWindowIDsToRetain(
+        processID: processID,
+        previousWindows: [window],
+        discoveredWindowIDs: [],
+        ignoredWindowIDs: [],
+        cgWindows: [makeCGWindow(id: 42)]
+      ) == [window.id]
+    )
+  }
+
+  @Test func rediscoveredIgnoredAndClosedWindowsDoNotUseCache() {
+    let window = makeWindow(id: 42)
+    let cgWindows = [makeCGWindow(id: 42)]
+
+    #expect(
+      cachedWindowIDsToRetain(
+        processID: processID,
+        previousWindows: [window],
+        discoveredWindowIDs: [window.id],
+        ignoredWindowIDs: [],
+        cgWindows: cgWindows
+      ).isEmpty
+    )
+    #expect(
+      cachedWindowIDsToRetain(
+        processID: processID,
+        previousWindows: [window],
+        discoveredWindowIDs: [],
+        ignoredWindowIDs: [window.id],
+        cgWindows: cgWindows
+      ).isEmpty
+    )
+    #expect(
+      cachedWindowIDsToRetain(
+        processID: processID,
+        previousWindows: [window],
+        discoveredWindowIDs: [],
+        ignoredWindowIDs: [],
+        cgWindows: []
+      ).isEmpty
+    )
+  }
+
+  private func makeWindow(id: UInt64) -> Window {
+    Window(
+      id: WindowID(rawValue: id),
+      appID: "com.example.app",
+      title: "Window",
+      frame: frame,
+      processID: processID,
+      monitorID: MonitorID(rawValue: 1)
+    )
+  }
+
+  private func makeCGWindow(id: CGWindowID) -> CGWindowRecord {
+    CGWindowRecord(
+      id: id,
+      processID: processID,
+      layer: 0,
+      title: "Window",
+      frame: frame
+    )
+  }
+}

--- a/Tests/DefiMacOSTests/WindowSnapshotStabilityTests.swift
+++ b/Tests/DefiMacOSTests/WindowSnapshotStabilityTests.swift
@@ -10,25 +10,37 @@ struct WindowSnapshotStabilityTests {
 
   @Test func transientGeometryFailureRemainsUnavailable() {
     #expect(
-      windowGeometryDiscovery(minimized: false, frame: nil) == .unavailable
+      windowGeometryDiscovery(minimized: false, frame: { nil }) == .unavailable
     )
   }
 
   @Test func minimizedAndAuxiliarySizedWindowsRemainIgnored() {
     #expect(
-      windowGeometryDiscovery(minimized: true, frame: frame) == .ignored
+      windowGeometryDiscovery(minimized: true, frame: { frame }) == .ignored
     )
     #expect(
       windowGeometryDiscovery(
         minimized: false,
-        frame: Rect(x: 0, y: 0, width: 79, height: 60)
+        frame: { Rect(x: 0, y: 0, width: 79, height: 60) }
       ) == .ignored
     )
   }
 
+  @Test func minimizedWindowDoesNotReadGeometry() {
+    var geometryReadCount = 0
+
+    let discovery = windowGeometryDiscovery(minimized: true) {
+      geometryReadCount += 1
+      return frame
+    }
+
+    #expect(discovery == .ignored)
+    #expect(geometryReadCount == 0)
+  }
+
   @Test func usableWindowGeometryRemainsDiscoverable() {
     #expect(
-      windowGeometryDiscovery(minimized: false, frame: frame) == .usable(frame)
+      windowGeometryDiscovery(minimized: false, frame: { frame }) == .usable(frame)
     )
   }
 
@@ -71,6 +83,21 @@ struct WindowSnapshotStabilityTests {
         cgWindows: [makeCGWindow(id: 42)],
         cachedMinimizedState: { _ in true }
       ).isEmpty
+    )
+  }
+
+  @Test func applicationAccessibilityFailureDoesNotProbeCachedWindows() {
+    let window = makeWindow(id: 42)
+
+    #expect(
+      cachedWindowIDsToRetain(
+        processID: processID,
+        previousWindows: [window],
+        discoveredWindowIDs: [],
+        ignoredWindowIDs: [],
+        cgWindows: [makeCGWindow(id: 42)],
+        cachedMinimizedState: nil
+      ) == [window.id]
     )
   }
 

--- a/Tests/DefiMacOSTests/WindowSnapshotStabilityTests.swift
+++ b/Tests/DefiMacOSTests/WindowSnapshotStabilityTests.swift
@@ -41,8 +41,36 @@ struct WindowSnapshotStabilityTests {
         previousWindows: [window],
         discoveredWindowIDs: [],
         ignoredWindowIDs: [],
-        cgWindows: [makeCGWindow(id: 42)]
+        cgWindows: [makeCGWindow(id: 42)],
+        cachedMinimizedState: { _ in nil }
       ) == [window.id]
+    )
+  }
+
+  @Test func retainedWindowDoesNotProvideFreshFrameObservation() {
+    let retainedWindow = makeWindow(id: 42)
+    let observedWindow = makeWindow(id: 43)
+
+    #expect(
+      freshWindowObservationIDs(
+        windows: [retainedWindow, observedWindow],
+        retainedWindowIDs: [retainedWindow.id]
+      ) == [observedWindow.id]
+    )
+  }
+
+  @Test func minimizedCachedWindowDoesNotSurviveAccessibilityOmission() {
+    let window = makeWindow(id: 42)
+
+    #expect(
+      cachedWindowIDsToRetain(
+        processID: processID,
+        previousWindows: [window],
+        discoveredWindowIDs: [],
+        ignoredWindowIDs: [],
+        cgWindows: [makeCGWindow(id: 42)],
+        cachedMinimizedState: { _ in true }
+      ).isEmpty
     )
   }
 
@@ -56,7 +84,8 @@ struct WindowSnapshotStabilityTests {
         previousWindows: [window],
         discoveredWindowIDs: [window.id],
         ignoredWindowIDs: [],
-        cgWindows: cgWindows
+        cgWindows: cgWindows,
+        cachedMinimizedState: { _ in nil }
       ).isEmpty
     )
     #expect(
@@ -65,7 +94,8 @@ struct WindowSnapshotStabilityTests {
         previousWindows: [window],
         discoveredWindowIDs: [],
         ignoredWindowIDs: [window.id],
-        cgWindows: cgWindows
+        cgWindows: cgWindows,
+        cachedMinimizedState: { _ in nil }
       ).isEmpty
     )
     #expect(
@@ -74,7 +104,8 @@ struct WindowSnapshotStabilityTests {
         previousWindows: [window],
         discoveredWindowIDs: [],
         ignoredWindowIDs: [],
-        cgWindows: []
+        cgWindows: [],
+        cachedMinimizedState: { _ in nil }
       ).isEmpty
     )
   }

--- a/Tests/DefiMacOSTests/WindowSnapshotStabilityTests.swift
+++ b/Tests/DefiMacOSTests/WindowSnapshotStabilityTests.swift
@@ -71,6 +71,25 @@ struct WindowSnapshotStabilityTests {
     )
   }
 
+  @Test func incrementalSnapshotCarriesOnlyLiveRetainedWindowStatus() {
+    let retainedWindow = makeWindow(id: 42)
+    let observedWindow = makeWindow(id: 43)
+    let closedRetainedWindowID = WindowID(rawValue: 44)
+
+    let carriedRetainedWindowIDs = retainedWindowIDsForCachedWindows(
+      [retainedWindow, observedWindow],
+      previousRetainedWindowIDs: [retainedWindow.id, closedRetainedWindowID]
+    )
+
+    #expect(carriedRetainedWindowIDs == [retainedWindow.id])
+    #expect(
+      freshWindowObservationIDs(
+        windows: [retainedWindow, observedWindow],
+        retainedWindowIDs: carriedRetainedWindowIDs
+      ) == [observedWindow.id]
+    )
+  }
+
   @Test func minimizedCachedWindowDoesNotSurviveAccessibilityOmission() {
     let window = makeWindow(id: 42)
 


### PR DESCRIPTION
## Why

Transient Accessibility snapshots can temporarily omit an existing window. Defi then removes and rediscovers it, causing `follow_focus` to select its workspace and column unexpectedly.

## Changes

- Distinguish unavailable AX geometry from intentionally ignored windows.
- Preserve cached windows while their CGWindow ID still exists.
- Keep real closures and minimized windows removable.
- Trace cache recovery with `window-cache-retained`.
- Add regression tests for omission, closure, rediscovery, and ignored geometry.

## How to test

- `swift build`
- `swift test`
- `./script/build_and_run.sh --verify`
- Manually keep Xcode running while using Helium and confirm transient Xcode activity no longer changes the visible column.