### PR TITLE
Clarify column maximization naming

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -236,7 +236,7 @@ an entry from `[workspaces].names`.
 | `send-window-to-workspace <name>` | Move focused window without switching workspace. | unset |
 | `cycle-width previous` | Select previous width preset, wrapping. | `<mod>-minus` |
 | `cycle-width next` | Select next width preset, wrapping. | `<mod>-equal` |
-| `toggle-fullscreen` | Toggle focused column between full width and previous width. | `<mod>-f` |
+| `maximize-column` | Toggle focused column between full width and previous width. | `<mod>-f` |
 | `toggle-floating` | Toggle focused window between tiled and floating layers. | `<mod>-backslash` |
 | `activate-floating` | Select floating layer and foreground its selected window. | `<mod>-shift-backslash` |
 | `focus-floating previous` | Focus previous floating window, wrapping. | `<mod>-comma` |
@@ -254,6 +254,26 @@ accepts `left`/`right` and `up`/`down` as previous/next aliases.
 Commands are validated when config loads. Direction compatibility can still be
 validated at execution for commands implemented by the layout engine; use forms
 listed above for deterministic behavior.
+
+### Native macOS fullscreen
+
+`maximize-column` changes only Defi's logical column width. It does not enter
+native macOS fullscreen or create a macOS Space.
+
+Native fullscreen lifecycle support is not implemented yet. Its required policy
+is:
+
+- macOS or the application owns fullscreen entry and exit; Defi passes those
+  actions through and never substitutes `maximize-column`
+- while macOS reports a window in native fullscreen, Defi temporarily unmanages
+  it and performs no layout, parking, frame, or focus writes for that window
+- Defi preserves the window's logical column slot, width, monitor, workspace,
+  and focus selection while it is unmanaged
+- on exit, Defi restores the window to that slot and reconciles once against
+  current monitor topology; normal deterministic monitor fallback applies when
+  the original monitor no longer exists
+- stale fullscreen events cannot restore older layout, visibility, or focus
+  state; latest transition wins
 
 ## `[[rules]]`
 
@@ -369,7 +389,7 @@ default = "1"
 
 "alt-minus" = "cycle-width previous"
 "alt-equal" = "cycle-width next"
-"alt-f" = "toggle-fullscreen"
+"alt-f" = "maximize-column"
 "alt-backslash" = "toggle-floating"
 "alt-shift-backslash" = "activate-floating"
 "alt-comma" = "focus-floating previous"

--- a/README.md
+++ b/README.md
@@ -70,10 +70,14 @@ Default hotkeys:
 - `Option + 1...9`: switch workspace
 - `Option + Shift + 1...9`: move window and follow
 - `Option + -/=`: cycle width
-- `Option + F`: fullscreen column
+- `Option + F`: maximize column
 - `Option + \\`: toggle focused window tiled/floating
 - `Option + Shift + \\`: foreground selected floating window
 - `Option + ,/.`: cycle floating windows
