### PR TITLE
Prevent unexpected native focus selection changes

### DIFF
--- a/Sources/DefiRuntime/FocusSelection.swift
+++ b/Sources/DefiRuntime/FocusSelection.swift
@@ -472,7 +472,7 @@ public func nativeFocusMutationIsReady(
     return (deferredMouseFocusReady ?? mouseInteractionEnded)
       && mouseReleaseFocusIntentCurrent
   }
-  return nativeFocusChanged
+  return false
 }
 
 public func keyboardFocusPreemptsMouseGesture(

--- a/Tests/DefiRuntimeTests/NativeFocusTests.swift
+++ b/Tests/DefiRuntimeTests/NativeFocusTests.swift
@@ -92,7 +92,7 @@ struct NativeFocusTests {
   }
 
   @Test
-  func nonMouseNativeFocusMutatesImmediately() {
+  func nativeFocusWithoutHumanIntentDoesNotMutateSelection() {
     #expect(
       nativeFocusMutationIsReady(
         nativeFocusChanged: true,
@@ -100,7 +100,7 @@ struct NativeFocusTests {
         leftMouseButtonDown: false,
         mouseReleaseFocusIntentCurrent: false,
         keyboardFocusIntentCurrent: false
-      )
+      ) == false
     )
   }
 


### PR DESCRIPTION
## Summary
- Prevent native focus changes without an active user intent from mutating selection.
- Update coverage for passive native focus events.

## Testing
- Updated `NativeFocusTests.nativeFocusWithoutHumanIntentDoesNotMutateSelection`.