### PR TITLE
Clarify product README and installation guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,138 +2,126 @@
 
 [![CI](https://github.com/qeude/Defi/actions/workflows/ci.yml/badge.svg)](https://github.com/qeude/Defi/actions/workflows/ci.yml)
 
-macOS-native scrolling-column window manager inspired by Niri.
+Defi is a native macOS scrolling-column window manager inspired by
+[Niri](https://github.com/YaLTeR/niri). It is built around one simple idea:
+your desktop is a continuous horizontal ribbon, not a grid of disconnected
+layouts.
 
-Status: `0.1.0-alpha`. Experimental software; behavior and configuration may
-change before the first stable release.
+Defi keeps several windows visible as scrolling columns. Keyboard navigation
+moves through the ribbon; virtual workspaces keep separate ribbons per monitor.
+Windows remain native macOS windows, so normal clicks, Dock activation, and
+Command-Tab still work.
 
-Basic MVP includes:
+Defi is also built with a performance-first goal: to do the best possible
+within macOS's constraints.
 
-- multiple visible scrolling columns
-- independent virtual workspaces per monitor
-- Accessibility window discovery, placement, and focus
-- global configurable hotkeys
-- TOML config and application rules
-- Unix-socket CLI
-- `launchd` development service commands
-- native application/focus event synchronization
-- real frame/target reconciliation and mouse-resize width learning
-- title-bar drag reordering for columns and stacked windows
-- topology-aware parking lanes with one-pixel side anchors
-- delayed real-frame verification and automatic parking repair
-- continuous scrolling strip with bounded neighboring-column prefetch
-- 60 Hz pixel-aligned scrolling with coalesced, per-app AX frame batches
-- selectable empty virtual workspaces
-- menu bar workspace and action controls
+> **Status: `0.1.0-alpha`**  
+> Defi is experimental software. Behavior and configuration may change before
+> the first stable release.
 
-No config required. Defaults provide workspaces `1...9` and Option-based bindings.
+## What Defi brings
 
-## Build and run
+- **Scrolling columns** — keep neighboring context visible while moving through
+  a wide desktop.
+- **Per-monitor workspaces** — every display owns its own workspace set,
+  focused window, widths, and scroll position.
+- **Keyboard-first control** — focus, move, stack, resize, maximize, and switch
+  workspaces without reaching for a mouse.
+- **Native focus and frame reconciliation** — Defi follows real macOS focus and
+  window frames instead of assuming every request succeeds immediately.
+- **Floating windows** — mix tiled columns with floating application windows.
+- **Mouse interaction** — focus follows the pointer when enabled; title-bar
+  dragging reorders columns and stacked windows.
+- **Application rules** — route apps to workspaces and choose tiling behavior
+  with a small TOML configuration.
+- **Menu bar and CLI controls** — inspect state, trace behavior, and control
+  Defi from the menu bar or Unix-socket CLI.
+- **Topology-aware workspaces** — inactive windows park outside visible monitor
+  regions and return when their workspace becomes active.
 
-```sh
-./script/build_and_run.sh
-```
+## Install the alpha
 
-Script builds, signs, and installs stable bundle at:
+Download [Defi v0.1.0-alpha](https://github.com/qeude/Defi/releases/tag/v0.1.0-alpha)
+and open `Defi-0.1.0-alpha.dmg`. Drag `Defi.app` to `Applications`, then launch
+it.
+
+The alpha DMG is signed with an Apple Development certificate but is not yet
+notarized. On first launch, macOS may require **Open Anyway** in System Settings
+→ Privacy & Security → Security.
+
+### Required permission
+
+Defi requires macOS **Accessibility** permission to discover, move, resize,
+focus, and park windows:
+
+1. Open System Settings → Privacy & Security → Accessibility.
+2. Enable `Defi`.
+3. Restart Defi if it was already running.
+
+Without this permission, Defi can start but cannot manage application windows.
+
+Defi targets macOS 14 or newer. No configuration file is required: built-in
+defaults provide workspaces `1` through `9` and Option-based shortcuts.
+
+Default keyboard bindings use Option. The complete shortcut and command
+reference lives in [CONFIGURATION.md](CONFIGURATION.md).
+
+## Configuration
+
+Default path:
 
 ```text
-~/Applications/Defi.app
+~/.config/defi/config.toml
 ```
 
-When absent, script installs `defi.example.toml` as `~/.config/defi/config.toml`.
-That daily-use config enables `hyper = Alt + Cmd + Ctrl`, named workspaces, and app rules.
+Defi works without this file. Start from [defi.example.toml](defi.example.toml)
+when you need named workspaces, custom hotkeys, application rules, or layout
+overrides. Full reference lives in [CONFIGURATION.md](CONFIGURATION.md).
 
-macOS requests Accessibility permission. Enable `Defi` under:
-
-`System Settings → Privacy & Security → Accessibility`
-
-Verify daemon:
+Configuration loads when the daemon starts. Restart the service after editing:
 
 ```sh
-./script/build_and_run.sh --verify
+~/Applications/Defi.app/Contents/MacOS/defi service restart
 ```
 
 ## CLI
+
+The installed CLI lives at `~/Applications/Defi.app/Contents/MacOS/defi`.
+Examples:
 
 ```sh
 ~/Applications/Defi.app/Contents/MacOS/defi status
 ~/Applications/Defi.app/Contents/MacOS/defi trace
 ~/Applications/Defi.app/Contents/MacOS/defi focus-column left
-~/Applications/Defi.app/Contents/MacOS/defi focus-column right
 ~/Applications/Defi.app/Contents/MacOS/defi workspace 2
 ~/Applications/Defi.app/Contents/MacOS/defi move-window-to-workspace 3
 ~/Applications/Defi.app/Contents/MacOS/defi quit
 ```
 
-Default hotkeys:
+## Build from source
 
-- `Option + Left/Right`: focus column
-- `Option + Up/Down`: focus stacked window
-- `Option + Shift + arrows`: move column/window
-- `Option + 1...9`: switch workspace
-- `Option + Shift + 1...9`: move window and follow
-- `Option + -/=`: cycle width
-- `Option + F`: maximize column
-- `Option + \\`: toggle focused window tiled/floating
-- `Option + Shift + \\`: foreground selected floating window
-- `Option + ,/.`: cycle floating windows
-
-`maximize-column` fills Defi's monitor work area; it is not native macOS
-fullscreen. Native fullscreen lifecycle policy is documented in
-[CONFIGURATION.md](CONFIGURATION.md#native-macos-fullscreen).
-
-## Config
-
-Default path: `~/.config/defi/config.toml`.
-
-Start from [defi.example.toml](defi.example.toml) only when custom workspace names, aliases, or rules are needed. Full reference: [CONFIGURATION.md](CONFIGURATION.md).
-
-Run with explicit config:
+Local development build:
 
 ```sh
-~/Applications/Defi.app/Contents/MacOS/defi-daemon --config ./defi.example.toml
-```
-
-## Development service
-
-After `./script/build_and_run.sh`, signed binaries live inside stable app bundle:
-
-```sh
-~/Applications/Defi.app/Contents/MacOS/defi service install
-~/Applications/Defi.app/Contents/MacOS/defi service start
-~/Applications/Defi.app/Contents/MacOS/defi service status
-~/Applications/Defi.app/Contents/MacOS/defi service restart
-~/Applications/Defi.app/Contents/MacOS/defi service stop
-```
-
-Service points at stable installed app bundle.
-Defi restores parked windows before managed shutdown or service stop.
-
-## Signing identity
-
-Local builds use the only available Apple Development identity. When multiple
-identities are installed, copy `.env.example` to the ignored `.env.local` and
-select the local developer team:
-
-```sh
-cp .env.example .env.local
-# Edit .env.local: DEFI_DEVELOPMENT_TEAM=TEAMID
 ./script/build_and_run.sh
 ```
 
-Environment variables override `.env.local`. Select an exact identity when a
-team has multiple valid development certificates:
+This builds, signs, and installs `~/Applications/Defi.app`. When no config
+exists, it installs `defi.example.toml` as the initial user config.
+
+The script uses an Apple Development identity. If multiple identities exist,
+copy `.env.example` to the ignored `.env.local` and select the development
+team, or set `DEFI_CODESIGN_IDENTITY` directly.
+
+Create a local DMG without installing or launching Defi:
 
 ```sh
-DEFI_CODESIGN_IDENTITY=SHA1 ./script/build_and_run.sh
+./script/package_dmg.sh
 ```
 
-Team selection matches the certificate's Apple team identifier, not the suffix
-shown in its display name.
+The artifact is written to `dist/`.
 
-Stable bundle ID and signing identity preserve Accessibility permission across builds.
-
-## Verify
+## Development checks
 
 ```sh
 swift build
@@ -141,29 +129,14 @@ swift test --skip DesktopE2ETests
 ./script/test_desktop.sh
 ```
 
-CI runs deterministic tests only. Desktop tests require an interactive macOS
-session, installed windows, and Accessibility permission. Run them locally with
-`./script/test_desktop.sh`; the script temporarily stops the installed
-LaunchAgent, exercises native focus, offscreen workspace parking, and real
-frame convergence, restores changed windows, then restarts the service.
+CI runs deterministic tests. Desktop tests are intentionally explicit: they
+need an interactive Mac, real application windows, and Accessibility
+permission. `./script/test_desktop.sh` stops the installed service, exercises
+the desktop, restores changed windows, and restarts the service.
 
-`defi trace` prints the bounded AX frame-coordinator history. `submit` includes
-the layout source; animation samples expose inter-app completion spread.
-`quality` reports adaptive intermediate-frame reduction when AX is slow.
-`commit-observed` reports real-frame settling and deferred post-animation
-corrections without unbounded log growth.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for code boundaries and contribution
+guidance. See [ROADMAP.md](ROADMAP.md) for planned work.
 
-Metal-backed animation, dimming, and config hot reload remain later phases.
+## License
 
-## Release artifact
-
-Alpha DMGs are attached to [GitHub Releases](https://github.com/qeude/Defi/releases).
-Build a local signed DMG with:
-
-```sh
-./script/package_dmg.sh
-```
-
-The alpha DMG uses an Apple Development signature and is not notarized. macOS
-may require opening it manually from Finder or approving Defi in Privacy &
-Security settings.
+Defi is released under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -81,21 +81,21 @@ overrides. Full reference lives in [CONFIGURATION.md](CONFIGURATION.md).
 Configuration loads when the daemon starts. Restart the service after editing:
 
 ```sh
-~/Applications/Defi.app/Contents/MacOS/defi service restart
+/Applications/Defi.app/Contents/MacOS/defi service restart
 ```
 
 ## CLI
 
-The installed CLI lives at `~/Applications/Defi.app/Contents/MacOS/defi`.
+The installed alpha CLI lives at `/Applications/Defi.app/Contents/MacOS/defi`.
 Examples:
 
 ```sh
-~/Applications/Defi.app/Contents/MacOS/defi status
-~/Applications/Defi.app/Contents/MacOS/defi trace
-~/Applications/Defi.app/Contents/MacOS/defi focus-column left
-~/Applications/Defi.app/Contents/MacOS/defi workspace 2
-~/Applications/Defi.app/Contents/MacOS/defi move-window-to-workspace 3
-~/Applications/Defi.app/Contents/MacOS/defi quit
+/Applications/Defi.app/Contents/MacOS/defi status
+/Applications/Defi.app/Contents/MacOS/defi trace
+/Applications/Defi.app/Contents/MacOS/defi focus-column left
+/Applications/Defi.app/Contents/MacOS/defi workspace 2
+/Applications/Defi.app/Contents/MacOS/defi move-window-to-workspace 3
+/Applications/Defi.app/Contents/MacOS/defi quit
 ```
 
 ## Build from source

--- a/README.md
+++ b/README.md
@@ -107,7 +107,11 @@ Local development build:
 ```
 
 This builds, signs, and installs `~/Applications/Defi.app`. When no config
-exists, it installs `defi.example.toml` as the initial user config.
+exists, it installs `defi.example.toml` as the initial user config. This
+example intentionally overrides the built-in defaults: it uses the Hyper
+modifier and named workspaces such as `dev`, `web`, and `tools`. Remove or
+edit `~/.config/defi/config.toml` if you want to use the built-in Option
+bindings and workspaces `1` through `9` instead.
 
 The script uses an Apple Development identity. If multiple identities exist,
 copy `.env.example` to the ignored `.env.local` and select the development
@@ -126,6 +130,7 @@ The artifact is written to `dist/`.
 ```sh
 swift build
 swift test --skip DesktopE2ETests
+./script/build_and_run.sh --verify
 ./script/test_desktop.sh
 ```
 

--- a/Sources/DefiCLI/Service.swift
+++ b/Sources/DefiCLI/Service.swift
@@ -121,7 +121,23 @@ enum ServiceManager {
   private static var domain: String { "gui/\(getuid())" }
 
   private static var installedAppURL: URL {
-    FileManager.default.homeDirectoryForCurrentUser
+    if let executableURL = Bundle.main.executableURL,
+      let appURL = appBundleURL(from: executableURL)
+    {
+      return appURL
+    }
+
+    let candidates = [
+      FileManager.default.homeDirectoryForCurrentUser
+        .appending(path: "Applications/Defi.app"),
+      URL(filePath: "/Applications/Defi.app"),
+    ]
+    if let existing = candidates.first(where: {
+      FileManager.default.fileExists(atPath: $0.path)
+    }) {
+      return existing
+    }
+    return FileManager.default.homeDirectoryForCurrentUser
       .appending(path: "Applications/Defi.app")
   }
 
@@ -134,6 +150,20 @@ enum ServiceManager {
     FileManager.default.homeDirectoryForCurrentUser
       .appending(path: "Library/Logs/Defi.log")
   }
+}
+
+func appBundleURL(from executableURL: URL) -> URL? {
+  let executableURL = executableURL.resolvingSymlinksInPath().standardizedFileURL
+  let appURL = executableURL
+    .deletingLastPathComponent()
+    .deletingLastPathComponent()
+    .deletingLastPathComponent()
+  guard appURL.pathExtension == "app",
+    appURL.lastPathComponent == "Defi.app"
+  else {
+    return nil
+  }
+  return appURL
 }
 
 enum ServiceStartAction: Equatable, Sendable {

--- a/Sources/DefiCLI/Service.swift
+++ b/Sources/DefiCLI/Service.swift
@@ -31,10 +31,20 @@ enum ServiceManager {
       try stop(ignoreFailure: false)
       print("stopped")
     case "restart":
-      if !FileManager.default.fileExists(atPath: plistURL.path) {
-        try install()
+      for action in serviceRestartActions() {
+        switch action {
+        case .stop:
+          try stop(ignoreFailure: true)
+        case .quit:
+          _ = try? sendCommand("quit")
+        case .waitForStop:
+          try waitForDaemonToStop()
+        case .install:
+          try install()
+        case .bootstrap:
+          try bootstrapWithRetry()
+        }
       }
-      try launchctl(["kickstart", "-k", "\(domain)/\(label)"])
       print("restarted")
     case "status":
       try launchctl(["print", "\(domain)/\(label)"])
@@ -90,6 +100,19 @@ enum ServiceManager {
       }
     }
     throw lastError ?? ServiceError.launchctl(-1)
+  }
+
+  private static func waitForDaemonToStop() throws {
+    let deadline = Date().addingTimeInterval(5)
+    while Date() < deadline {
+      do {
+        _ = try sendCommand("status")
+        Thread.sleep(forTimeInterval: 0.1)
+      } catch {
+        return
+      }
+    }
+    throw ServiceError.daemonDidNotStop
   }
 
   private static func isLoaded() -> Bool {
@@ -158,12 +181,31 @@ func appBundleURL(from executableURL: URL) -> URL? {
     .deletingLastPathComponent()
     .deletingLastPathComponent()
     .deletingLastPathComponent()
-  guard appURL.pathExtension == "app",
-    appURL.lastPathComponent == "Defi.app"
+  guard appURL.pathExtension == "app" else {
+    return nil
+  }
+  let expectedExecutableDirectory = appURL
+    .appending(path: "Contents/MacOS")
+    .standardizedFileURL
+  guard
+    executableURL.deletingLastPathComponent().path
+      == expectedExecutableDirectory.path
   else {
     return nil
   }
   return appURL
+}
+
+enum ServiceRestartAction: Equatable, Sendable {
+  case stop
+  case quit
+  case waitForStop
+  case install
+  case bootstrap
+}
+
+func serviceRestartActions() -> [ServiceRestartAction] {
+  [.stop, .quit, .waitForStop, .install, .bootstrap]
 }
 
 enum ServiceStartAction: Equatable, Sendable {
@@ -182,12 +224,14 @@ func serviceStartActions(
 enum ServiceError: Error, CustomStringConvertible {
   case invalidCommand(String)
   case daemonMissing(String)
+  case daemonDidNotStop
   case launchctl(Int32)
 
   var description: String {
     switch self {
     case .invalidCommand(let command): "unknown service command: \(command)"
     case .daemonMissing(let path): "defi-daemon missing beside CLI: \(path)"
+    case .daemonDidNotStop: "defi-daemon did not stop before restart"
     case .launchctl(let status): "launchctl exited with status \(status)"
     }
   }

--- a/Tests/DefiCLITests/ServiceTests.swift
+++ b/Tests/DefiCLITests/ServiceTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 
 @testable import DefiCLI
@@ -22,7 +23,25 @@ struct ServiceTests {
       serviceStartActions(
         plistExists: true,
         isLoaded: true
-      ) == [.kickstart]
+    ) == [.kickstart]
+    )
+  }
+
+  @Test
+  func resolvesApplicationBundleFromInstalledCLIPath() {
+    #expect(
+      appBundleURL(
+        from: URL(filePath: "/Applications/Defi.app/Contents/MacOS/defi")
+      )?.path == "/Applications/Defi.app"
+    )
+  }
+
+  @Test
+  func rejectsExecutableOutsideApplicationBundle() {
+    #expect(
+      appBundleURL(
+        from: URL(filePath: "/Users/test/Defi/.build/debug/defi")
+      ) == nil
     )
   }
 }

--- a/Tests/DefiCLITests/ServiceTests.swift
+++ b/Tests/DefiCLITests/ServiceTests.swift
@@ -28,11 +28,23 @@ struct ServiceTests {
   }
 
   @Test
+  func restartStopsAndReplacesLoadedService() {
+    #expect(
+      serviceRestartActions() == [.stop, .quit, .waitForStop, .install, .bootstrap]
+    )
+  }
+
+  @Test
   func resolvesApplicationBundleFromInstalledCLIPath() {
     #expect(
       appBundleURL(
         from: URL(filePath: "/Applications/Defi.app/Contents/MacOS/defi")
       )?.path == "/Applications/Defi.app"
+    )
+    #expect(
+      appBundleURL(
+        from: URL(filePath: "/Applications/Defi 2.app/Contents/MacOS/defi")
+      )?.path == "/Applications/Defi 2.app"
     )
   }
 


### PR DESCRIPTION
## Summary

- Reworked README to explain Defi’s scrolling-column model and core capabilities.
- Added alpha installation, Accessibility permission, configuration, CLI, and build guidance.
- Aligned installed CLI/service paths with both release and development app locations.
- Made service restart replace the loaded daemon job and handle direct app launches.
- Consolidated development checks, release details, project links, and license information.

## Testing

- `swift build`
- `swift test --skip DesktopE2ETests`
- `./script/build_and_run.sh --verify`