+
+`maximize-column` fills Defi's monitor work area; it is not native macOS
+fullscreen. Native fullscreen lifecycle policy is documented in
+[CONFIGURATION.md](CONFIGURATION.md#native-macos-fullscreen).
 
 ## Config
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,7 +5,7 @@
 - [x] SwiftPM package boundaries
 - [x] Pure model types and command parsing
 - [x] Scrolling-column layout engine
-- [x] Focus, move, stack, width, fullscreen, parking, and frame-diff primitives
+- [x] Focus, move, stack, width, column maximization, parking, and frame-diff primitives
 - [x] Initial deterministic unit tests
 - [x] Reducer and runtime state
 - [x] TOML configuration and application rules

--- a/Sources/DefiConfig/Config.swift
+++ b/Sources/DefiConfig/Config.swift
@@ -171,7 +171,7 @@ public struct Config: Equatable, Sendable {
       "\(modifier)-shift-rightbracket": "move-column last",
       "\(modifier)-minus": "cycle-width previous",
       "\(modifier)-equal": "cycle-width next",
-      "\(modifier)-f": "toggle-fullscreen",
+      "\(modifier)-f": "maximize-column",
       "\(modifier)-backslash": "toggle-floating",
       "\(modifier)-shift-backslash": "activate-floating",
       "\(modifier)-comma": "focus-floating previous",

--- a/Sources/DefiCore/Workspace.swift
+++ b/Sources/DefiCore/Workspace.swift
@@ -177,7 +177,7 @@ public func cycleWidth(
   presets: [Double]
 ) {
   guard !presets.isEmpty else { return }
-  if column.fullscreenPreviousWidth != nil {
+  if column.preMaximizedWidth != nil {
     let boundaryIndex: Int?
     switch direction {
     case .next, .right, .first:
@@ -193,12 +193,12 @@ public func cycleWidth(
     }
     guard let boundaryIndex else { return }
     column.width = .fraction(presets[boundaryIndex])
-    column.fullscreenPreviousWidth = nil
+    column.preMaximizedWidth = nil
     return
   }
   guard case .fraction(let current) = column.width else {
     column.width = .fraction(presets[0])
-    column.fullscreenPreviousWidth = nil
+    column.preMaximizedWidth = nil
     return
   }
 
@@ -219,15 +219,15 @@ public func cycleWidth(
     nextIndex = currentIndex
   }
   column.width = .fraction(presets[nextIndex])
-  column.fullscreenPreviousWidth = nil
+  column.preMaximizedWidth = nil
 }
 
-public func toggleFullscreen(of column: inout Column, defaultWidth: Double) {
+public func maximizeColumn(_ column: inout Column, defaultWidth: Double) {
   if case .fraction(let value) = column.width, abs(value - 1) < .ulpOfOne {
-    column.width = column.fullscreenPreviousWidth ?? .fraction(defaultWidth)
-    column.fullscreenPreviousWidth = nil
+    column.width = column.preMaximizedWidth ?? .fraction(defaultWidth)
+    column.preMaximizedWidth = nil
   } else {
-    column.fullscreenPreviousWidth = column.width
+    column.preMaximizedWidth = column.width
     column.width = .fraction(1)
   }
 }

--- a/Sources/DefiDaemon/DaemonStatusLifecycle.swift
+++ b/Sources/DefiDaemon/DaemonStatusLifecycle.swift
@@ -93,7 +93,7 @@ extension Daemon {
       }
       let column = workspace.columns[workspace.focusedColumn]
       return
-        "\(columnWidthStatus(column.width))/prev:\(column.fullscreenPreviousWidth.map(columnWidthStatus) ?? "none")"
+        "\(columnWidthStatus(column.width))/pre-max:\(column.preMaximizedWidth.map(columnWidthStatus) ?? "none")"
     }()
     let displaySizes = latestMonitors.map {
       "\($0.id.rawValue):\(Int($0.frame.width))x\(Int($0.frame.height))"

--- a/Sources/DefiModel/Model.swift
+++ b/Sources/DefiModel/Model.swift
@@ -98,30 +98,30 @@ public struct Column: Equatable, Codable, Sendable {
   public var windows: [WindowID]
   public var focusedWindow: Int
   public var width: ColumnWidth
-  public var fullscreenPreviousWidth: ColumnWidth?
+  public var preMaximizedWidth: ColumnWidth?
 
   public init(
     window: WindowID,
     width: ColumnWidth,
     focusedWindow: Int = 0,
-    fullscreenPreviousWidth: ColumnWidth? = nil
+    preMaximizedWidth: ColumnWidth? = nil
   ) {
     self.windows = [window]
     self.focusedWindow = focusedWindow
     self.width = width
-    self.fullscreenPreviousWidth = fullscreenPreviousWidth
+    self.preMaximizedWidth = preMaximizedWidth
   }
 
   public init(
     windows: [WindowID],
     focusedWindow: Int,
     width: ColumnWidth,
-    fullscreenPreviousWidth: ColumnWidth? = nil
+    preMaximizedWidth: ColumnWidth? = nil
   ) {
     self.windows = windows
     self.focusedWindow = focusedWindow
     self.width = width
-    self.fullscreenPreviousWidth = fullscreenPreviousWidth
+    self.preMaximizedWidth = preMaximizedWidth
   }
 }
 
@@ -194,7 +194,7 @@ public enum Command: Equatable, Codable, Sendable {
   case sendWindowToWorkspace(WorkspaceID)
   case switchWorkspace(WorkspaceID)
   case cycleWidth(Direction)
-  case toggleFullscreen
+  case maximizeColumn
   case toggleFloating
   case activateFloating
   case joinWindow(Direction)
@@ -203,7 +203,7 @@ public enum Command: Equatable, Codable, Sendable {
 
   public var resizesManagedLayout: Bool {
     switch self {
-    case .cycleWidth, .toggleFullscreen, .joinWindow, .unjoinWindows:
+    case .cycleWidth, .maximizeColumn, .joinWindow, .unjoinWindows:
       true
     default:
       false
@@ -295,8 +295,8 @@ public func parseCommand(_ input: String) throws -> Command {
     return .switchWorkspace(WorkspaceID(rawValue: try argument("workspace")))
   case "cycle-width":
     return .cycleWidth(try parseDirection(argument("direction")))
-  case "toggle-fullscreen":
-    return .toggleFullscreen
+  case "maximize-column":
+    return .maximizeColumn
   case "toggle-floating":
     return .toggleFloating
   case "activate-floating":

--- a/Sources/DefiRuntime/CommandReducer.swift
+++ b/Sources/DefiRuntime/CommandReducer.swift
@@ -85,13 +85,13 @@ public func reduce(
             workspace: state.monitors[monitorIndex].workspaces[index]
           )
       }
-    case .toggleFullscreen:
+    case .maximizeColumn:
       let index = try workspaceIndex(state.monitors[monitorIndex])
       let columnIndex = state.monitors[monitorIndex].workspaces[index].focusedColumn
       if state.monitors[monitorIndex].workspaces[index].columns.indices.contains(columnIndex) {
         state.monitors[monitorIndex].workspaces[index].focusedLayer = .tiled
-        toggleFullscreen(
-          of: &state.monitors[monitorIndex].workspaces[index].columns[columnIndex],
+        maximizeColumn(
+          &state.monitors[monitorIndex].workspaces[index].columns[columnIndex],
           defaultWidth: layout.defaultColumnWidth
         )
         state.monitors[monitorIndex].workspaces[index].targetScrollOffset =

--- a/Sources/DefiRuntime/RuntimeState.swift
+++ b/Sources/DefiRuntime/RuntimeState.swift
@@ -162,12 +162,12 @@ private func scalePixelWidths(in monitor: inout Monitor, by scale: Double) {
       if var previous =
         monitor.workspaces[workspaceIndex]
         .columns[columnIndex]
-        .fullscreenPreviousWidth
+        .preMaximizedWidth
       {
         scalePixelWidth(&previous, by: scale)
         monitor.workspaces[workspaceIndex]
           .columns[columnIndex]
-          .fullscreenPreviousWidth = previous
+          .preMaximizedWidth = previous
       }
     }
   }

--- a/Sources/DefiRuntime/ScrollReconciliation.swift
+++ b/Sources/DefiRuntime/ScrollReconciliation.swift
@@ -71,7 +71,7 @@ public func learnTiledWindowWidth(
         continue
       }
       guard workspace.id == state.monitors[monitorIndex].activeWorkspace,
-        workspace.columns[columnIndex].fullscreenPreviousWidth == nil
+        workspace.columns[columnIndex].preMaximizedWidth == nil
       else {
         return false
       }

--- a/Tests/DefiConfigTests/ConfigTests.swift
+++ b/Tests/DefiConfigTests/ConfigTests.swift
@@ -109,7 +109,7 @@ final class ConfigTests: XCTestCase {
     XCTAssertEqual(config.keys["hyper-1"], "workspace dev")
     XCTAssertEqual(config.keys["hyper-minus"], "cycle-width previous")
     XCTAssertEqual(config.keys["hyper-equal"], "cycle-width next")
-    XCTAssertEqual(config.keys["hyper-f"], "toggle-fullscreen")
+    XCTAssertEqual(config.keys["hyper-f"], "maximize-column")
     XCTAssertEqual(config.keys["hyper-backslash"], "toggle-floating")
     XCTAssertEqual(config.keys["hyper-shift-backslash"], "activate-floating")
     XCTAssertEqual(config.keys["hyper-comma"], "focus-floating previous")

--- a/Tests/DefiCoreTests/WorkspaceTests.swift
+++ b/Tests/DefiCoreTests/WorkspaceTests.swift
@@ -64,48 +64,48 @@ final class WorkspaceTests: XCTestCase {
     XCTAssertEqual(workspace.focusedColumn, 1)
   }
 
-  func testFullscreenRestoresPixelWidth() {
+  func testMaximizedColumnRestoresPixelWidth() {
     var column = Column(window: WindowID(rawValue: 1), width: .pixels(420))
 
-    toggleFullscreen(of: &column, defaultWidth: 0.8)
+    maximizeColumn(&column, defaultWidth: 0.8)
     XCTAssertEqual(column.width, .fraction(1))
-    XCTAssertEqual(column.fullscreenPreviousWidth, .pixels(420))
+    XCTAssertEqual(column.preMaximizedWidth, .pixels(420))
 
-    toggleFullscreen(of: &column, defaultWidth: 0.8)
+    maximizeColumn(&column, defaultWidth: 0.8)
     XCTAssertEqual(column.width, .pixels(420))
-    XCTAssertNil(column.fullscreenPreviousWidth)
+    XCTAssertNil(column.preMaximizedWidth)
   }
 
-  func testCyclingForwardFromFullscreenUsesFirstPreset() {
+  func testCyclingForwardFromMaximizedUsesFirstPreset() {
     var column = Column(window: WindowID(rawValue: 1), width: .fraction(0.5))
     let presets = [1.0, 0.33, 0.5, 0.66, 0.8]
 
-    toggleFullscreen(of: &column, defaultWidth: 0.8)
+    maximizeColumn(&column, defaultWidth: 0.8)
     cycleWidth(of: &column, direction: .next, presets: presets)
 
     XCTAssertEqual(column.width, .fraction(0.33))
-    XCTAssertNil(column.fullscreenPreviousWidth)
+    XCTAssertNil(column.preMaximizedWidth)
   }
 
-  func testCyclingBackwardFromFullscreenUsesLastPreset() {
+  func testCyclingBackwardFromMaximizedUsesLastPreset() {
     var column = Column(window: WindowID(rawValue: 1), width: .fraction(0.5))
     let presets = [0.33, 0.5, 0.66, 0.8, 1.0]
 
-    toggleFullscreen(of: &column, defaultWidth: 0.8)
+    maximizeColumn(&column, defaultWidth: 0.8)
     cycleWidth(of: &column, direction: .previous, presets: presets)
 
     XCTAssertEqual(column.width, .fraction(0.8))
-    XCTAssertNil(column.fullscreenPreviousWidth)
+    XCTAssertNil(column.preMaximizedWidth)
   }
 
-  func testCyclingFromFullscreenWithOnlyFullWidthPresetDoesNothing() {
+  func testCyclingFromMaximizedWithOnlyFullWidthPresetDoesNothing() {
     var column = Column(window: WindowID(rawValue: 1), width: .fraction(0.5))
 
-    toggleFullscreen(of: &column, defaultWidth: 0.8)
+    maximizeColumn(&column, defaultWidth: 0.8)
     cycleWidth(of: &column, direction: .previous, presets: [1.0])
 
     XCTAssertEqual(column.width, .fraction(1))
-    XCTAssertEqual(column.fullscreenPreviousWidth, .fraction(0.5))
+    XCTAssertEqual(column.preMaximizedWidth, .fraction(0.5))
   }
 
 }

--- a/Tests/DefiModelTests/ModelTests.swift
+++ b/Tests/DefiModelTests/ModelTests.swift
@@ -18,7 +18,7 @@ final class ModelTests: XCTestCase {
     XCTAssertFalse(window.forceTiling)
     XCTAssertFalse(window.intrinsicSize)
     XCTAssertEqual(column.focusedWindow, 0)
-    XCTAssertNil(column.fullscreenPreviousWidth)
+    XCTAssertNil(column.preMaximizedWidth)
     XCTAssertEqual(workspace.focusedColumn, 0)
     XCTAssertTrue(workspace.columns.isEmpty)
     XCTAssertTrue(workspace.floatingWindows.isEmpty)
@@ -61,7 +61,7 @@ final class ModelTests: XCTestCase {
       try parseCommand("workspace sim"),
       .switchWorkspace(WorkspaceID(rawValue: "sim"))
     )
-    XCTAssertEqual(try parseCommand("toggle-fullscreen"), .toggleFullscreen)
+    XCTAssertEqual(try parseCommand("maximize-column"), .maximizeColumn)
     XCTAssertEqual(try parseCommand("toggle-floating"), .toggleFloating)
     XCTAssertEqual(try parseCommand("activate-floating"), .activateFloating)
   }
@@ -72,9 +72,18 @@ final class ModelTests: XCTestCase {
     }
   }
 
+  func testRejectsObsoleteFullscreenCommandName() {
+    XCTAssertThrowsError(try parseCommand("toggle-fullscreen")) { error in
+      XCTAssertEqual(
+        error as? CommandParseError,
+        .unknownCommand("toggle-fullscreen")
+      )
+    }
+  }
+
   func testManagedLayoutResizeCommandsAreExplicit() {
     XCTAssertTrue(Command.cycleWidth(.next).resizesManagedLayout)
-    XCTAssertTrue(Command.toggleFullscreen.resizesManagedLayout)
+    XCTAssertTrue(Command.maximizeColumn.resizesManagedLayout)
     XCTAssertTrue(Command.joinWindow(.left).resizesManagedLayout)
     XCTAssertTrue(Command.unjoinWindows.resizesManagedLayout)
     XCTAssertFalse(Command.focusColumn(.right).resizesManagedLayout)

--- a/Tests/DefiRuntimeTests/FloatingWindowTests.swift
+++ b/Tests/DefiRuntimeTests/FloatingWindowTests.swift
@@ -40,7 +40,7 @@ final class FloatingWindowTests: XCTestCase {
       Command.focusColumn(.next),
       .focusWindow(.next),
       .cycleWidth(.next),
-      .toggleFullscreen,
+      .maximizeColumn,
     ] {
       try reduce(command, on: monitorID, state: &state)
       XCTAssertEqual(state.selectedWindowID(on: monitorID), floaters[1].id)

--- a/Tests/DefiRuntimeTests/RuntimeMonitorTests.swift
+++ b/Tests/DefiRuntimeTests/RuntimeMonitorTests.swift
@@ -6,7 +6,7 @@ import XCTest
 final class RuntimeMonitorTests: XCTestCase {
   private let monitorID = MonitorID(rawValue: 1)
 
-  func testDisplayResizeScalesPixelAndFullscreenPreviousWidths() {
+  func testDisplayResizeScalesPixelAndPreMaximizedWidths() {
     let config = Config()
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)
@@ -15,7 +15,7 @@ final class RuntimeMonitorTests: XCTestCase {
         windows: [WindowID(rawValue: 1)],
         focusedWindow: 0,
         width: .fraction(1),
-        fullscreenPreviousWidth: .pixels(800)
+        preMaximizedWidth: .pixels(800)
       ),
       Column(window: WindowID(rawValue: 2), width: .pixels(1_000)),
     ]
@@ -31,7 +31,7 @@ final class RuntimeMonitorTests: XCTestCase {
     )
 
     XCTAssertEqual(
-      state.monitors[0].workspaces[0].columns[0].fullscreenPreviousWidth,
+      state.monitors[0].workspaces[0].columns[0].preMaximizedWidth,
       .pixels(400)
     )
     XCTAssertEqual(

--- a/Tests/DefiRuntimeTests/RuntimeWidthLearningTests.swift
+++ b/Tests/DefiRuntimeTests/RuntimeWidthLearningTests.swift
@@ -61,7 +61,7 @@ final class RuntimeWidthLearningTests: XCTestCase {
     )
   }
 
-  func testFullscreenWidthCannotBeLearnedFromAXDrift() throws {
+  func testMaximizedWidthCannotBeLearnedFromAXDrift() throws {
     let config = Config()
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)
@@ -73,7 +73,7 @@ final class RuntimeWidthLearningTests: XCTestCase {
       monitorID: monitorID
     )
     try discoverWindow(window, decision: RuleDecision(), state: &state)
-    try reduce(.toggleFullscreen, on: monitorID, state: &state)
+    try reduce(.maximizeColumn, on: monitorID, state: &state)
 
     XCTAssertFalse(
       learnTiledWindowWidth(
@@ -88,7 +88,7 @@ final class RuntimeWidthLearningTests: XCTestCase {
       .fraction(1)
     )
     XCTAssertEqual(
-      state.monitors[0].workspaces[0].columns[0].fullscreenPreviousWidth,
+      state.monitors[0].workspaces[0].columns[0].preMaximizedWidth,
       .fraction(0.8)
     )
   }


### PR DESCRIPTION
## Why

The existing `toggle-fullscreen` command only expands a Defi column to the monitor work area. Its name incorrectly suggests native macOS fullscreen and Spaces behavior.

## Changes

- Rename `toggle-fullscreen` to `maximize-column` across commands, defaults, runtime state, status output, and tests.
- Reject the obsolete command name instead of adding a pre-stable compatibility alias.
- Clarify that column maximization does not enter native macOS fullscreen.
- Document the required native fullscreen lifecycle policy: passthrough, temporary unmanagement, deterministic restoration, and latest-wins event handling.

## How to test

- `swift build`
- `swift test`
- `./script/build_and_run.sh --verify`
