### PR TITLE
fix: prevent background windows from stealing focus

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -367,7 +367,7 @@ intrinsic_size = true
 | `title` | unset | string | Case-insensitive substring match against window title. |
 | `role` | unset | string | Exact, case-sensitive Accessibility role match, such as `AXWindow`. |
 | `workspace` | unset | string present in `[workspaces].names` | Places newly discovered matching window on workspace. |
-| `follow_focus` | `false` | boolean | Activates target workspace and selects matching window when discovered. |
+| `follow_focus` | `false` | boolean | Activates the target workspace when the newly discovered matching window has native focus. |
 | `floating` | `false` | boolean | Places matching window in workspace floating layer. |
 | `force_tiling` | `false` | boolean | Tiles matching window even when platform classification would normally float or ignore it. Overrides `floating`. |
 | `intrinsic_size` | `false` | boolean | Preserves observed window width and height inside its tile. |

--- a/Sources/DefiRuntime/WindowReconciliation.swift
+++ b/Sources/DefiRuntime/WindowReconciliation.swift
@@ -28,7 +28,7 @@ public func discoverWindow(
   window.intrinsicSize = decision.intrinsicSize
   let effectivePlacement = window.floatingOrigin == .automatic ? nil : placement
   let transientLocation = transientPlacementLocation(for: window, state: state)
-  let followsFocus = decision.followFocus && (transientLocation == nil || isNativelyFocused)
+  let followsFocus = decision.followFocus && isNativelyFocused
   let preferredMonitorID = effectivePlacement?.monitorID.flatMap { preferred in
     state.monitors.contains(where: { $0.id == preferred }) ? preferred : nil
   }

--- a/Tests/DefiRuntimeTests/BackgroundWindowDiscoveryTests.swift
+++ b/Tests/DefiRuntimeTests/BackgroundWindowDiscoveryTests.swift
@@ -5,6 +5,49 @@ import Testing
 
 struct BackgroundWindowDiscoveryTests {
   @Test
+  func followFocusRuleDoesNotActivateUnfocusedBackgroundWindow() throws {
+    let monitorID = MonitorID(rawValue: 1)
+    let tools = WorkspaceID(rawValue: "tools")
+    let config = Config(
+      workspaces: WorkspacesConfig(names: ["dev", tools.rawValue]),
+      rules: [Rule(appID: "proxy", workspace: tools.rawValue, followFocus: true)]
+    )
+    var state = RuntimeState(config: config)
+    state.attachMonitor(monitorID)
+    let selectedWindow = Window(
+      id: WindowID(rawValue: 1),
+      appID: "editor",
+      title: "Selected",
+      frame: Rect(x: 0, y: 0, width: 600, height: 800),
+      monitorID: monitorID
+    )
+    let backgroundWindow = Window(
+      id: WindowID(rawValue: 2),
+      appID: "proxy",
+      title: "Background",
+      frame: Rect(x: 600, y: 0, width: 600, height: 800),
+      monitorID: monitorID
+    )
+    try discoverWindow(
+      selectedWindow,
+      decision: RuleDecision(followFocus: true),
+      isNativelyFocused: true,
+      state: &state
+    )
+
+    reconcileWindows(
+      [selectedWindow, backgroundWindow],
+      config: config,
+      nativeFocusedWindowID: selectedWindow.id,
+      state: &state
+    )
+
+    #expect(state.monitors[0].activeWorkspace.rawValue == "dev")
+    #expect(state.selectedWindowID(on: monitorID) == selectedWindow.id)
+    #expect(state.location(containing: backgroundWindow.id)?.workspaceID == tools)
+  }
+
+  @Test
   func tiledWindowDiscoveredWithoutFollowFocusPreservesSelectionAndScroll() throws {
     let monitorID = MonitorID(rawValue: 1)
     var state = RuntimeState(config: Config())
@@ -27,6 +70,7 @@ struct BackgroundWindowDiscoveryTests {
     try discoverWindow(
       selectedWindow,
       decision: RuleDecision(followFocus: true),
+      isNativelyFocused: true,
       state: &state
     )
     state.monitors[0].workspaces[0].scrollOffset = 0.25

--- a/Tests/DefiRuntimeTests/FloatingWindowTests.swift
+++ b/Tests/DefiRuntimeTests/FloatingWindowTests.swift
@@ -159,6 +159,7 @@ final class FloatingWindowTests: XCTestCase {
     try discoverWindow(
       floater,
       decision: RuleDecision(workspace: tools, followFocus: true),
+      isNativelyFocused: true,
       state: &state
     )
     try reduce(.switchWorkspace(WorkspaceID(rawValue: "dev")), on: monitorID, state: &state)
@@ -205,6 +206,7 @@ final class FloatingWindowTests: XCTestCase {
     try discoverWindow(
       followed,
       decision: RuleDecision(workspace: tools, followFocus: true),
+      isNativelyFocused: true,
       state: &state
     )
 
@@ -223,6 +225,7 @@ final class FloatingWindowTests: XCTestCase {
     try discoverWindow(
       floater,
       decision: RuleDecision(workspace: tools, followFocus: true),
+      isNativelyFocused: true,
       state: &state
     )
 
@@ -230,6 +233,7 @@ final class FloatingWindowTests: XCTestCase {
     try discoverWindow(
       followed,
       decision: RuleDecision(workspace: tools, followFocus: true),
+      isNativelyFocused: true,
       state: &state
     )
 

--- a/Tests/DefiRuntimeTests/MouseReorderingTests.swift
+++ b/Tests/DefiRuntimeTests/MouseReorderingTests.swift
@@ -723,6 +723,7 @@ final class MouseReorderingTests: XCTestCase {
       try discoverWindow(
         window,
         decision: RuleDecision(followFocus: true),
+        isNativelyFocused: true,
         state: &state
       )
     }

--- a/Tests/DefiRuntimeTests/NativeFocusTests.swift
+++ b/Tests/DefiRuntimeTests/NativeFocusTests.swift
@@ -960,6 +960,7 @@ struct NativeFocusTests {
       try discoverWindow(
         window,
         decision: RuleDecision(followFocus: true),
+        isNativelyFocused: true,
         state: &state
       )
     }

--- a/Tests/DefiRuntimeTests/WindowLifecycleTests.swift
+++ b/Tests/DefiRuntimeTests/WindowLifecycleTests.swift
@@ -21,7 +21,12 @@ final class WindowLifecycleTests: XCTestCase {
       monitorID: monitorID
     )
 
-    try discoverWindow(window, decision: config.decision(for: window), state: &state)
+    try discoverWindow(
+      window,
+      decision: config.decision(for: window),
+      isNativelyFocused: true,
+      state: &state
+    )
 
     XCTAssertEqual(state.monitors[0].activeWorkspace, WorkspaceID(rawValue: "web"))
     XCTAssertEqual(state.monitors[0].workspaces[1].columns[0].windows, [window.id])


### PR DESCRIPTION
## Summary

- Require native focus before a newly discovered window with `follow_focus` activates its workspace.
- Add a regression test for background window discovery preserving the current workspace and selection.
- Clarify the `follow_focus` documentation and make focused-window test fixtures explicit.

## Root cause

A window temporarily missing from a desktop snapshot could later be rediscovered with `follow_focus = true`. `discoverWindow` activated its workspace even while macOS still focused another application.

## Testing

- `swift build`
- `swift test` with 315 passing tests
- `DEFI_CODESIGN_IDENTITY=<identity> ./script/build_and_run.sh --verify`
- Regression test observed failing before the fix and passing after it
- Installed build inspected with Computer Use, with `dev` and T3 restored and one daemon active
- `./script/test_desktop.sh`: 16 of 17 tests pass in the full sequence. The pointer hit-test case passes in isolation but remains order-dependent and does not exercise the changed `DefiRuntime` path.