### PR TITLE
Gate focus readiness on target window

### DIFF
--- a/Sources/DefiDaemon/DaemonAnimation.swift
+++ b/Sources/DefiDaemon/DaemonAnimation.swift
@@ -200,7 +200,10 @@ extension Daemon {
 
   func finishPendingAnimatedFocusIfReady() {
     if let pendingAnimatedFocus,
-      focusIsReady(on: pendingAnimatedFocus.monitorID)
+      focusIsReady(
+        on: pendingAnimatedFocus.monitorID,
+        targetWindowID: pendingAnimatedFocus.windowID
+      )
     {
       self.pendingAnimatedFocus = nil
       commitCommandFocus(
@@ -220,7 +223,10 @@ extension Daemon {
   func finishPendingWorkspaceFocusIfReady() {
     guard let request = pendingWorkspaceFocus,
       submittedWorkspaceFocusGeneration != request.commandGeneration,
-      focusIsReady(on: request.monitorID)
+      focusIsReady(
+        on: request.monitorID,
+        targetWindowID: request.requestedWindowID
+      )
     else { return }
 
     submittedWorkspaceFocusGeneration = request.commandGeneration
@@ -246,20 +252,16 @@ extension Daemon {
         : request.focusInputTimestamp
   }
 
-  func focusIsReady(on monitorID: MonitorID) -> Bool {
-    focusMonitorIsReady(
+  func focusIsReady(
+    on monitorID: MonitorID,
+    targetWindowID: WindowID
+  ) -> Bool {
+    focusTargetIsReady(
       targetMonitorID: monitorID,
+      targetWindowID: targetWindowID,
       scrollingMonitorIDs: Set(scrollAnimations.keys.map(\.monitorID)),
-      pendingFrameMonitorIDs: Set(
-        platform.pendingFrameWindowIDs.compactMap {
-          state.monitorID(containing: $0)
-        }
-      ),
-      deferredSlowMonitorIDs: Set(
-        deferredSlowWindowIDs.compactMap {
-          state.monitorID(containing: $0)
-        }
-      )
+      pendingFrameWindowIDs: platform.pendingFrameWindowIDs,
+      deferredSlowWindowIDs: deferredSlowWindowIDs
     )
   }
 

--- a/Sources/DefiDaemon/DaemonCommands.swift
+++ b/Sources/DefiDaemon/DaemonCommands.swift
@@ -278,7 +278,7 @@ extension Daemon {
           selectedFloatingWindowID: state.selectedFloatingWindowID(on: monitorID)
         )
       {
-        if focusIsReady(on: monitorID) {
+        if focusIsReady(on: monitorID, targetWindowID: selected) {
           commitCommandFocus(
             selected,
             previousSelectedWindowID: previouslySelectedWindowID,

--- a/Sources/DefiDaemon/DaemonFocus.swift
+++ b/Sources/DefiDaemon/DaemonFocus.swift
@@ -380,7 +380,7 @@ extension Daemon {
         cursorWarpInputTimestamp: nil,
         retryCount: request.retryCount
       )
-      guard focusIsReady(on: request.monitorID) else {
+      guard focusIsReady(on: request.monitorID, targetWindowID: restored.windowID) else {
         pendingAnimatedFocus = restored
         return
       }
@@ -414,7 +414,10 @@ extension Daemon {
         retryCount: request.retryCount
       )
       submittedWorkspaceFocusGeneration = nil
-      if focusIsReady(on: request.monitorID) {
+      if focusIsReady(
+        on: request.monitorID,
+        targetWindowID: request.requestedWindowID
+      ) {
         finishPendingWorkspaceFocusIfReady()
       }
     }

--- a/Sources/DefiDaemon/DaemonPointerFocusRecovery.swift
+++ b/Sources/DefiDaemon/DaemonPointerFocusRecovery.swift
@@ -267,12 +267,19 @@ extension Daemon {
     guard let targetMonitorID = state.monitorID(containing: windowID) else {
       return false
     }
-    return focusTargetIsReady(
+    return focusMonitorIsReady(
       targetMonitorID: targetMonitorID,
-      targetWindowID: windowID,
       scrollingMonitorIDs: Set(scrollAnimations.keys.map(\.monitorID)),
-      pendingFrameWindowIDs: platform.pendingFrameWindowIDs,
-      deferredSlowWindowIDs: deferredSlowWindowIDs
+      pendingFrameMonitorIDs: Set(
+        platform.pendingFrameWindowIDs.compactMap {
+          state.monitorID(containing: $0)
+        }
+      ),
+      deferredSlowMonitorIDs: Set(
+        deferredSlowWindowIDs.compactMap {
+          state.monitorID(containing: $0)
+        }
+      )
     )
   }
 

--- a/Sources/DefiDaemon/DaemonPointerFocusRecovery.swift
+++ b/Sources/DefiDaemon/DaemonPointerFocusRecovery.swift
@@ -267,19 +267,12 @@ extension Daemon {
     guard let targetMonitorID = state.monitorID(containing: windowID) else {
       return false
     }
-    return focusMonitorIsReady(
+    return focusTargetIsReady(
       targetMonitorID: targetMonitorID,
+      targetWindowID: windowID,
       scrollingMonitorIDs: Set(scrollAnimations.keys.map(\.monitorID)),
-      pendingFrameMonitorIDs: Set(
-        platform.pendingFrameWindowIDs.compactMap {
-          state.monitorID(containing: $0)
-        }
-      ),
-      deferredSlowMonitorIDs: Set(
-        deferredSlowWindowIDs.compactMap {
-          state.monitorID(containing: $0)
-        }
-      )
+      pendingFrameWindowIDs: platform.pendingFrameWindowIDs,
+      deferredSlowWindowIDs: deferredSlowWindowIDs
     )
   }
 

--- a/Sources/DefiRuntime/FocusSelection.swift
+++ b/Sources/DefiRuntime/FocusSelection.swift
@@ -357,7 +357,22 @@ public func nextCommandFocusRetryCount(
   return currentRetryCount + 1
 }
 
-/// Returns whether focus can proceed for one target window.
+/// Pointer focus waits until all geometry writes on target monitor settle.
+///
+/// Hit-test geometry can become stale while any sibling is moving, and no new
+/// pointer event is guaranteed after that sibling moves under the cursor.
+public func focusMonitorIsReady(
+  targetMonitorID: MonitorID,
+  scrollingMonitorIDs: Set<MonitorID>,
+  pendingFrameMonitorIDs: Set<MonitorID>,
+  deferredSlowMonitorIDs: Set<MonitorID>
+) -> Bool {
+  !scrollingMonitorIDs.contains(targetMonitorID)
+    && !pendingFrameMonitorIDs.contains(targetMonitorID)
+    && !deferredSlowMonitorIDs.contains(targetMonitorID)
+}
+
+/// Keyboard focus can proceed when target window is ready.
 ///
 /// Frame debt from sibling windows must not block focus. A slow or delayed
 /// Accessibility response elsewhere on the monitor cannot make keyboard

--- a/Sources/DefiRuntime/FocusSelection.swift
+++ b/Sources/DefiRuntime/FocusSelection.swift
@@ -357,15 +357,21 @@ public func nextCommandFocusRetryCount(
   return currentRetryCount + 1
 }
 
-public func focusMonitorIsReady(
+/// Returns whether focus can proceed for one target window.
+///
+/// Frame debt from sibling windows must not block focus. A slow or delayed
+/// Accessibility response elsewhere on the monitor cannot make keyboard
+/// focus unresponsive for the selected window.
+public func focusTargetIsReady(
   targetMonitorID: MonitorID,
+  targetWindowID: WindowID,
   scrollingMonitorIDs: Set<MonitorID>,
-  pendingFrameMonitorIDs: Set<MonitorID>,
-  deferredSlowMonitorIDs: Set<MonitorID>
+  pendingFrameWindowIDs: Set<WindowID>,
+  deferredSlowWindowIDs: Set<WindowID>
 ) -> Bool {
   !scrollingMonitorIDs.contains(targetMonitorID)
-    && !pendingFrameMonitorIDs.contains(targetMonitorID)
-    && !deferredSlowMonitorIDs.contains(targetMonitorID)
+    && !pendingFrameWindowIDs.contains(targetWindowID)
+    && !deferredSlowWindowIDs.contains(targetWindowID)
 }
 
 public func nativeFocusMutationIsReady(

--- a/Tests/DefiRuntimeTests/PointerFocusTests.swift
+++ b/Tests/DefiRuntimeTests/PointerFocusTests.swift
@@ -460,39 +460,54 @@ struct PointerFocusTests {
   }
 
   @Test
-  func focusReadinessIsIsolatedPerMonitorAndIncludesAllFrameWrites() {
+  func focusReadinessIsIsolatedPerMonitorAndTargetWindow() {
     let otherMonitorID = MonitorID(rawValue: 2)
+    let targetWindowID = WindowID(rawValue: 1)
+    let otherWindowID = WindowID(rawValue: 2)
 
     #expect(
-      focusMonitorIsReady(
+      focusTargetIsReady(
         targetMonitorID: monitorID,
+        targetWindowID: targetWindowID,
         scrollingMonitorIDs: [otherMonitorID],
-        pendingFrameMonitorIDs: [otherMonitorID],
-        deferredSlowMonitorIDs: [otherMonitorID]
+        pendingFrameWindowIDs: [otherWindowID],
+        deferredSlowWindowIDs: [otherWindowID]
       )
     )
     #expect(
-      !focusMonitorIsReady(
+      !focusTargetIsReady(
         targetMonitorID: monitorID,
+        targetWindowID: targetWindowID,
         scrollingMonitorIDs: [monitorID],
-        pendingFrameMonitorIDs: [],
-        deferredSlowMonitorIDs: []
+        pendingFrameWindowIDs: [],
+        deferredSlowWindowIDs: []
       )
     )
     #expect(
-      !focusMonitorIsReady(
+      !focusTargetIsReady(
         targetMonitorID: monitorID,
+        targetWindowID: targetWindowID,
         scrollingMonitorIDs: [],
-        pendingFrameMonitorIDs: [monitorID],
-        deferredSlowMonitorIDs: []
+        pendingFrameWindowIDs: [targetWindowID],
+        deferredSlowWindowIDs: []
       )
     )
     #expect(
-      !focusMonitorIsReady(
+      !focusTargetIsReady(
         targetMonitorID: monitorID,
+        targetWindowID: targetWindowID,
         scrollingMonitorIDs: [],
-        pendingFrameMonitorIDs: [],
-        deferredSlowMonitorIDs: [monitorID]
+        pendingFrameWindowIDs: [],
+        deferredSlowWindowIDs: [targetWindowID]
+      )
+    )
+    #expect(
+      focusTargetIsReady(
+        targetMonitorID: monitorID,
+        targetWindowID: targetWindowID,
+        scrollingMonitorIDs: [],
+        pendingFrameWindowIDs: [otherWindowID],
+        deferredSlowWindowIDs: [otherWindowID]
       )
     )
   }

--- a/Tests/DefiRuntimeTests/PointerFocusTests.swift
+++ b/Tests/DefiRuntimeTests/PointerFocusTests.swift
@@ -512,6 +512,36 @@ struct PointerFocusTests {
     )
   }
 
+  @Test
+  func pointerFocusReadinessRemainsMonitorWide() {
+    let otherMonitorID = MonitorID(rawValue: 2)
+
+    #expect(
+      !focusMonitorIsReady(
+        targetMonitorID: monitorID,
+        scrollingMonitorIDs: [],
+        pendingFrameMonitorIDs: [monitorID],
+        deferredSlowMonitorIDs: []
+      )
+    )
+    #expect(
+      !focusMonitorIsReady(
+        targetMonitorID: monitorID,
+        scrollingMonitorIDs: [],
+        pendingFrameMonitorIDs: [],
+        deferredSlowMonitorIDs: [monitorID]
+      )
+    )
+    #expect(
+      focusMonitorIsReady(
+        targetMonitorID: monitorID,
+        scrollingMonitorIDs: [otherMonitorID],
+        pendingFrameMonitorIDs: [otherMonitorID],
+        deferredSlowMonitorIDs: [otherMonitorID]
+      )
+    )
+  }
+
   private func makeState(
     columnWidths: [Double],
     centerFocusedColumn: CenterFocusedColumnConfig = .never


### PR DESCRIPTION
## Summary

- Make focus readiness target-window aware.
- Prevent sibling frame debt from blocking keyboard focus.
- Update daemon focus paths and pointer recovery checks.
- Add isolated readiness coverage for target and sibling windows.

## Testing

- Updated `PointerFocusTests` coverage for target-window readiness.
- Full test suite not run.