### PR TITLE
Migrate tests to Swift Testing

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "fd28c74cbae76db9fce7de10c74a99dea0447d2668a2225947b8f9d25d5922da",
+  "originHash" : "f6e71ac0e593e329c26a8a68dcbbeea8de3328a68254d63bb336f37fdc97d413",
   "pins" : [
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
     {
       "identity" : "tomldecoder",
       "kind" : "remoteSourceControl",

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,8 @@ let package = Package(
     .executable(name: "defi", targets: ["DefiCLI"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/dduan/TOMLDecoder.git", from: "0.4.5")
+    .package(url: "https://github.com/dduan/TOMLDecoder.git", from: "0.4.5"),
+    .package(url: "https://github.com/apple/swift-numerics.git", from: "1.1.1"),
   ],
   targets: [
     .target(name: "DefiModel"),
@@ -66,7 +67,11 @@ let package = Package(
     ),
     .testTarget(
       name: "DefiCoreTests",
-      dependencies: ["DefiCore", "DefiModel"]
+      dependencies: [
+        "DefiCore",
+        "DefiModel",
+        .product(name: "Numerics", package: "swift-numerics"),
+      ]
     ),
     .testTarget(
       name: "DefiConfigTests",
@@ -74,7 +79,12 @@ let package = Package(
     ),
     .testTarget(
       name: "DefiRuntimeTests",
-      dependencies: ["DefiRuntime", "DefiConfig", "DefiModel"]
+      dependencies: [
+        "DefiRuntime",
+        "DefiConfig",
+        "DefiModel",
+        .product(name: "Numerics", package: "swift-numerics"),
+      ]
     ),
     .testTarget(
       name: "DefiIPCTests",
@@ -86,7 +96,13 @@ let package = Package(
     ),
     .testTarget(
       name: "DefiMacOSTests",
-      dependencies: ["DefiMacOS", "DefiConfig", "DefiCore", "DefiModel"]
+      dependencies: [
+        "DefiMacOS",
+        "DefiConfig",
+        "DefiCore",
+        "DefiModel",
+        .product(name: "Numerics", package: "swift-numerics"),
+      ]
     ),
     .testTarget(
       name: "DefiDaemonTests",

--- a/Tests/DefiConfigTests/ConfigTests.swift
+++ b/Tests/DefiConfigTests/ConfigTests.swift
@@ -1,34 +1,36 @@
 import DefiConfig
 import DefiModel
 import Foundation
-import XCTest
+import Testing
 
-final class ConfigTests: XCTestCase {
-  func testEmptyConfigUsesDefaults() throws {
+struct ConfigTests {
+  @Test
+  func `Empty config uses defaults`() throws {
     let config = try Config.decode(Data())
 
-    XCTAssertEqual(config.workspaces.names, (1...9).map(String.init))
-    XCTAssertEqual(config.layout.defaultColumnWidth, 0.8)
-    XCTAssertTrue(config.animation.enabled)
-    XCTAssertEqual(config.animation.durationMS, 35)
-    XCTAssertTrue(config.decorations.borders.enabled)
-    XCTAssertEqual(config.decorations.borders.width, 4)
-    XCTAssertEqual(config.decorations.borders.color, "#FFC099FF")
-    XCTAssertFalse(config.decorations.borders.inactiveEnabled)
-    XCTAssertEqual(config.decorations.borders.inactiveColor, "#66C099FF")
-    XCTAssertFalse(config.decorations.borders.captureEnabled)
-    XCTAssertEqual(config.keys["alt-left"], "focus-column left")
-    XCTAssertEqual(config.keys["alt-backslash"], "toggle-floating")
-    XCTAssertEqual(config.keys["alt-shift-backslash"], "activate-floating")
-    XCTAssertEqual(config.keys["alt-period"], "focus-floating next")
-    XCTAssertEqual(config.keys["alt-shift-1"], "move-window-to-workspace 1")
-    XCTAssertEqual(config.keys["alt-shift-h"], "move-column-to-monitor left")
-    XCTAssertEqual(config.keys["alt-shift-j"], "move-column-to-monitor down")
-    XCTAssertEqual(config.keys["alt-shift-k"], "move-column-to-monitor up")
-    XCTAssertEqual(config.keys["alt-shift-l"], "move-column-to-monitor right")
+    #expect(config.workspaces.names == (1...9).map(String.init))
+    #expect(config.layout.defaultColumnWidth == 0.8)
+    #expect(config.animation.enabled)
+    #expect(config.animation.durationMS == 35)
+    #expect(config.decorations.borders.enabled)
+    #expect(config.decorations.borders.width == 4)
+    #expect(config.decorations.borders.color == "#FFC099FF")
+    #expect(config.decorations.borders.inactiveEnabled == false)
+    #expect(config.decorations.borders.inactiveColor == "#66C099FF")
+    #expect(config.decorations.borders.captureEnabled == false)
+    #expect(config.keys["alt-left"] == "focus-column left")
+    #expect(config.keys["alt-backslash"] == "toggle-floating")
+    #expect(config.keys["alt-shift-backslash"] == "activate-floating")
+    #expect(config.keys["alt-period"] == "focus-floating next")
+    #expect(config.keys["alt-shift-1"] == "move-window-to-workspace 1")
+    #expect(config.keys["alt-shift-h"] == "move-column-to-monitor left")
+    #expect(config.keys["alt-shift-j"] == "move-column-to-monitor down")
+    #expect(config.keys["alt-shift-k"] == "move-column-to-monitor up")
+    #expect(config.keys["alt-shift-l"] == "move-column-to-monitor right")
   }
 
-  func testDecodesBorderConfiguration() throws {
+  @Test
+  func `Decodes border configuration`() throws {
     let config = try Config.decode(
       Data(
         """
@@ -43,44 +45,52 @@ final class ConfigTests: XCTestCase {
       )
     )
 
-    XCTAssertEqual(config.decorations.borders.width, 3.5)
-    XCTAssertEqual(config.decorations.borders.color, "#ff33aaff")
-    XCTAssertTrue(config.decorations.borders.inactiveEnabled)
-    XCTAssertEqual(config.decorations.borders.inactiveColor, "0x4433aaff")
-    XCTAssertTrue(config.decorations.borders.captureEnabled)
+    #expect(config.decorations.borders.width == 3.5)
+    #expect(config.decorations.borders.color == "#ff33aaff")
+    #expect(config.decorations.borders.inactiveEnabled)
+    #expect(config.decorations.borders.inactiveColor == "0x4433aaff")
+    #expect(config.decorations.borders.captureEnabled)
   }
 
-  func testRejectsInvalidBorderConfiguration() {
-    XCTAssertThrowsError(
-      try Config.decode(
-        Data(
-          """
-          [decorations.borders]
-          width = 65
-          """.utf8
-        )
-      )
+  @Test(arguments: [
+    (
+      "width = 65",
+      ConfigError.invalidValue("decorations.borders.width")
+    ),
+    (
+      "color = \"ffffff\"",
+      ConfigError.invalidValue("decorations.borders.color")
+    ),
+  ])
+  func `Rejects invalid border configuration`(
+    testCase: (setting: String, expectedError: ConfigError)
+  ) {
+    let data = Data(
+      """
+      [decorations.borders]
+      \(testCase.setting)
+      """.utf8
     )
-    XCTAssertThrowsError(
-      try Config.decode(
-        Data(
-          """
-          [decorations.borders]
-          color = "ffffff"
-          """.utf8
-        )
-      )
-    )
+
+    #expect(throws: testCase.expectedError) {
+      try Config.decode(data)
+    }
   }
 
-  func testParsesBorderColors() {
-    XCTAssertEqual(parseBorderColor("0xffffffff"), 0xffff_ffff)
-    XCTAssertEqual(parseBorderColor("#8033aaff"), 0x8033_aaff)
-    XCTAssertNil(parseBorderColor("#fff"))
-    XCTAssertNil(parseBorderColor("8033aaff"))
+  @Test(arguments: [
+    ("0xffffffff", UInt32(0xffff_ffff)),
+    ("#8033aaff", UInt32(0x8033_aaff)),
+    ("#fff", nil),
+    ("8033aaff", nil),
+  ])
+  func `Parses border colors`(
+    testCase: (value: String, expected: UInt32?)
+  ) {
+    #expect(parseBorderColor(testCase.value) == testCase.expected)
   }
 
-  func testDecodesExampleShapeAndGeneratesNamedWorkspaceKeys() throws {
+  @Test
+  func `Decodes example shape and generates named workspace keys`() throws {
     let data = Data(
       """
       default_key_modifier = "hyper"
@@ -107,22 +117,23 @@ final class ConfigTests: XCTestCase {
 
     let config = try Config.decode(data)
 
-    XCTAssertEqual(config.layout.gaps, 4)
-    XCTAssertEqual(config.animation.durationMS, 120)
-    XCTAssertEqual(config.workspaces.defaultName, "dev")
-    XCTAssertEqual(config.keys["hyper-1"], "workspace dev")
-    XCTAssertEqual(config.keys["hyper-minus"], "cycle-width previous")
-    XCTAssertEqual(config.keys["hyper-equal"], "cycle-width next")
-    XCTAssertEqual(config.keys["hyper-f"], "maximize-column")
-    XCTAssertEqual(config.keys["hyper-backslash"], "toggle-floating")
-    XCTAssertEqual(config.keys["hyper-shift-backslash"], "activate-floating")
-    XCTAssertEqual(config.keys["hyper-comma"], "focus-floating previous")
-    XCTAssertEqual(config.keys["hyper-period"], "focus-floating next")
-    XCTAssertEqual(config.modifierCombinations["hyper"], "Alt + Cmd + Ctrl")
-    XCTAssertEqual(config.rules.count, 1)
+    #expect(config.layout.gaps == 4)
+    #expect(config.animation.durationMS == 120)
+    #expect(config.workspaces.defaultName == "dev")
+    #expect(config.keys["hyper-1"] == "workspace dev")
+    #expect(config.keys["hyper-minus"] == "cycle-width previous")
+    #expect(config.keys["hyper-equal"] == "cycle-width next")
+    #expect(config.keys["hyper-f"] == "maximize-column")
+    #expect(config.keys["hyper-backslash"] == "toggle-floating")
+    #expect(config.keys["hyper-shift-backslash"] == "activate-floating")
+    #expect(config.keys["hyper-comma"] == "focus-floating previous")
+    #expect(config.keys["hyper-period"] == "focus-floating next")
+    #expect(config.modifierCombinations["hyper"] == "Alt + Cmd + Ctrl")
+    #expect(config.rules.count == 1)
   }
 
-  func testAcceptsDiagnosticMarkerBinding() throws {
+  @Test
+  func `Accepts diagnostic marker binding`() throws {
     let config = try Config.decode(
       Data(
         """
@@ -135,10 +146,11 @@ final class ConfigTests: XCTestCase {
       )
     )
 
-    XCTAssertEqual(config.keys["hyper-d"], "diagnostic-mark")
+    #expect(config.keys["hyper-d"] == "diagnostic-mark")
   }
 
-  func testRuleDecisionCombinesMatches() {
+  @Test
+  func `Rule decision combines matches`() {
     let config = Config(
       workspaces: WorkspacesConfig(names: ["dev", "web"]),
       rules: [
@@ -160,18 +172,17 @@ final class ConfigTests: XCTestCase {
 
     let decision = config.decision(for: window)
 
-    XCTAssertEqual(
-      decision,
-      config.decision(appID: window.appID, title: window.title, role: window.role)
-    )
-    XCTAssertEqual(decision.workspace, WorkspaceID(rawValue: "dev"))
-    XCTAssertTrue(decision.followFocus)
-    XCTAssertTrue(decision.floating)
-    XCTAssertTrue(decision.forceTiling)
-    XCTAssertTrue(decision.intrinsicSize)
+    #expect(
+      decision == config.decision(appID: window.appID, title: window.title, role: window.role))
+    #expect(decision.workspace == WorkspaceID(rawValue: "dev"))
+    #expect(decision.followFocus)
+    #expect(decision.floating)
+    #expect(decision.forceTiling)
+    #expect(decision.intrinsicSize)
   }
 
-  func testRejectsUnknownRuleWorkspace() {
+  @Test
+  func `Rejects unknown rule workspace`() {
     let data = Data(
       """
       [workspaces]
@@ -183,18 +194,21 @@ final class ConfigTests: XCTestCase {
       """.utf8
     )
 
-    XCTAssertThrowsError(try Config.decode(data))
+    #expect(throws: ConfigError.unknownWorkspace("missing")) {
+      try Config.decode(data)
+    }
   }
 
-  func testRepositoryExampleDecodes() throws {
+  @Test
+  func `Repository example decodes`() throws {
     let repository = URL(filePath: #filePath)
       .deletingLastPathComponent()
       .deletingLastPathComponent()
       .deletingLastPathComponent()
     let config = try Config.load(from: repository.appending(path: "defi.example.toml"))
 
-    XCTAssertEqual(config.workspaces.names.first, "dev")
-    XCTAssertEqual(config.keys["hyper-left"], "focus-column left")
-    XCTAssertEqual(config.rules.count, 9)
+    #expect(config.workspaces.names.first == "dev")
+    #expect(config.keys["hyper-left"] == "focus-column left")
+    #expect(config.rules.count == 9)
   }
 }

--- a/Tests/DefiCoreTests/AnimationTests.swift
+++ b/Tests/DefiCoreTests/AnimationTests.swift
@@ -1,30 +1,27 @@
 import DefiCore
 import DefiModel
+import Numerics
 import Testing
-import XCTest
 
 struct AnimationTests {
   @Test
   func `Speculative navigation settlement waits past visual animation`() {
-    XCTAssertEqual(
-      speculativeNavigationSettlementDelay(animationDuration: 0.035),
-      0.075,
-      accuracy: 0.000_1
+    #expect(
+      speculativeNavigationSettlementDelay(animationDuration: 0.035)
+        .isApproximatelyEqual(to: 0.075, absoluteTolerance: 0.000_1)
     )
-    XCTAssertEqual(
-      speculativeNavigationSettlementDelay(animationDuration: 0.1),
-      0.12,
-      accuracy: 0.000_1
+    #expect(
+      speculativeNavigationSettlementDelay(animationDuration: 0.1)
+        .isApproximatelyEqual(to: 0.12, absoluteTolerance: 0.000_1)
     )
   }
 
   @Test
   func `Scroll animation uses ease out cubic and finishes exactly`() {
     #expect(animatedScalar(from: 0, to: 1, elapsed: 0, duration: 0.08) == 0)
-    XCTAssertEqual(
-      animatedScalar(from: 0, to: 1, elapsed: 0.04, duration: 0.08),
-      0.875,
-      accuracy: 0.000_1
+    #expect(
+      animatedScalar(from: 0, to: 1, elapsed: 0.04, duration: 0.08)
+        .isApproximatelyEqual(to: 0.875, absoluteTolerance: 0.000_1)
     )
     #expect(animatedScalar(from: 0, to: 1, elapsed: 0.08, duration: 0.08) == 1)
   }
@@ -46,8 +43,8 @@ struct AnimationTests {
       value = step.value
       velocity = step.velocity
     }
-    XCTAssertEqual(value, 500, accuracy: 0.01)
-    XCTAssertEqual(velocity, 0, accuracy: 0.5)
+    #expect(value.isApproximatelyEqual(to: 500, absoluteTolerance: 0.01))
+    #expect(velocity.isApproximatelyEqual(to: 0, absoluteTolerance: 0.5))
   }
 
   @Test
@@ -63,7 +60,9 @@ struct AnimationTests {
 
     #expect(at120Hz.count == 4)
     #expect(at60Hz.count == 2)
-    XCTAssertEqual(at120Hz.first ?? 0, 0.247, accuracy: 0.002)
+    #expect(
+      (at120Hz.first ?? 0).isApproximatelyEqual(to: 0.247, absoluteTolerance: 0.002)
+    )
     #expect(at120Hz.last ?? 0 > 0.85)
     #expect(at120Hz.last ?? 1 < 1)
     #expect(at120Hz == at120Hz.sorted())
@@ -184,21 +183,23 @@ struct AnimationTests {
 
   @Test
   func `Completed AX frame schedules next write after display interval`() {
-    XCTAssertEqual(
+    #expect(
       nextCompletedFrameDispatchDeadline(
         completedAt: 10,
         refreshRateHz: 120
-      ),
-      10 + 1.0 / 120,
-      accuracy: 0.000_001
+      ).isApproximatelyEqual(
+        to: 10 + 1.0 / 120,
+        absoluteTolerance: 0.000_001
+      )
     )
-    XCTAssertEqual(
+    #expect(
       nextCompletedFrameDispatchDeadline(
         completedAt: 10,
         refreshRateHz: 60
-      ),
-      10 + 1.0 / 60,
-      accuracy: 0.000_001
+      ).isApproximatelyEqual(
+        to: 10 + 1.0 / 60,
+        absoluteTolerance: 0.000_001
+      )
     )
   }
 
@@ -243,13 +244,11 @@ struct AnimationTests {
 
   @Test
   func `Final AX frame is dispatched early enough to finish on animation deadline`() {
-    XCTAssertEqual(
+    #expect(
       anticipatedFinalFrameDispatchDelay(
         animationDuration: 0.035,
         predictedFrameLatency: 0.012
-      ),
-      0.023,
-      accuracy: 0.000_1
+      ).isApproximatelyEqual(to: 0.023, absoluteTolerance: 0.000_1)
     )
     #expect(
       anticipatedFinalFrameDispatchDelay(

--- a/Tests/DefiCoreTests/AnimationTests.swift
+++ b/Tests/DefiCoreTests/AnimationTests.swift
@@ -1,9 +1,11 @@
 import DefiCore
 import DefiModel
+import Testing
 import XCTest
 
-final class AnimationTests: XCTestCase {
-  func testSpeculativeNavigationSettlementWaitsPastVisualAnimation() {
+struct AnimationTests {
+  @Test
+  func `Speculative navigation settlement waits past visual animation`() {
     XCTAssertEqual(
       speculativeNavigationSettlementDelay(animationDuration: 0.035),
       0.075,
@@ -16,17 +18,19 @@ final class AnimationTests: XCTestCase {
     )
   }
 
-  func testScrollAnimationUsesEaseOutCubicAndFinishesExactly() {
-    XCTAssertEqual(animatedScalar(from: 0, to: 1, elapsed: 0, duration: 0.08), 0)
+  @Test
+  func `Scroll animation uses ease out cubic and finishes exactly`() {
+    #expect(animatedScalar(from: 0, to: 1, elapsed: 0, duration: 0.08) == 0)
     XCTAssertEqual(
       animatedScalar(from: 0, to: 1, elapsed: 0.04, duration: 0.08),
       0.875,
       accuracy: 0.000_1
     )
-    XCTAssertEqual(animatedScalar(from: 0, to: 1, elapsed: 0.08, duration: 0.08), 1)
+    #expect(animatedScalar(from: 0, to: 1, elapsed: 0.08, duration: 0.08) == 1)
   }
 
-  func testCriticallyDampedSpringConvergesWithoutOvershoot() {
+  @Test
+  func `Critically damped spring converges without overshoot`() {
     var value = 0.0
     var velocity = 0.0
     for _ in 0..<90 {
@@ -37,8 +41,8 @@ final class AnimationTests: XCTestCase {
         deltaTime: 1 / 120,
         response: 0.18
       )
-      XCTAssertGreaterThanOrEqual(step.value, value)
-      XCTAssertLessThanOrEqual(step.value, 500)
+      #expect(step.value >= value)
+      #expect(step.value <= 500)
       value = step.value
       velocity = step.velocity
     }
@@ -46,7 +50,8 @@ final class AnimationTests: XCTestCase {
     XCTAssertEqual(velocity, 0, accuracy: 0.5)
   }
 
-  func testCompletedFrameSpringKeepsMultipleMonotonicSamples() {
+  @Test
+  func `Completed frame spring keeps multiple monotonic samples`() {
     let at120Hz = completedFrameSpringProgresses(
       duration: 0.035,
       refreshRateHz: 120
@@ -56,25 +61,27 @@ final class AnimationTests: XCTestCase {
       refreshRateHz: 60
     )
 
-    XCTAssertEqual(at120Hz.count, 4)
-    XCTAssertEqual(at60Hz.count, 2)
+    #expect(at120Hz.count == 4)
+    #expect(at60Hz.count == 2)
     XCTAssertEqual(at120Hz.first ?? 0, 0.247, accuracy: 0.002)
-    XCTAssertGreaterThan(at120Hz.last ?? 0, 0.85)
-    XCTAssertLessThan(at120Hz.last ?? 1, 1)
-    XCTAssertEqual(at120Hz, at120Hz.sorted())
+    #expect(at120Hz.last ?? 0 > 0.85)
+    #expect(at120Hz.last ?? 1 < 1)
+    #expect(at120Hz == at120Hz.sorted())
   }
 
-  func testCompletedFrameSpringUsesTheFullRefreshBudget() {
+  @Test
+  func `Completed frame spring uses the full refresh budget`() {
     let progresses = completedFrameSpringProgresses(
       duration: 0.08,
       refreshRateHz: 120
     )
 
-    XCTAssertEqual(progresses.count, 9)
-    XCTAssertGreaterThan(progresses.last ?? 0, 0.85)
+    #expect(progresses.count == 9)
+    #expect(progresses.last ?? 0 > 0.85)
   }
 
-  func testRetargetedSpringKeepsForwardVelocityAndRemainsMonotonic() {
+  @Test
+  func `Retargeted spring keeps forward velocity and remains monotonic`() {
     let stationary = completedFrameSpringSamples(
       duration: 0.08,
       refreshRateHz: 120
@@ -85,32 +92,23 @@ final class AnimationTests: XCTestCase {
       initialVelocity: 12
     )
 
-    XCTAssertGreaterThan(
-      retargeted.first?.progress ?? 0,
-      stationary.first?.progress ?? 1
-    )
-    XCTAssertEqual(
-      retargeted.map(\.progress),
-      retargeted.map(\.progress).sorted()
-    )
-    XCTAssertLessThanOrEqual(retargeted.last?.progress ?? 2, 1)
-    XCTAssertEqual(
+    #expect(retargeted.first?.progress ?? 0 > stationary.first?.progress ?? 1)
+    #expect(retargeted.map(\.progress) == retargeted.map(\.progress).sorted())
+    #expect(retargeted.last?.progress ?? 2 <= 1)
+    #expect(
       retainedSpringProgressVelocity(
         normalizedCandidates: [-4, 8, 12, .infinity],
         maximum: 10
-      ),
-      10
-    )
-    XCTAssertEqual(
+      ) == 10)
+    #expect(
       retainedSpringProgressVelocity(
         normalizedCandidates: [-4, -.infinity],
         maximum: 10
-      ),
-      0
-    )
+      ) == 0)
   }
 
-  func testDisplayLinkedSpringSamplingUsesElapsedTimeAndNeverRollsBack() {
+  @Test
+  func `Display linked spring sampling uses elapsed time and never rolls back`() {
     let first = springProgressSample(
       elapsed: 1.0 / 120,
       duration: 0.08
@@ -126,77 +124,66 @@ final class AnimationTests: XCTestCase {
       minimumProgress: delayed.progress
     )
 
-    XCTAssertGreaterThan(first.progress, 0)
-    XCTAssertGreaterThan(delayed.progress, first.progress)
-    XCTAssertEqual(staleTimestamp.progress, delayed.progress)
-    XCTAssertEqual(staleTimestamp.velocity, 0)
-    XCTAssertLessThanOrEqual(staleTimestamp.progress, 1)
+    #expect(first.progress > 0)
+    #expect(delayed.progress > first.progress)
+    #expect(staleTimestamp.progress == delayed.progress)
+    #expect(staleTimestamp.velocity == 0)
+    #expect(staleTimestamp.progress <= 1)
   }
 
-  func testAdaptiveFrameLimitAvoidsMultiplyingSlowAXCalls() {
-    XCTAssertEqual(
+  @Test
+  func `Adaptive frame limit avoids multiplying slow AX calls`() {
+    #expect(
       adaptiveIntermediateFrameLimit(
         predictedFrameLatency: 0.004,
         refreshRateHz: 120,
         availableIntermediateFrames: 4
-      ),
-      4
-    )
-    XCTAssertEqual(
+      ) == 4)
+    #expect(
       adaptiveIntermediateFrameLimit(
         predictedFrameLatency: 0.012,
         refreshRateHz: 120,
         availableIntermediateFrames: 4
-      ),
-      1
-    )
-    XCTAssertEqual(
+      ) == 1)
+    #expect(
       adaptiveIntermediateFrameLimit(
         predictedFrameLatency: 0.030,
         refreshRateHz: 120,
         availableIntermediateFrames: 4
-      ),
-      0
-    )
+      ) == 0)
   }
 
-  func testSpringProgressAnticipatesAXCompletionLatency() {
-    XCTAssertEqual(
+  @Test
+  func `Spring progress anticipates AX completion latency`() {
+    #expect(
       anticipatedSpringProgressIndex(
         predictedFrameLatency: 0.002,
         refreshRateHz: 120,
         availableIntermediateFrames: 4
-      ),
-      0
-    )
-    XCTAssertEqual(
+      ) == 0)
+    #expect(
       anticipatedSpringProgressIndex(
         predictedFrameLatency: 0.018,
         refreshRateHz: 120,
         availableIntermediateFrames: 4
-      ),
-      2
-    )
-    XCTAssertEqual(
+      ) == 2)
+    #expect(
       anticipatedSpringProgressIndex(
         predictedFrameLatency: 0.030,
         refreshRateHz: 120,
         availableIntermediateFrames: 4
-      ),
-      3
-    )
-    XCTAssertEqual(
+      ) == 3)
+    #expect(
       anticipatedSpringProgressIndex(
         predictedFrameLatency: 0.051,
         refreshRateHz: 120,
         availableIntermediateFrames: 4,
         maximumIndex: 1
-      ),
-      1
-    )
+      ) == 1)
   }
 
-  func testCompletedAXFrameSchedulesNextWriteAfterDisplayInterval() {
+  @Test
+  func `Completed AX frame schedules next write after display interval`() {
     XCTAssertEqual(
       nextCompletedFrameDispatchDeadline(
         completedAt: 10,
@@ -215,49 +202,47 @@ final class AnimationTests: XCTestCase {
     )
   }
 
-  func testSlowCompletedFrameSkipsIntermediateThatCannotFitBudget() {
-    XCTAssertTrue(
+  @Test
+  func `Slow completed frame skips intermediate that cannot fit budget`() {
+    #expect(
       shouldEmitAnotherIntermediateFrame(
         elapsed: 0.029,
         predictedFrameLatency: 0.024,
         budget: 0.06,
         completedIntermediateFrames: 1
-      )
-    )
-    XCTAssertFalse(
+      ))
+    #expect(
       shouldEmitAnotherIntermediateFrame(
         elapsed: 0.029,
         predictedFrameLatency: 0.032,
         budget: 0.06,
         completedIntermediateFrames: 1
-      )
-    )
-    XCTAssertTrue(
+      ) == false)
+    #expect(
       shouldEmitAnotherIntermediateFrame(
         elapsed: 0.059,
         predictedFrameLatency: 0.5,
         budget: 0.06,
         completedIntermediateFrames: 0
-      )
-    )
+      ))
   }
 
-  func testSlowCompletedSampleStopsFurtherAXFrames() {
-    XCTAssertTrue(
+  @Test
+  func `Slow completed sample stops further AX frames`() {
+    #expect(
       completedFrameSupportsAnotherSample(
         duration: 0.006,
         refreshRateHz: 120
-      )
-    )
-    XCTAssertFalse(
+      ))
+    #expect(
       completedFrameSupportsAnotherSample(
         duration: 0.020,
         refreshRateHz: 120
-      )
-    )
+      ) == false)
   }
 
-  func testFinalAXFrameIsDispatchedEarlyEnoughToFinishOnAnimationDeadline() {
+  @Test
+  func `Final AX frame is dispatched early enough to finish on animation deadline`() {
     XCTAssertEqual(
       anticipatedFinalFrameDispatchDelay(
         animationDuration: 0.035,
@@ -266,58 +251,49 @@ final class AnimationTests: XCTestCase {
       0.023,
       accuracy: 0.000_1
     )
-    XCTAssertEqual(
+    #expect(
       anticipatedFinalFrameDispatchDelay(
         animationDuration: 0.035,
         predictedFrameLatency: 0.050
-      ),
-      0
-    )
+      ) == 0)
   }
 
-  func testSlowIntermediateFrameDoesNotLeaveAnimationFrozenUntilDeadline() {
-    XCTAssertEqual(
+  @Test
+  func `Slow intermediate frame does not leave animation frozen until deadline`() {
+    #expect(
       finalFrameDispatchDeadline(
         nominalDeadline: 10.08,
         nextDisplayDeadline: 10.025,
         previousFrameWasSlow: true
-      ),
-      10.08
-    )
-    XCTAssertEqual(
+      ) == 10.08)
+    #expect(
       finalFrameDispatchDeadline(
         nominalDeadline: 10.08,
         nextDisplayDeadline: 10.025,
         previousFrameWasSlow: false
-      ),
-      10.08
-    )
-    XCTAssertEqual(
+      ) == 10.08)
+    #expect(
       finalFrameDispatchDeadline(
         nominalDeadline: 10.075,
         nextDisplayDeadline: 10.12,
         previousFrameWasSlow: false,
         hardDeadline: 10.08
-      ),
-      10.08
-    )
+      ) == 10.08)
   }
 
-  func testDisplayedFrameRebaseUsesMedianAndRejectsOutliers() {
-    XCTAssertEqual(
+  @Test
+  func `Displayed frame rebase uses median and rejects outliers`() {
+    #expect(
       rebaseScalarToDisplayedFrames(
         logicalValue: 500,
         expectedMinusDisplayedDeltas: [-82, -80, 4_000],
         maximumAbsoluteDelta: 1_000
-      ),
-      DisplayedScalarRebase(value: 420, delta: -80)
-    )
-    XCTAssertNil(
+      ) == DisplayedScalarRebase(value: 420, delta: -80))
+    #expect(
       rebaseScalarToDisplayedFrames(
         logicalValue: 500,
         expectedMinusDisplayedDeltas: [0.1, 4_000],
         maximumAbsoluteDelta: 1_000
-      )
-    )
+      ) == nil)
   }
 }

--- a/Tests/DefiCoreTests/ParkingTests.swift
+++ b/Tests/DefiCoreTests/ParkingTests.swift
@@ -1,19 +1,21 @@
 import DefiCore
 import DefiModel
-import XCTest
+import Testing
 
-final class ParkingTests: XCTestCase {
-  func testParkingUsesStableUniqueSlots() {
+struct ParkingTests {
+  @Test
+  func `Parking uses stable unique slots`() {
     let diff = parkOffscreen([
       WindowID(rawValue: 1),
       WindowID(rawValue: 2),
     ])
 
-    XCTAssertEqual(diff.frames[0].frame, Rect(x: -10_000, y: -10_000, width: 1, height: 1))
-    XCTAssertEqual(diff.frames[1].frame, Rect(x: -10_000, y: -10_020, width: 1, height: 1))
+    #expect(diff.frames[0].frame == Rect(x: -10_000, y: -10_000, width: 1, height: 1))
+    #expect(diff.frames[1].frame == Rect(x: -10_000, y: -10_020, width: 1, height: 1))
   }
 
-  func testContinuousStripAnchorsEveryOffscreenColumnAndPrefetchesNeighbors() {
+  @Test
+  func `Continuous strip anchors every offscreen column and prefetches neighbors`() {
     let viewport = Rect(x: 0, y: 0, width: 1_000, height: 700)
     let frames = (0..<10).map { index in
       FrameAssignment(
@@ -37,27 +39,22 @@ final class ParkingTests: XCTestCase {
       uniqueKeysWithValues: plan.frames.map { ($0.windowID, $0.frame) }
     )
 
-    XCTAssertEqual(byID[WindowID(rawValue: 4)]?.x, -499)
-    XCTAssertEqual(byID[WindowID(rawValue: 3)]?.x, -499)
-    XCTAssertEqual(byID[WindowID(rawValue: 3)]?.y, 0)
-    XCTAssertEqual(byID[WindowID(rawValue: 9)]?.x, 999)
-    XCTAssertEqual(byID[WindowID(rawValue: 10)]?.x, 999)
-    XCTAssertEqual(byID[WindowID(rawValue: 10)]?.y, 0)
-    XCTAssertTrue(plan.parkedWindowIDs.contains(WindowID(rawValue: 3)))
-    XCTAssertTrue(plan.parkedWindowIDs.contains(WindowID(rawValue: 10)))
-    XCTAssertTrue(plan.parkedWindowIDs.contains(WindowID(rawValue: 4)))
-    XCTAssertTrue(plan.parkedWindowIDs.contains(WindowID(rawValue: 9)))
-    XCTAssertEqual(
-      plan.visibilityByWindowID[WindowID(rawValue: 4)],
-      .prefetched
-    )
-    XCTAssertEqual(
-      plan.visibilityByWindowID[WindowID(rawValue: 3)],
-      .parked
-    )
+    #expect(byID[WindowID(rawValue: 4)]?.x == -499)
+    #expect(byID[WindowID(rawValue: 3)]?.x == -499)
+    #expect(byID[WindowID(rawValue: 3)]?.y == 0)
+    #expect(byID[WindowID(rawValue: 9)]?.x == 999)
+    #expect(byID[WindowID(rawValue: 10)]?.x == 999)
+    #expect(byID[WindowID(rawValue: 10)]?.y == 0)
+    #expect(plan.parkedWindowIDs.contains(WindowID(rawValue: 3)))
+    #expect(plan.parkedWindowIDs.contains(WindowID(rawValue: 10)))
+    #expect(plan.parkedWindowIDs.contains(WindowID(rawValue: 4)))
+    #expect(plan.parkedWindowIDs.contains(WindowID(rawValue: 9)))
+    #expect(plan.visibilityByWindowID[WindowID(rawValue: 4)] == .prefetched)
+    #expect(plan.visibilityByWindowID[WindowID(rawValue: 3)] == .parked)
   }
 
-  func testParkingResolverAvoidsNeighboringMonitor() {
+  @Test
+  func `Parking resolver avoids neighboring monitor`() {
     let owner = Rect(x: 0, y: 0, width: 1_000, height: 700)
     let leftNeighbor = Rect(x: -1_000, y: 0, width: 1_000, height: 700)
     let placement = resolveParkingPlacement(
@@ -67,14 +64,12 @@ final class ParkingTests: XCTestCase {
       preferredSide: .left
     )
 
-    XCTAssertEqual(placement.side, .right)
-    XCTAssertEqual(
-      placement.frame,
-      Rect(x: 999, y: 0, width: 500, height: 700)
-    )
+    #expect(placement.side == .right)
+    #expect(placement.frame == Rect(x: 999, y: 0, width: 500, height: 700))
   }
 
-  func testParkingResolverUsesVerticalLaneAroundStaggeredDisplays() {
+  @Test
+  func `Parking resolver uses vertical lane around staggered displays`() {
     let owner = Rect(x: 1_000, y: 0, width: 1_000, height: 1_000)
     let leftNeighbor = Rect(x: 0, y: 400, width: 1_000, height: 500)
     let rightNeighbor = Rect(x: 2_000, y: 0, width: 1_000, height: 500)
@@ -85,12 +80,9 @@ final class ParkingTests: XCTestCase {
       preferredSide: .left
     )
 
-    XCTAssertGreaterThan(
-      verticalIntersection(placement.frame, owner),
-      0
-    )
-    XCTAssertEqual(intersectionArea(placement.frame, leftNeighbor), 0)
-    XCTAssertEqual(intersectionArea(placement.frame, rightNeighbor), 0)
+    #expect(verticalIntersection(placement.frame, owner) > 0)
+    #expect(intersectionArea(placement.frame, leftNeighbor) == 0)
+    #expect(intersectionArea(placement.frame, rightNeighbor) == 0)
   }
 
   private func intersectionArea(_ lhs: Rect, _ rhs: Rect) -> Double {

--- a/Tests/DefiCoreTests/WindowLayoutTests.swift
+++ b/Tests/DefiCoreTests/WindowLayoutTests.swift
@@ -1,11 +1,12 @@
 import DefiCore
 import DefiModel
-import XCTest
+import Testing
 
-final class WindowLayoutTests: XCTestCase {
+struct WindowLayoutTests {
   private let settings = LayoutSettings()
 
-  func testIntrinsicSizeWindowStaysCenteredInTile() {
+  @Test
+  func `Intrinsic size window stays centered in tile`() {
     var workspace = Workspace(id: WorkspaceID(rawValue: "1"))
     insertNewWindow(
       WindowID(rawValue: 1),
@@ -28,16 +29,16 @@ final class WindowLayoutTests: XCTestCase {
       settings: settings
     )
 
-    XCTAssertEqual(
-      diff.frames[0],
-      FrameAssignment(
-        windowID: WindowID(rawValue: 1),
-        frame: Rect(x: 8, y: 88, width: 304, height: 624)
-      )
-    )
+    #expect(
+      diff.frames[0]
+        == FrameAssignment(
+          windowID: WindowID(rawValue: 1),
+          frame: Rect(x: 8, y: 88, width: 304, height: 624)
+        ))
   }
 
-  func testFrameBatchSkipsUnchangedAssignments() {
+  @Test
+  func `Frame batch skips unchanged assignments`() {
     let first = FrameAssignment(
       windowID: WindowID(rawValue: 1),
       frame: Rect(x: 0, y: 0, width: 500, height: 800)
@@ -53,12 +54,13 @@ final class WindowLayoutTests: XCTestCase {
 
     let batch = planFrameBatch(previous: [first, second], next: [first, moved])
 
-    XCTAssertEqual(batch.frames, [moved])
-    XCTAssertEqual(batch.stats.plannedWrites, 1)
-    XCTAssertEqual(batch.stats.skippedUnchanged, 1)
+    #expect(batch.frames == [moved])
+    #expect(batch.stats.plannedWrites == 1)
+    #expect(batch.stats.skippedUnchanged == 1)
   }
 
-  func testEachViewportProducesItsOwnMonitorSizedLayout() {
+  @Test
+  func `Each viewport produces its own monitor sized layout`() {
     let noGaps = LayoutSettings(
       defaultColumnWidth: 0.8,
       innerHorizontalGap: 0,
@@ -84,11 +86,8 @@ final class WindowLayoutTests: XCTestCase {
       settings: noGaps
     ).frames[0].frame
 
-    XCTAssertEqual(laptop, Rect(x: 0, y: 0, width: 1_200, height: 900))
-    XCTAssertEqual(
-      external,
-      Rect(x: 1_500, y: 30, width: 2_048, height: 1_362)
-    )
+    #expect(laptop == Rect(x: 0, y: 0, width: 1_200, height: 900))
+    #expect(external == Rect(x: 1_500, y: 30, width: 2_048, height: 1_362))
   }
 
 }

--- a/Tests/DefiCoreTests/WorkspaceScrollingTests.swift
+++ b/Tests/DefiCoreTests/WorkspaceScrollingTests.swift
@@ -1,7 +1,7 @@
 import DefiCore
 import DefiModel
+import Numerics
 import Testing
-import XCTest
 
 struct WorkspaceScrollingTests {
   private let settings = LayoutSettings()
@@ -21,8 +21,15 @@ struct WorkspaceScrollingTests {
       settings: compact
     )
 
-    XCTAssertEqual(workspace.targetScrollOffset, 0.44, accuracy: 0.001)
-    XCTAssertEqual(diff.frames[1].frame.x, 407.2, accuracy: 0.001)
+    #expect(
+      workspace.targetScrollOffset.isApproximatelyEqual(
+        to: 0.44,
+        absoluteTolerance: 0.001
+      )
+    )
+    #expect(
+      diff.frames[1].frame.x.isApproximatelyEqual(to: 407.2, absoluteTolerance: 0.001)
+    )
   }
 
   @Test
@@ -37,25 +44,22 @@ struct WorkspaceScrollingTests {
       columns: columns,
       focusedColumn: 1
     )
-    XCTAssertEqual(
-      focusedColumnScrollOffset(workspace: workspace, viewport: viewport),
-      0,
-      accuracy: 0.001
+    #expect(
+      focusedColumnScrollOffset(workspace: workspace, viewport: viewport)
+        .isApproximatelyEqual(to: 0, absoluteTolerance: 0.001)
     )
 
     workspace.focusedColumn = 2
-    XCTAssertEqual(
-      focusedColumnScrollOffset(workspace: workspace, viewport: viewport),
-      0.5,
-      accuracy: 0.001
+    #expect(
+      focusedColumnScrollOffset(workspace: workspace, viewport: viewport)
+        .isApproximatelyEqual(to: 0.5, absoluteTolerance: 0.001)
     )
 
     workspace.focusedColumn = 3
     workspace.scrollOffset = 0.5
-    XCTAssertEqual(
-      focusedColumnScrollOffset(workspace: workspace, viewport: viewport),
-      1,
-      accuracy: 0.001
+    #expect(
+      focusedColumnScrollOffset(workspace: workspace, viewport: viewport)
+        .isApproximatelyEqual(to: 1, absoluteTolerance: 0.001)
     )
   }
 
@@ -85,8 +89,15 @@ struct WorkspaceScrollingTests {
       settings: centered
     )
 
-    XCTAssertEqual(workspace.targetScrollOffset, 0.25, accuracy: 0.001)
-    XCTAssertEqual(diff.frames[1].frame.x, 250, accuracy: 0.001)
+    #expect(
+      workspace.targetScrollOffset.isApproximatelyEqual(
+        to: 0.25,
+        absoluteTolerance: 0.001
+      )
+    )
+    #expect(
+      diff.frames[1].frame.x.isApproximatelyEqual(to: 250, absoluteTolerance: 0.001)
+    )
   }
 
 }

--- a/Tests/DefiCoreTests/WorkspaceScrollingTests.swift
+++ b/Tests/DefiCoreTests/WorkspaceScrollingTests.swift
@@ -1,11 +1,13 @@
 import DefiCore
 import DefiModel
+import Testing
 import XCTest
 
-final class WorkspaceScrollingTests: XCTestCase {
+struct WorkspaceScrollingTests {
   private let settings = LayoutSettings()
 
-  func testFocusScrollsOnlyEnoughForOverflow() throws {
+  @Test
+  func `Focus scrolls only enough for overflow`() throws {
     let compact = LayoutSettings(defaultColumnWidth: 0.72)
     var workspace = Workspace(id: WorkspaceID(rawValue: "1"))
     insertNewWindow(WindowID(rawValue: 1), into: &workspace, settings: compact)
@@ -23,7 +25,8 @@ final class WorkspaceScrollingTests: XCTestCase {
     XCTAssertEqual(diff.frames[1].frame.x, 407.2, accuracy: 0.001)
   }
 
-  func testNeverCenteringPreservesVisibleColumn() {
+  @Test
+  func `Never centering preserves visible column`() {
     let viewport = Rect(x: 0, y: 0, width: 1_000, height: 700)
     let columns = (1...4).map {
       Column(window: WindowID(rawValue: UInt64($0)), width: .fraction(0.5))
@@ -56,7 +59,8 @@ final class WorkspaceScrollingTests: XCTestCase {
     )
   }
 
-  func testAlwaysCenteringCentersTarget() throws {
+  @Test
+  func `Always centering centers target`() throws {
     let centered = LayoutSettings(
       defaultColumnWidth: 0.5,
       centerFocusedColumn: .always,

--- a/Tests/DefiCoreTests/WorkspaceTests.swift
+++ b/Tests/DefiCoreTests/WorkspaceTests.swift
@@ -1,111 +1,116 @@
 import DefiCore
 import DefiModel
-import XCTest
+import Testing
 
-final class WorkspaceTests: XCTestCase {
+struct WorkspaceTests {
   private let settings = LayoutSettings()
 
-  func testNewWindowInsertsAfterFocusedColumn() {
+  @Test
+  func `New window inserts after focused column`() {
     var workspace = Workspace(id: WorkspaceID(rawValue: "1"))
     insertNewWindow(WindowID(rawValue: 1), into: &workspace, settings: settings)
     insertNewWindow(WindowID(rawValue: 2), into: &workspace, settings: settings)
     workspace.focusedColumn = 0
     insertNewWindow(WindowID(rawValue: 3), into: &workspace, settings: settings)
 
-    XCTAssertEqual(
-      workspace.columns.map(\.windows[0]),
-      [WindowID(rawValue: 1), WindowID(rawValue: 3), WindowID(rawValue: 2)]
-    )
-    XCTAssertEqual(workspace.focusedColumn, 1)
+    #expect(
+      workspace.columns.map(\.windows[0]) == [
+        WindowID(rawValue: 1), WindowID(rawValue: 3), WindowID(rawValue: 2),
+      ])
+    #expect(workspace.focusedColumn == 1)
   }
 
-  func testMoveFocusedWindowSwapsColumns() throws {
+  @Test
+  func `Move focused window swaps columns`() throws {
     var workspace = Workspace(id: WorkspaceID(rawValue: "1"))
     insertNewWindow(WindowID(rawValue: 1), into: &workspace, settings: settings)
     insertNewWindow(WindowID(rawValue: 2), into: &workspace, settings: settings)
 
     try moveFocusedWindow(.left, in: &workspace, settings: settings)
 
-    XCTAssertEqual(
-      workspace.columns.map(\.windows[0]),
-      [WindowID(rawValue: 2), WindowID(rawValue: 1)]
-    )
-    XCTAssertEqual(workspace.focusedColumn, 0)
+    #expect(workspace.columns.map(\.windows[0]) == [WindowID(rawValue: 2), WindowID(rawValue: 1)])
+    #expect(workspace.focusedColumn == 0)
   }
 
-  func testRemovingLastWindowRepairsFocus() {
+  @Test
+  func `Removing last window repairs focus`() {
     var workspace = Workspace(id: WorkspaceID(rawValue: "1"))
     insertNewWindow(WindowID(rawValue: 1), into: &workspace, settings: settings)
     insertNewWindow(WindowID(rawValue: 2), into: &workspace, settings: settings)
 
-    XCTAssertTrue(
-      removeWindow(WindowID(rawValue: 2), from: &workspace, settings: settings)
-    )
-    XCTAssertEqual(workspace.columns.count, 1)
-    XCTAssertEqual(workspace.focusedColumn, 0)
+    #expect(removeWindow(WindowID(rawValue: 2), from: &workspace, settings: settings))
+    #expect(workspace.columns.count == 1)
+    #expect(workspace.focusedColumn == 0)
   }
 
-  func testJoinAndUnjoinRoundTrip() throws {
+  @Test
+  func `Join and unjoin round trip`() throws {
     var workspace = Workspace(id: WorkspaceID(rawValue: "1"))
     insertNewWindow(WindowID(rawValue: 1), into: &workspace, settings: settings)
     insertNewWindow(WindowID(rawValue: 2), into: &workspace, settings: settings)
 
     try joinFocusedWindow(.left, in: &workspace, settings: settings)
-    XCTAssertEqual(workspace.columns.count, 1)
-    XCTAssertEqual(
-      workspace.columns[0].windows,
-      [WindowID(rawValue: 1), WindowID(rawValue: 2)]
-    )
-    XCTAssertEqual(workspace.columns[0].focusedWindow, 1)
+    #expect(workspace.columns.count == 1)
+    #expect(workspace.columns[0].windows == [WindowID(rawValue: 1), WindowID(rawValue: 2)])
+    #expect(workspace.columns[0].focusedWindow == 1)
 
     try unjoinFocusedWindow(in: &workspace, settings: settings)
-    XCTAssertEqual(workspace.columns.count, 2)
-    XCTAssertEqual(workspace.columns[1].windows, [WindowID(rawValue: 2)])
-    XCTAssertEqual(workspace.focusedColumn, 1)
+    #expect(workspace.columns.count == 2)
+    #expect(workspace.columns[1].windows == [WindowID(rawValue: 2)])
+    #expect(workspace.focusedColumn == 1)
   }
 
-  func testMaximizedColumnRestoresPixelWidth() {
+  @Test
+  func `Maximized column restores pixel width`() {
     var column = Column(window: WindowID(rawValue: 1), width: .pixels(420))
 
     maximizeColumn(&column, defaultWidth: 0.8)
-    XCTAssertEqual(column.width, .fraction(1))
-    XCTAssertEqual(column.preMaximizedWidth, .pixels(420))
+    #expect(column.width == .fraction(1))
+    #expect(column.preMaximizedWidth == .pixels(420))
 
     maximizeColumn(&column, defaultWidth: 0.8)
-    XCTAssertEqual(column.width, .pixels(420))
-    XCTAssertNil(column.preMaximizedWidth)
+    #expect(column.width == .pixels(420))
+    #expect(column.preMaximizedWidth == nil)
   }
 
-  func testCyclingForwardFromMaximizedUsesFirstPreset() {
+  @Test(arguments: [
+    (
+      Direction.next,
+      [1.0, 0.33, 0.5, 0.66, 0.8],
+      ColumnWidth.fraction(0.33),
+      nil
+    ),
+    (
+      Direction.previous,
+      [0.33, 0.5, 0.66, 0.8, 1.0],
+      ColumnWidth.fraction(0.8),
+      nil
+    ),
+    (
+      Direction.previous,
+      [1.0],
+      ColumnWidth.fraction(1),
+      ColumnWidth.fraction(0.5)
+    ),
+  ])
+  func `Cycling from maximized selects the expected preset`(
+    testCase: (
+      direction: Direction,
+      presets: [Double],
+      expectedWidth: ColumnWidth,
+      expectedPreviousWidth: ColumnWidth?
+    )
+  ) {
     var column = Column(window: WindowID(rawValue: 1), width: .fraction(0.5))
-    let presets = [1.0, 0.33, 0.5, 0.66, 0.8]
 
     maximizeColumn(&column, defaultWidth: 0.8)
-    cycleWidth(of: &column, direction: .next, presets: presets)
+    cycleWidth(
+      of: &column,
+      direction: testCase.direction,
+      presets: testCase.presets
+    )
 
-    XCTAssertEqual(column.width, .fraction(0.33))
-    XCTAssertNil(column.preMaximizedWidth)
+    #expect(column.width == testCase.expectedWidth)
+    #expect(column.preMaximizedWidth == testCase.expectedPreviousWidth)
   }
-
-  func testCyclingBackwardFromMaximizedUsesLastPreset() {
-    var column = Column(window: WindowID(rawValue: 1), width: .fraction(0.5))
-    let presets = [0.33, 0.5, 0.66, 0.8, 1.0]
-
-    maximizeColumn(&column, defaultWidth: 0.8)
-    cycleWidth(of: &column, direction: .previous, presets: presets)
-
-    XCTAssertEqual(column.width, .fraction(0.8))
-    XCTAssertNil(column.preMaximizedWidth)
-  }
-
-  func testCyclingFromMaximizedWithOnlyFullWidthPresetDoesNothing() {
-    var column = Column(window: WindowID(rawValue: 1), width: .fraction(0.5))
-
-    maximizeColumn(&column, defaultWidth: 0.8)
-    cycleWidth(of: &column, direction: .previous, presets: [1.0])
-
-    XCTAssertEqual(column.width, .fraction(1))
-    XCTAssertEqual(column.preMaximizedWidth, .fraction(0.5))
-  }
-
 }

--- a/Tests/DefiDaemonTests/DaemonCommandPolicyTests.swift
+++ b/Tests/DefiDaemonTests/DaemonCommandPolicyTests.swift
@@ -66,12 +66,11 @@ struct DaemonCommandPolicyTests {
       )
     )
     #expect(
-      !commandFollowUpIsPending(
+      commandFollowUpIsPending(
         frameWrites: false,
         animatedFocus: false,
         workspaceFocus: false
-      )
-    )
+      ) == false)
   }
 
   @Test

--- a/Tests/DefiDaemonTests/DaemonReadResponseCacheTests.swift
+++ b/Tests/DefiDaemonTests/DaemonReadResponseCacheTests.swift
@@ -1,48 +1,50 @@
 import DefiIPC
-import XCTest
+import Testing
 
 @testable import DefiDaemon
 
-final class DaemonReadResponseCacheTests: XCTestCase {
-  func testStoresAndServesReadResponsesWithinTTL() {
+struct DaemonReadResponseCacheTests {
+  @Test
+  func `Stores and serves read responses within TTL`() {
     let cache = DaemonReadResponseCache(maxAge: 0.25)
 
-    XCTAssertNil(cache.response(for: "status", now: 10))
+    #expect(cache.response(for: "status", now: 10) == nil)
     cache.store(message: "running", for: "status", now: 10)
 
-    XCTAssertEqual(
-      cache.response(for: "status", now: 10.2),
-      .success("running")
-    )
+    #expect(cache.response(for: "status", now: 10.2) == .success("running"))
   }
 
-  func testExpiresResponsesAfterTTL() {
+  @Test
+  func `Expires responses after TTL`() {
     let cache = DaemonReadResponseCache(maxAge: 0.25)
     cache.store(message: "running", for: "status", now: 10)
 
-    XCTAssertNil(cache.response(for: "status", now: 10.26))
+    #expect(cache.response(for: "status", now: 10.26) == nil)
   }
 
-  func testKeysAreIsolatedPerCommand() {
+  @Test
+  func `Keys are isolated per command`() {
     let cache = DaemonReadResponseCache(maxAge: 1)
     cache.store(message: "a", for: "status", now: 10)
     cache.store(message: "b", for: "trace", now: 10)
 
-    XCTAssertEqual(
-      cache.response(for: "status", now: 10.5),
-      .success("a")
-    )
-    XCTAssertEqual(
-      cache.response(for: "trace", now: 10.5),
-      .success("b")
-    )
-    XCTAssertNil(cache.response(for: "list-workspaces", now: 10.5))
+    #expect(cache.response(for: "status", now: 10.5) == .success("a"))
+    #expect(cache.response(for: "trace", now: 10.5) == .success("b"))
+    #expect(cache.response(for: "list-workspaces", now: 10.5) == nil)
   }
 
-  func testOnlyReadCommandsAreCacheable() {
-    XCTAssertTrue(DaemonReadResponseCache.isReadCommand("status"))
-    XCTAssertTrue(DaemonReadResponseCache.isReadCommand("list-workspaces --json"))
-    XCTAssertFalse(DaemonReadResponseCache.isReadCommand("focus-column left"))
-    XCTAssertFalse(DaemonReadResponseCache.isReadCommand("quit"))
+  @Test(arguments: [
+    ("status", true),
+    ("list-workspaces --json", true),
+    ("focus-column left", false),
+    ("quit", false),
+  ])
+  func `Only read commands are cacheable`(
+    testCase: (command: String, expected: Bool)
+  ) {
+    #expect(
+      DaemonReadResponseCache.isReadCommand(testCase.command)
+        == testCase.expected
+    )
   }
 }

--- a/Tests/DefiDaemonTests/DiagnosticRecorderTests.swift
+++ b/Tests/DefiDaemonTests/DiagnosticRecorderTests.swift
@@ -50,8 +50,8 @@ struct DiagnosticRecorderTests {
     #expect(lines.count == 2)
     #expect(contents.contains("\"applicationID\":\"com.example.Editor\""))
     #expect(contents.contains("\"kind\":\"marker\""))
-    #expect(!contents.contains("windowTitle"))
-    #expect(!contents.contains("document"))
+    #expect(contents.contains("windowTitle") == false)
+    #expect(contents.contains("document") == false)
   }
 
   @Test

--- a/Tests/DefiIPCTests/IPCTests.swift
+++ b/Tests/DefiIPCTests/IPCTests.swift
@@ -1,32 +1,32 @@
-@testable import DefiIPC
 import Darwin
 import Foundation
 import Synchronization
 import Testing
-import XCTest
 
-final class IPCTests: XCTestCase {
-  func testProtocolRoundTrip() throws {
+@testable import DefiIPC
+
+struct IPCTests {
+  @Test
+  func `Protocol round trip`() throws {
     let request = CommandRequest(command: "focus-column left")
     let requestData = try JSONEncoder().encode(request)
-    XCTAssertEqual(try JSONDecoder().decode(CommandRequest.self, from: requestData), request)
+    #expect(try JSONDecoder().decode(CommandRequest.self, from: requestData) == request)
 
     let response = CommandResponse.success("moved")
     let responseData = try JSONEncoder().encode(response)
-    XCTAssertEqual(
-      try JSONDecoder().decode(CommandResponse.self, from: responseData),
-      response
-    )
+    #expect(try JSONDecoder().decode(CommandResponse.self, from: responseData) == response)
   }
 
-  func testDefaultSocketPathIsPerUser() {
-    XCTAssertTrue(SocketPath.defaultURL.lastPathComponent.hasPrefix("defi-"))
-    XCTAssertEqual(SocketPath.defaultURL.pathExtension, "sock")
+  @Test
+  func `Default socket path is per user`() {
+    #expect(SocketPath.defaultURL.lastPathComponent.hasPrefix("defi-"))
+    #expect(SocketPath.defaultURL.pathExtension == "sock")
   }
 
-  func testClosedPeerReturnsBrokenPipeInsteadOfTerminatingProcess() throws {
+  @Test
+  func `Closed peer returns broken pipe instead of terminating process`() throws {
     var descriptors = [Int32](repeating: -1, count: 2)
-    XCTAssertEqual(socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors), 0)
+    #expect(socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors) == 0)
     defer {
       if descriptors[0] >= 0 { Darwin.close(descriptors[0]) }
       if descriptors[1] >= 0 { Darwin.close(descriptors[1]) }
@@ -35,28 +35,33 @@ final class IPCTests: XCTestCase {
     Darwin.close(descriptors[1])
     descriptors[1] = -1
 
-    XCTAssertThrowsError(try writeAll(Data("request\n".utf8), to: descriptors[0])) {
-      guard case IPCError.systemCall("write", EPIPE) = $0 else {
-        return XCTFail("expected EPIPE, got \($0)")
-      }
+    let capturedError = #expect(throws: IPCError.self) {
+      try writeAll(Data("request\n".utf8), to: descriptors[0])
+    }
+    let error = try #require(capturedError)
+    guard case IPCError.systemCall("write", EPIPE) = error else {
+      Issue.record("expected EPIPE, got \(error)")
+      return
     }
   }
 
-  func testAcceptedClientCanBeRestoredToBlockingMode() throws {
+  @Test
+  func `Accepted client can be restored to blocking mode`() throws {
     let descriptor = socket(AF_UNIX, SOCK_STREAM, 0)
-    XCTAssertGreaterThanOrEqual(descriptor, 0)
+    #expect(descriptor >= 0)
     defer { Darwin.close(descriptor) }
     let flags = fcntl(descriptor, F_GETFL)
-    XCTAssertEqual(fcntl(descriptor, F_SETFL, flags | O_NONBLOCK), 0)
+    #expect(fcntl(descriptor, F_SETFL, flags | O_NONBLOCK) == 0)
 
     try configureBlocking(descriptor)
 
-    XCTAssertEqual(fcntl(descriptor, F_GETFL) & O_NONBLOCK, 0)
+    #expect(fcntl(descriptor, F_GETFL) & O_NONBLOCK == 0)
   }
 
-  func testReadTimeoutIsConfigured() throws {
+  @Test
+  func `Read timeout is configured`() throws {
     var descriptors = [Int32](repeating: -1, count: 2)
-    XCTAssertEqual(socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors), 0)
+    #expect(socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors) == 0)
     defer {
       if descriptors[0] >= 0 { Darwin.close(descriptors[0]) }
       if descriptors[1] >= 0 { Darwin.close(descriptors[1]) }
@@ -66,17 +71,15 @@ final class IPCTests: XCTestCase {
 
     var timeout = timeval(tv_sec: 0, tv_usec: 0)
     var length = socklen_t(MemoryLayout<timeval>.size)
-    XCTAssertEqual(
+    #expect(
       getsockopt(
         descriptors[0],
         SOL_SOCKET,
         SO_RCVTIMEO,
         &timeout,
         &length
-      ),
-      0
-    )
-    XCTAssertGreaterThan(timeout.tv_sec, 0)
+      ) == 0)
+    #expect(timeout.tv_sec > 0)
   }
 }
 

--- a/Tests/DefiMacOSTests/BudgetedFreshReadPartitionTests.swift
+++ b/Tests/DefiMacOSTests/BudgetedFreshReadPartitionTests.swift
@@ -1,9 +1,11 @@
+import Darwin
 import DefiModel
-import XCTest
+import Foundation
+import Testing
 
 @testable import DefiMacOS
 
-final class BudgetedFreshReadPartitionTests: XCTestCase {
+struct BudgetedFreshReadPartitionTests {
   private func partition(
     requested: Set<pid_t>,
     deferred: Set<pid_t> = [],
@@ -30,31 +32,34 @@ final class BudgetedFreshReadPartitionTests: XCTestCase {
     )
   }
 
-  func testServesCheapestProcessesFirstWithinBudget() {
+  @Test
+  func `Serves cheapest processes first within budget`() {
     let result = partition(
       requested: [1, 2, 3, 4],
       latencies: [1: 2, 2: 4, 3: 8, 4: 120],
       budget: 12
     )
 
-    XCTAssertEqual(result.allowedNow, [1, 2])
-    XCTAssertEqual(result.stillDeferred, [3, 4])
-    XCTAssertEqual(result.deferredSince, 100)
+    #expect(result.allowedNow == [1, 2])
+    #expect(result.stillDeferred == [3, 4])
+    #expect(result.deferredSince == 100)
   }
 
-  func testAlwaysServesAtLeastOneProcessPerPass() {
+  @Test
+  func `Always serves at least one process per pass`() {
     let result = partition(
       requested: [7],
       latencies: [7: 500],
       budget: 12
     )
 
-    XCTAssertEqual(result.allowedNow, [7])
-    XCTAssertTrue(result.stillDeferred.isEmpty)
-    XCTAssertNil(result.deferredSince)
+    #expect(result.allowedNow == [7])
+    #expect(result.stillDeferred.isEmpty)
+    #expect(result.deferredSince == nil)
   }
 
-  func testEventPendingProcessesBypassTheBudget() {
+  @Test
+  func `Event pending processes bypass the budget`() {
     let result = partition(
       requested: [1, 2, 3],
       eventPending: [3],
@@ -62,11 +67,12 @@ final class BudgetedFreshReadPartitionTests: XCTestCase {
       budget: 6
     )
 
-    XCTAssertEqual(result.allowedNow, [1, 2, 3])
-    XCTAssertTrue(result.stillDeferred.isEmpty)
+    #expect(result.allowedNow == [1, 2, 3])
+    #expect(result.stillDeferred.isEmpty)
   }
 
-  func testDeferredAgeFlushServesEverythingAndClearsTimestamp() {
+  @Test
+  func `Deferred age flush serves everything and clears timestamp`() {
     let result = partition(
       requested: [9],
       deferred: [4, 5],
@@ -75,31 +81,33 @@ final class BudgetedFreshReadPartitionTests: XCTestCase {
       now: 100
     )
 
-    XCTAssertEqual(result.allowedNow, [4, 5, 9])
-    XCTAssertTrue(result.stillDeferred.isEmpty)
-    XCTAssertNil(result.deferredSince)
+    #expect(result.allowedNow == [4, 5, 9])
+    #expect(result.stillDeferred.isEmpty)
+    #expect(result.deferredSince == nil)
   }
 
-  func testEmptyPendingClearsDeferralTimestamp() {
+  @Test
+  func `Empty pending clears deferral timestamp`() {
     let result = partition(
       requested: [],
       deferred: [],
       deferredSince: 90
     )
 
-    XCTAssertTrue(result.allowedNow.isEmpty)
-    XCTAssertTrue(result.stillDeferred.isEmpty)
-    XCTAssertNil(result.deferredSince)
+    #expect(result.allowedNow.isEmpty)
+    #expect(result.stillDeferred.isEmpty)
+    #expect(result.deferredSince == nil)
   }
 
-  func testDeferredProcessesKeepTheirOriginalDeferralTimestamp() {
+  @Test
+  func `Deferred processes keep their original deferral timestamp`() {
     let first = partition(
       requested: [1, 2],
       latencies: [1: 2, 2: 120],
       deferredSince: nil,
       now: 100
     )
-    XCTAssertEqual(first.deferredSince, 100)
+    #expect(first.deferredSince == 100)
 
     // Progress guarantee: the single deferred process is always served on
     // the next pass even though it exceeds the budget alone.
@@ -110,6 +118,6 @@ final class BudgetedFreshReadPartitionTests: XCTestCase {
       deferredSince: first.deferredSince,
       now: 100.2
     )
-    XCTAssertNil(second.deferredSince)
+    #expect(second.deferredSince == nil)
   }
 }

--- a/Tests/DefiMacOSTests/CursorTests.swift
+++ b/Tests/DefiMacOSTests/CursorTests.swift
@@ -164,11 +164,10 @@ struct CursorTests {
   @Test
   func rawPointerWindowTransitionsInvalidateHitTestCache() {
     #expect(
-      !pointerRawWindowTransitionRequiresRefresh(
+      pointerRawWindowTransitionRequiresRefresh(
         previousRawWindowID: nil,
         currentRawWindowID: nil
-      )
-    )
+      ) == false)
     #expect(
       pointerRawWindowTransitionRequiresRefresh(
         previousRawWindowID: WindowID(rawValue: 1),
@@ -206,21 +205,19 @@ struct CursorTests {
   @Test
   func newerGeneralInputOrHeldButtonRejectsWarp() {
     #expect(
-      !cursorWarpIsCurrent(
+      cursorWarpIsCurrent(
         latestPointerMotionTimestamp: 10,
         latestUserInputTimestamp: 12,
         maximumInputTimestamp: 11,
         mouseButtonDown: false
-      )
-    )
+      ) == false)
     #expect(
-      !cursorWarpIsCurrent(
+      cursorWarpIsCurrent(
         latestPointerMotionTimestamp: 10,
         latestUserInputTimestamp: 10,
         maximumInputTimestamp: 11,
         mouseButtonDown: true
-      )
-    )
+      ) == false)
   }
 
   @Test
@@ -232,7 +229,7 @@ struct CursorTests {
         }
       )
     }
-    #expect(!anyMouseButtonIsDown { _ in false })
+    #expect(anyMouseButtonIsDown { _ in false } == false)
   }
 
   @Test

--- a/Tests/DefiMacOSTests/FrameCommitTests.swift
+++ b/Tests/DefiMacOSTests/FrameCommitTests.swift
@@ -2,9 +2,9 @@ import ApplicationServices
 import Darwin
 import DefiCore
 import DefiModel
+import Numerics
 import Synchronization
 import Testing
-import XCTest
 
 @testable import DefiMacOS
 
@@ -719,33 +719,27 @@ struct FrameCommitTests {
 
   @Test
   func `Initial window commit uses short quarantine for fast retries`() {
-    XCTAssertEqual(
+    #expect(
       frameCommitQuarantineDuration(
         animationDuration: 0,
         initialFrameSettlement: true
-      ),
-      0.18,
-      accuracy: 0.000_1
+      ).isApproximatelyEqual(to: 0.18, absoluteTolerance: 0.000_1)
     )
-    XCTAssertEqual(
+    #expect(
       frameCommitQuarantineDuration(
         animationDuration: 0,
         initialFrameSettlement: false
-      ),
-      0.8,
-      accuracy: 0.000_1
+      ).isApproximatelyEqual(to: 0.8, absoluteTolerance: 0.000_1)
     )
   }
 
   @Test
   func `Initial window commit still covers animation`() {
-    XCTAssertEqual(
+    #expect(
       frameCommitQuarantineDuration(
         animationDuration: 0.35,
         initialFrameSettlement: true
-      ),
-      0.47,
-      accuracy: 0.000_1
+      ).isApproximatelyEqual(to: 0.47, absoluteTolerance: 0.000_1)
     )
   }
 
@@ -844,10 +838,9 @@ struct FrameCommitTests {
 
   @Test
   func `Initial settlement schedules stable follow up before expiration`() {
-    XCTAssertEqual(
-      initialSettlementFollowUpDelay(now: 12.1, deadline: 12.5)!,
-      0.06,
-      accuracy: 0.000_1
+    #expect(
+      initialSettlementFollowUpDelay(now: 12.1, deadline: 12.5)!
+        .isApproximatelyEqual(to: 0.06, absoluteTolerance: 0.000_1)
     )
     #expect(initialSettlementFollowUpDelay(now: 12.48, deadline: 12.5) == nil)
     #expect(initialSettlementFollowUpDelay(now: 12.5, deadline: 12.5) == nil)

--- a/Tests/DefiMacOSTests/FrameCommitTests.swift
+++ b/Tests/DefiMacOSTests/FrameCommitTests.swift
@@ -1,13 +1,14 @@
+import ApplicationServices
+import Darwin
 import DefiCore
 import DefiModel
-import Darwin
-import ApplicationServices
 import Synchronization
+import Testing
 import XCTest
 
 @testable import DefiMacOS
 
-final class FrameCommitTests: XCTestCase {
+struct FrameCommitTests {
   private let expectation = FrameCommitExpectation(
     from: Rect(x: 900, y: 40, width: 800, height: 700),
     target: Rect(x: 100, y: 40, width: 800, height: 700),
@@ -16,23 +17,23 @@ final class FrameCommitTests: XCTestCase {
     observedAt: nil
   )
 
-  func testReverseRetargetUsesLastCompletedPositionDuringObservationLag() {
+  @Test
+  func `Reverse retarget uses last completed position during observation lag`() {
     let staleObserved = Rect(x: 900, y: 40, width: 800, height: 700)
     let completed = CGPoint(x: 100, y: 40)
 
-    XCTAssertEqual(
+    #expect(
       frameApplicationReference(
         pendingCorrection: nil,
         settlingReference: staleObserved,
         completedPosition: completed,
         previousTarget: Rect(x: 100, y: 40, width: 800, height: 700),
         nativeReference: nil
-      ),
-      Rect(x: 100, y: 40, width: 800, height: 700)
-    )
+      ) == Rect(x: 100, y: 40, width: 800, height: 700))
   }
 
-  func testFrameApplicationReferenceDoesNotReadNativeFrameWhenCached() {
+  @Test
+  func `Frame application reference does not read native frame when cached`() {
     var nativeFrameWasRead = false
 
     _ = frameApplicationReference(
@@ -46,95 +47,94 @@ final class FrameCommitTests: XCTestCase {
       }()
     )
 
-    XCTAssertFalse(nativeFrameWasRead)
+    #expect(nativeFrameWasRead == false)
   }
 
-  func testDeferredFrameCorrectionSurvivesSnapshotRebuild() {
+  @Test
+  func `Deferred frame correction survives snapshot rebuild`() {
     let windowID = WindowID(rawValue: 42)
     let deferred = Rect(x: 900, y: 40, width: 800, height: 700)
     let fresh = Rect(x: 100, y: 40, width: 800, height: 700)
 
-    XCTAssertEqual(
+    #expect(
       frameCorrectionsPreservingDebt(
         existing: [windowID: deferred],
         observed: [:],
         debtWindowIDs: [windowID]
-      )[windowID],
-      deferred
-    )
-    XCTAssertEqual(
+      )[windowID] == deferred)
+    #expect(
       frameCorrectionsPreservingDebt(
         existing: [windowID: deferred],
         observed: [windowID: fresh],
         debtWindowIDs: [windowID]
-      )[windowID],
-      fresh
-    )
+      )[windowID] == fresh)
   }
 
-  func testDisplayLinkActivationRejectsOlderGenerationAndStaleRequest() {
-    XCTAssertTrue(
+  @Test
+  func `Display link activation rejects older generation and stale request`() {
+    #expect(
       displayLinkActivationIsCurrent(
         generation: 4,
         latestGeneration: 4,
         requestID: 8,
         latestRequestID: 8
-      )
-    )
-    XCTAssertFalse(
+      ))
+    #expect(
       displayLinkActivationIsCurrent(
         generation: 3,
         latestGeneration: 4,
         requestID: 7,
         latestRequestID: 8
-      )
-    )
-    XCTAssertFalse(
+      ) == false)
+    #expect(
       displayLinkActivationIsCurrent(
         generation: 4,
         latestGeneration: 4,
         requestID: 7,
         latestRequestID: 8
-      )
-    )
+      ) == false)
   }
 
-  func testDeferredParkingKeepsCoordinatorBusyUntilInvalidated() {
+  @Test
+  func `Deferred parking keeps coordinator busy until invalidated`() {
     let coordinator = AXFrameCoordinator()
     coordinator.deferredParkingWriteGenerations[WindowID(rawValue: 42)] = 3
 
-    XCTAssertTrue(coordinator.isBusy)
-    XCTAssertTrue(coordinator.hasPendingDeferredParkingWrites)
-    XCTAssertTrue(coordinator.isBusy(for: WindowID(rawValue: 42)))
-    XCTAssertFalse(coordinator.isBusy(for: WindowID(rawValue: 43)))
+    #expect(coordinator.isBusy)
+    #expect(coordinator.hasPendingDeferredParkingWrites)
+    #expect(coordinator.isBusy(for: WindowID(rawValue: 42)))
+    #expect(coordinator.isBusy(for: WindowID(rawValue: 43)) == false)
 
     coordinator.invalidate(reason: "mouse-gesture")
 
-    XCTAssertFalse(coordinator.isBusy)
-    XCTAssertFalse(coordinator.hasPendingDeferredParkingWrites)
+    #expect(coordinator.isBusy == false)
+    #expect(coordinator.hasPendingDeferredParkingWrites == false)
   }
 
-  func testStaticSettlementSamplesCanExitTheSlowLane() {
+  @Test
+  func `Static settlement samples can exit the slow lane`() {
     let coordinator = AXFrameCoordinator()
     coordinator.predictedProcessLatencyMS[42] = 12
     coordinator.latencySensitiveProcessIDs.insert(42)
 
     coordinator.recordProcessLatencySamples([42: 0])
 
-    XCTAssertFalse(coordinator.latencySensitiveProcessIDs.contains(42))
+    #expect(coordinator.latencySensitiveProcessIDs.contains(42) == false)
   }
 
-  func testExitedProcessesAreRemovedFromSlowLaneDiagnostics() {
+  @Test
+  func `Exited processes are removed from slow lane diagnostics`() {
     let coordinator = AXFrameCoordinator()
     coordinator.predictedProcessLatencyMS = [42: 20, 43: 18]
     coordinator.latencySensitiveProcessIDs = [42, 43]
 
     coordinator.pruneProcessLatencyState(liveProcessIDs: [43])
 
-    XCTAssertEqual(coordinator.slowProcessLatenciesMS, [43: 18])
+    #expect(coordinator.slowProcessLatenciesMS == [43: 18])
   }
 
-  func testStaleBatchDoesNotRecordLatencySample() {
+  @Test
+  func `Stale batch does not record latency sample`() {
     let accumulator = FrameResultAccumulator()
     accumulator.add(
       applied: 0,
@@ -146,10 +146,11 @@ final class FrameCommitTests: XCTestCase {
       completedAt: 1
     )
 
-    XCTAssertTrue(accumulator.result.processLatencySamplesMS.isEmpty)
+    #expect(accumulator.result.processLatencySamplesMS.isEmpty)
   }
 
-  func testCursorWarpRequiresSuccessfulTargetFrameWrite() {
+  @Test
+  func `Cursor warp requires successful target frame write`() {
     let target = WindowID(rawValue: 2)
     let sibling = WindowID(rawValue: 3)
     let failed = FrameWriteCompletion(
@@ -163,206 +164,192 @@ final class FrameCommitTests: XCTestCase {
       successfulWindowIDs: [target, sibling]
     )
 
-    XCTAssertNil(
+    #expect(
       cursorWarpTimestampAfterFrameCompletion(
         requestedTimestamp: 10,
         targetWindowID: target,
         completion: failed
-      )
-    )
-    XCTAssertEqual(
+      ) == nil)
+    #expect(
       cursorWarpTimestampAfterFrameCompletion(
         requestedTimestamp: 10,
         targetWindowID: target,
         completion: succeeded
-      ),
-      10
-    )
+      ) == 10)
   }
 
-  func testCursorWarpAllowsObservedConvergenceAfterFailedWrite() {
+  @Test
+  func `Cursor warp allows observed convergence after failed write`() {
     let target = Rect(x: 100, y: 40, width: 800, height: 700)
 
-    XCTAssertFalse(
+    #expect(
       cursorWarpFrameReadiness(
         latestWriteSucceeded: false,
         observedFrame: Rect(x: 900, y: 40, width: 800, height: 700),
         targetFrame: target
-      )
-    )
-    XCTAssertTrue(
+      ) == false)
+    #expect(
       cursorWarpFrameReadiness(
         latestWriteSucceeded: false,
         observedFrame: target,
         targetFrame: target
-      )
-    )
+      ))
   }
 
-  func testSynchronousSizeFailureBlocksWarpReadiness() {
-    XCTAssertFalse(
+  @Test
+  func `Synchronous size failure blocks warp readiness`() {
+    #expect(
       frameSizeWriteSucceeded(
         sizeChanged: true,
         synchronousWriteSucceeded: false,
         animatesSize: false,
         asynchronousWriteSucceeded: false
-      )
-    )
-    XCTAssertTrue(
+      ) == false)
+    #expect(
       frameSizeWriteSucceeded(
         sizeChanged: true,
         synchronousWriteSucceeded: true,
         animatesSize: false,
         asynchronousWriteSucceeded: false
-      )
-    )
-    XCTAssertFalse(
+      ))
+    #expect(
       frameSizeWriteSucceeded(
         sizeChanged: true,
         synchronousWriteSucceeded: true,
         animatesSize: true,
         asynchronousWriteSucceeded: false
-      )
-    )
-    XCTAssertTrue(
+      ) == false)
+    #expect(
       frameSizeWriteSucceeded(
         sizeChanged: true,
         synchronousWriteSucceeded: false,
         animatesSize: false,
         asynchronousWriteSucceeded: true
-      )
-    )
-    XCTAssertTrue(
+      ))
+    #expect(
       frameSizeWriteSucceeded(
         sizeChanged: false,
         synchronousWriteSucceeded: false,
         animatesSize: false,
         asynchronousWriteSucceeded: false
-      )
-    )
+      ))
   }
 
-  func testAsynchronousLayoutRoutesNonAnimatedSizeWritesToCoordinator() {
-    XCTAssertTrue(
+  @Test
+  func `Asynchronous layout routes non animated size writes to coordinator`() {
+    #expect(
       asynchronousSizeWriteIsRequired(
         sizeChanged: true,
         synchronousWriteSucceeded: false,
         animatesSize: false
-      )
-    )
-    XCTAssertFalse(
+      ))
+    #expect(
       asynchronousSizeWriteIsRequired(
         sizeChanged: true,
         synchronousWriteSucceeded: true,
         animatesSize: false
-      )
-    )
+      ) == false)
   }
 
-  func testDeferredFrameFocusRejectsNewerInputBeforeSubmission() {
-    XCTAssertTrue(
+  @Test
+  func `Deferred frame focus rejects newer input before submission`() {
+    #expect(
       deferredFocusInputIsCurrent(
         requestedTimestamp: 10,
         latestUserInputTimestamp: 10
-      )
-    )
-    XCTAssertFalse(
+      ))
+    #expect(
       deferredFocusInputIsCurrent(
         requestedTimestamp: 10,
         latestUserInputTimestamp: 11
-      )
-    )
-    XCTAssertTrue(
+      ) == false)
+    #expect(
       deferredFocusInputIsCurrent(
         requestedTimestamp: nil,
         latestUserInputTimestamp: 11
-      )
-    )
+      ))
   }
 
-  func testDeferredFrameFocusWaitsForPendingFrameDebt() {
+  @Test
+  func `Deferred frame focus waits for pending frame debt`() {
     let target = WindowID(rawValue: 42)
 
-    XCTAssertFalse(
+    #expect(
       deferredFocusFrameIsReady(
         targetWindowID: target,
         pendingFrameWindowIDs: [target]
-      )
-    )
-    XCTAssertTrue(
+      ) == false)
+    #expect(
       deferredFocusFrameIsReady(
         targetWindowID: target,
         pendingFrameWindowIDs: []
-      )
-    )
+      ))
   }
 
-  func testDeferredFrameFocusRequiresTargetWriteOrObservedConvergence() {
+  @Test
+  func `Deferred frame focus requires target write or observed convergence`() {
     let target = WindowID(rawValue: 42)
     let frame = Rect(x: 10, y: 20, width: 300, height: 400)
 
-    XCTAssertFalse(
+    #expect(
       deferredFocusFrameCommitIsReady(
         targetWindowID: target,
         pendingFrameWindowIDs: [],
         successfulWindowIDs: [],
         observedFrame: nil,
         targetFrame: frame
-      )
-    )
-    XCTAssertTrue(
+      ) == false)
+    #expect(
       deferredFocusFrameCommitIsReady(
         targetWindowID: target,
         pendingFrameWindowIDs: [],
         successfulWindowIDs: [target],
         observedFrame: nil,
         targetFrame: frame
-      )
-    )
-    XCTAssertTrue(
+      ))
+    #expect(
       deferredFocusFrameCommitIsReady(
         targetWindowID: target,
         pendingFrameWindowIDs: [],
         successfulWindowIDs: [],
         observedFrame: frame,
         targetFrame: frame
-      )
-    )
-    XCTAssertFalse(
+      ))
+    #expect(
       deferredFocusFrameCommitIsReady(
         targetWindowID: target,
         pendingFrameWindowIDs: [target],
         successfulWindowIDs: [target],
         observedFrame: frame,
         targetFrame: frame
-      )
-    )
+      ) == false)
   }
 
-  func testDisplacedQueuedFrameCompletesAsSuperseded() {
-    let completion = expectation(description: "superseded completion")
-    let frame = QueuedPositionFrame(
-      generation: 1,
-      source: "test",
-      writes: [:],
-      animatedWindowIDs: [],
-      animationDuration: 0,
-      refreshRateHz: 60,
-      displayIDs: [],
-      initialProgressVelocity: 0,
-      stagesVisibleBeforeParking: false
-    ) { result in
-      XCTAssertFalse(result.completedLatest)
-      XCTAssertTrue(result.successfulWindowIDs.isEmpty)
-      completion.fulfill()
+  @Test
+  func `Displaced queued frame completes as superseded`() async {
+    await confirmation { confirm in
+      let frame = QueuedPositionFrame(
+        generation: 1,
+        source: "test",
+        writes: [:],
+        animatedWindowIDs: [],
+        animationDuration: 0,
+        refreshRateHz: 60,
+        displayIDs: [],
+        initialProgressVelocity: 0,
+        stagesVisibleBeforeParking: false
+      ) { result in
+        #expect(result.completedLatest == false)
+        #expect(result.successfulWindowIDs.isEmpty)
+        confirm()
+      }
+
+      completeSupersededFrame(frame)
     }
-
-    completeSupersededFrame(frame)
-
-    wait(for: [completion], timeout: 0.1)
   }
 
-  func testSuccessfulWriteReportsTheWindowThatWasWritten() {
+  @Test
+  func `Successful write reports the window that was written`() {
     let coordinator = AXFrameCoordinator()
     let firstWindowID = WindowID(rawValue: 42)
     let secondWindowID = WindowID(rawValue: 43)
@@ -399,13 +386,11 @@ final class FrameCommitTests: XCTestCase {
       at: 12
     )
 
-    XCTAssertEqual(
-      reportedWindowIDs.withLock { $0 },
-      [firstWindowID, secondWindowID]
-    )
+    #expect(reportedWindowIDs.withLock { $0 } == [firstWindowID, secondWindowID])
   }
 
-  func testReplacementFramePreservesSupersededAsyncSizeWrite() {
+  @Test
+  func `Replacement frame preserves superseded async size write`() {
     let element = AXUIElementCreateSystemWide()
     func write(
       size: CGSize,
@@ -445,11 +430,12 @@ final class FrameCommitTests: XCTestCase {
       ]
     )
 
-    XCTAssertEqual(result[carriedWindowID]?.size.width, 900)
-    XCTAssertEqual(result[replacementWindowID]?.size.width, 1_000)
+    #expect(result[carriedWindowID]?.size.width == 900)
+    #expect(result[replacementWindowID]?.size.width == 1_000)
   }
 
-  func testPositionOnlyReplacementRetargetsAsyncSizeDebtToLatestPlan() {
+  @Test
+  func `Position only replacement retargets async size debt to latest plan`() {
     let element = AXUIElementCreateSystemWide()
     func write(
       point: CGPoint,
@@ -497,14 +483,15 @@ final class FrameCommitTests: XCTestCase {
       ]
     )
 
-    XCTAssertEqual(result[windowID]?.point, CGPoint(x: 100, y: 40))
-    XCTAssertEqual(result[windowID]?.size, CGSize(width: 800, height: 600))
-    XCTAssertTrue(result[windowID]?.positionChanged == true)
-    XCTAssertTrue(result[windowID]?.sizeChanged == true)
-    XCTAssertFalse(result[windowID]?.synchronousSizeWriteSucceeded == true)
+    #expect(result[windowID]?.point == CGPoint(x: 100, y: 40))
+    #expect(result[windowID]?.size == CGSize(width: 800, height: 600))
+    #expect(result[windowID]?.positionChanged == true)
+    #expect(result[windowID]?.sizeChanged == true)
+    #expect(result[windowID]?.synchronousSizeWriteSucceeded != true)
   }
 
-  func testRecentInternalWriteMatchesEveryRecordedComponent() {
+  @Test
+  func `Recent internal write matches every recorded component`() {
     let sizeWrite = RecentInternalFrameWrite(
       frame: Rect(x: 100, y: 40, width: 900, height: 700),
       positionChanged: false,
@@ -518,39 +505,35 @@ final class FrameCommitTests: XCTestCase {
       deadline: 20
     )
 
-    XCTAssertTrue(
+    #expect(
       frameMatchesRecentInternalWrite(
         actual: sizeWrite.frame,
         write: sizeWrite
-      )
-    )
-    XCTAssertTrue(
+      ))
+    #expect(
       frameMatchesRecentInternalWrite(
         actual: positionWrite.frame,
         write: positionWrite
-      )
-    )
-    XCTAssertFalse(
+      ))
+    #expect(
       frameMatchesRecentInternalWrite(
         actual: Rect(x: 400, y: 200, width: 900, height: 700),
         write: sizeWrite
-      )
-    )
-    XCTAssertFalse(
+      ) == false)
+    #expect(
       frameMatchesRecentInternalWrite(
         actual: Rect(x: 100, y: 40, width: 1_200, height: 800),
         write: positionWrite
-      )
-    )
-    XCTAssertFalse(
+      ) == false)
+    #expect(
       frameMatchesRecentInternalWrite(
         actual: Rect(x: 400, y: 200, width: 1_200, height: 800),
         write: sizeWrite
-      )
-    )
+      ) == false)
   }
 
-  func testRecentInternalWriteHistoryRetainsEveryLiveTarget() {
+  @Test
+  func `Recent internal write history retains every live target`() {
     let coordinator = AXFrameCoordinator()
     let windowID = WindowID(rawValue: 42)
     let first = Rect(x: 100, y: 40, width: 900, height: 700)
@@ -571,23 +554,22 @@ final class FrameCommitTests: XCTestCase {
       now: 10.1
     )
 
-    XCTAssertTrue(
+    #expect(
       coordinator.frameMatchesRecentInternalWrite(
         windowID: windowID,
         actual: first,
         now: 10.2
-      )
-    )
-    XCTAssertTrue(
+      ))
+    #expect(
       coordinator.frameMatchesRecentInternalWrite(
         windowID: windowID,
         actual: second,
         now: 10.2
-      )
-    )
+      ))
   }
 
-  func testInvalidationRetainsRecentInternalWriteHistory() {
+  @Test
+  func `Invalidation retains recent internal write history`() {
     let coordinator = AXFrameCoordinator()
     let windowID = WindowID(rawValue: 42)
     let frame = Rect(x: 100, y: 40, width: 900, height: 700)
@@ -620,17 +602,17 @@ final class FrameCommitTests: XCTestCase {
     )
     coordinator.invalidate(reason: "display-change")
 
-    XCTAssertTrue(coordinator.activeWrites.isEmpty)
-    XCTAssertTrue(
+    #expect(coordinator.activeWrites.isEmpty)
+    #expect(
       coordinator.frameMatchesRecentInternalWrite(
         windowID: windowID,
         actual: frame,
         now: 10.1
-      )
-    )
+      ))
   }
 
-  func testPruningRecentInternalWritesDropsClosedWindows() {
+  @Test
+  func `Pruning recent internal writes drops closed windows`() {
     let coordinator = AXFrameCoordinator()
     let windowID = WindowID(rawValue: 42)
     coordinator.recordInternalFrameWrite(
@@ -643,16 +625,16 @@ final class FrameCommitTests: XCTestCase {
 
     coordinator.pruneRecentInternalFrameWrites(liveWindowIDs: [], now: 10.2)
 
-    XCTAssertFalse(
+    #expect(
       coordinator.frameMatchesRecentInternalWrite(
         windowID: windowID,
         actual: Rect(x: 100, y: 40, width: 900, height: 700),
         now: 10.1
-      )
-    )
+      ) == false)
   }
 
-  func testPruningRecentInternalWritesDropsExpiredEntriesForLiveWindows() {
+  @Test
+  func `Pruning recent internal writes drops expired entries for live windows`() {
     let coordinator = AXFrameCoordinator()
     let windowID = WindowID(rawValue: 42)
     coordinator.recordInternalFrameWrite(
@@ -663,54 +645,51 @@ final class FrameCommitTests: XCTestCase {
       now: 10
     )
 
-    XCTAssertFalse(
+    #expect(
       coordinator.frameMatchesRecentInternalWrite(
         windowID: windowID,
         actual: Rect(x: 100, y: 40, width: 900, height: 700),
         now: 12.6
-      )
-    )
-    XCTAssertTrue(
+      ) == false)
+    #expect(
       coordinator.frameMatchesRecentInternalWrite(
         windowID: windowID,
         actual: Rect(x: 100, y: 40, width: 900, height: 700),
         now: 12.4
-      )
-    )
+      ))
   }
 
-  func testSuccessfulFrameWriteIntentKeepsPartialPositionWrite() {
-    XCTAssertEqual(
+  @Test
+  func `Successful frame write intent keeps partial position write`() {
+    #expect(
       successfulFrameWriteIntent(
         positionChanged: true,
         positionApplied: true,
         sizeChanged: true,
         sizeApplied: false
-      ),
-      FrameWriteIntent(position: true, size: false)
-    )
+      ) == FrameWriteIntent(position: true, size: false))
   }
 
-  func testLiveBorderWindowRequiresAcceptedFrameReadbackAfterPositionWrite() {
+  @Test
+  func `Live border window requires accepted frame readback after position write`() {
     let liveWindowID = WindowID(rawValue: 42)
 
-    XCTAssertTrue(
+    #expect(
       acceptedFrameRequiresReadback(
         windowID: liveWindowID,
         sizeChanged: false,
         liveBorderWindowID: liveWindowID
-      )
-    )
-    XCTAssertFalse(
+      ))
+    #expect(
       acceptedFrameRequiresReadback(
         windowID: WindowID(rawValue: 43),
         sizeChanged: false,
         liveBorderWindowID: liveWindowID
-      )
-    )
+      ) == false)
   }
 
-  func testCompletedActiveSizeWriteIsNotCarriedIntoReplacement() {
+  @Test
+  func `Completed active size write is not carried into replacement`() {
     let coordinator = AXFrameCoordinator()
     let element = AXUIElementCreateSystemWide()
     let windowID = WindowID(rawValue: 42)
@@ -735,10 +714,11 @@ final class FrameCommitTests: XCTestCase {
 
     coordinator.recordCompletedActiveSizeWrite(windowID: windowID)
 
-    XCTAssertNil(coordinator.activeWrites[windowID])
+    #expect(coordinator.activeWrites[windowID] == nil)
   }
 
-  func testInitialWindowCommitUsesShortQuarantineForFastRetries() {
+  @Test
+  func `Initial window commit uses short quarantine for fast retries`() {
     XCTAssertEqual(
       frameCommitQuarantineDuration(
         animationDuration: 0,
@@ -757,7 +737,8 @@ final class FrameCommitTests: XCTestCase {
     )
   }
 
-  func testInitialWindowCommitStillCoversAnimation() {
+  @Test
+  func `Initial window commit still covers animation`() {
     XCTAssertEqual(
       frameCommitQuarantineDuration(
         animationDuration: 0.35,
@@ -768,48 +749,45 @@ final class FrameCommitTests: XCTestCase {
     )
   }
 
-  func testInitialSettlementRepairsPositionOrSizeDrift() {
+  @Test
+  func `Initial settlement repairs position or size drift`() {
     let target = Rect(x: 100, y: 40, width: 1_200, height: 900)
 
-    XCTAssertFalse(initialFrameNeedsRepair(actual: target, target: target))
-    XCTAssertTrue(
+    #expect(initialFrameNeedsRepair(actual: target, target: target) == false)
+    #expect(
       initialFrameNeedsRepair(
         actual: Rect(x: 140, y: 40, width: 1_200, height: 900),
         target: target
-      )
-    )
-    XCTAssertTrue(
+      ))
+    #expect(
       initialFrameNeedsRepair(
         actual: Rect(x: 100, y: 40, width: 900, height: 700),
         target: target
-      )
-    )
+      ))
   }
 
-  func testInitialSettlementStaysArmedAfterMatchingFrame() {
+  @Test
+  func `Initial settlement stays armed after matching frame`() {
     let target = Rect(x: 100, y: 40, width: 1_200, height: 900)
 
-    XCTAssertEqual(
+    #expect(
       initialSettlementObservation(
         actual: target,
         target: target,
         now: 10,
         deadline: 12.5
-      ),
-      .stable
-    )
-    XCTAssertEqual(
+      ) == .stable)
+    #expect(
       initialSettlementObservation(
         actual: target,
         target: target,
         now: 12.5,
         deadline: 12.5
-      ),
-      .expired
-    )
+      ) == .expired)
   }
 
-  func testInitialSettlementRepairsOnlyStableDrift() {
+  @Test
+  func `Initial settlement repairs only stable drift`() {
     let generation: UInt64 = 4
     let first = InitialSettlementDriftSample(
       generation: generation,
@@ -817,33 +795,31 @@ final class FrameCommitTests: XCTestCase {
       observedAt: 10
     )
 
-    XCTAssertFalse(
+    #expect(
       initialSettlementDriftIsStable(
         previous: first,
         generation: generation,
         actual: Rect(x: 100, y: 40, width: 1_000, height: 760),
         now: 10.1
-      )
-    )
-    XCTAssertFalse(
+      ) == false)
+    #expect(
       initialSettlementDriftIsStable(
         previous: first,
         generation: generation,
         actual: first.frame,
         now: 10.04
-      )
-    )
-    XCTAssertTrue(
+      ) == false)
+    #expect(
       initialSettlementDriftIsStable(
         previous: first,
         generation: generation,
         actual: Rect(x: 101, y: 40, width: 900, height: 700),
         now: 10.08
-      )
-    )
+      ))
   }
 
-  func testUnchangedSettlementDriftPreservesFirstObservationTime() {
+  @Test
+  func `Unchanged settlement drift preserves first observation time`() {
     let first = InitialSettlementDriftSample(
       generation: 4,
       frame: Rect(x: 100, y: 40, width: 900, height: 700),
@@ -862,121 +838,114 @@ final class FrameCommitTests: XCTestCase {
       now: 10.04
     )
 
-    XCTAssertEqual(unchanged.observedAt, 10)
-    XCTAssertEqual(changed.observedAt, 10.04)
+    #expect(unchanged.observedAt == 10)
+    #expect(changed.observedAt == 10.04)
   }
 
-  func testInitialSettlementSchedulesStableFollowUpBeforeExpiration() {
+  @Test
+  func `Initial settlement schedules stable follow up before expiration`() {
     XCTAssertEqual(
       initialSettlementFollowUpDelay(now: 12.1, deadline: 12.5)!,
       0.06,
       accuracy: 0.000_1
     )
-    XCTAssertNil(initialSettlementFollowUpDelay(now: 12.48, deadline: 12.5))
-    XCTAssertNil(initialSettlementFollowUpDelay(now: 12.5, deadline: 12.5))
+    #expect(initialSettlementFollowUpDelay(now: 12.48, deadline: 12.5) == nil)
+    #expect(initialSettlementFollowUpDelay(now: 12.5, deadline: 12.5) == nil)
   }
 
-  func testInitialSettlementRepairRequiresCurrentGenerationAndIdleMouse() {
-    XCTAssertTrue(
+  @Test
+  func `Initial settlement repair requires current generation and idle mouse`() {
+    #expect(
       initialSettlementRepairIsCurrent(
         expectedGeneration: 4,
         currentGeneration: 4,
         repairsSuspended: false,
         leftMouseButtonDown: false,
         animationRunning: false
-      )
-    )
-    XCTAssertFalse(
+      ))
+    #expect(
       initialSettlementRepairIsCurrent(
         expectedGeneration: 4,
         currentGeneration: 5,
         repairsSuspended: false,
         leftMouseButtonDown: false,
         animationRunning: false
-      )
-    )
-    XCTAssertFalse(
+      ) == false)
+    #expect(
       initialSettlementRepairIsCurrent(
         expectedGeneration: 4,
         currentGeneration: 4,
         repairsSuspended: true,
         leftMouseButtonDown: false,
         animationRunning: false
-      )
-    )
-    XCTAssertFalse(
+      ) == false)
+    #expect(
       initialSettlementRepairIsCurrent(
         expectedGeneration: 4,
         currentGeneration: 4,
         repairsSuspended: false,
         leftMouseButtonDown: true,
         animationRunning: false
-      )
-    )
-    XCTAssertFalse(
+      ) == false)
+    #expect(
       initialSettlementRepairIsCurrent(
         expectedGeneration: 4,
         currentGeneration: 4,
         repairsSuspended: false,
         leftMouseButtonDown: false,
         animationRunning: true
-      )
-    )
+      ) == false)
   }
 
-  func testWindowEventsUseIncrementalRefreshOnlyWithStablePIDContext() {
+  @Test
+  func `Window events use incremental refresh only with stable PID context`() {
     let processIDs: Set<pid_t> = [101, 202]
 
-    XCTAssertEqual(
+    #expect(
       incrementalWindowRefreshProcessIDs(
         hasCompletedSnapshot: true,
         eventPending: true,
         requiresFullSnapshot: false,
         processIDs: processIDs
-      ),
-      processIDs
-    )
-    XCTAssertNil(
+      ) == processIDs)
+    #expect(
       incrementalWindowRefreshProcessIDs(
         hasCompletedSnapshot: false,
         eventPending: true,
         requiresFullSnapshot: false,
         processIDs: processIDs
-      )
-    )
-    XCTAssertNil(
+      ) == nil)
+    #expect(
       incrementalWindowRefreshProcessIDs(
         hasCompletedSnapshot: true,
         eventPending: true,
         requiresFullSnapshot: true,
         processIDs: processIDs
-      )
-    )
-    XCTAssertNil(
+      ) == nil)
+    #expect(
       incrementalWindowRefreshProcessIDs(
         hasCompletedSnapshot: true,
         eventPending: true,
         requiresFullSnapshot: false,
         processIDs: []
-      )
-    )
+      ) == nil)
   }
 
-  func testIncrementalRefreshIncludesCoalescedFrameProcess() {
-    XCTAssertEqual(
+  @Test
+  func `Incremental refresh includes coalesced frame process`() {
+    #expect(
       incrementalWindowRefreshProcessIDs(
         hasCompletedSnapshot: true,
         eventPending: true,
         requiresFullSnapshot: false,
         processIDs: [101],
         coalescedProcessIDs: [202]
-      ),
-      [101, 202]
-    )
+      ) == [101, 202])
   }
 
-  func testCoalescedFrameProcessDuringGestureDoesNotRequireTopologyEvent() {
-    XCTAssertEqual(
+  @Test
+  func `Coalesced frame process during gesture does not require topology event`() {
+    #expect(
       incrementalWindowRefreshProcessIDs(
         hasCompletedSnapshot: true,
         eventPending: false,
@@ -984,38 +953,36 @@ final class FrameCommitTests: XCTestCase {
         processIDs: [],
         coalescedProcessIDs: [202],
         allowsCoalescedProcessRefresh: true
-      ),
-      [202]
-    )
+      ) == [202])
   }
 
-  func testCoalescedFrameProcessOutsideGestureUsesFullRefresh() {
-    XCTAssertNil(
+  @Test
+  func `Coalesced frame process outside gesture uses full refresh`() {
+    #expect(
       incrementalWindowRefreshProcessIDs(
         hasCompletedSnapshot: true,
         eventPending: false,
         requiresFullSnapshot: false,
         processIDs: [],
         coalescedProcessIDs: [202]
-      )
-    )
+      ) == nil)
   }
 
-  func testFocusOnlySynchronizationReusesCachedWindows() {
-    XCTAssertEqual(
+  @Test
+  func `Focus only synchronization reuses cached windows`() {
+    #expect(
       incrementalWindowRefreshProcessIDs(
         hasCompletedSnapshot: true,
         eventPending: false,
         requiresFullSnapshot: false,
         processIDs: [],
         allowsCachedRefresh: true
-      ),
-      []
-    )
+      ) == [])
   }
 
-  func testFrameNotificationRefreshesOnlyAffectedProcess() {
-    XCTAssertEqual(
+  @Test
+  func `Frame notification refreshes only affected process`() {
+    #expect(
       incrementalWindowRefreshProcessIDs(
         hasCompletedSnapshot: true,
         eventPending: false,
@@ -1024,277 +991,249 @@ final class FrameCommitTests: XCTestCase {
         coalescedProcessIDs: [202],
         allowsCoalescedProcessRefresh: true,
         allowsCachedRefresh: true
-      ),
-      [202]
-    )
+      ) == [202])
   }
 
-  func testCoalescedMouseResizeForcesFullRefresh() {
-    XCTAssertNil(
+  @Test
+  func `Coalesced mouse resize forces full refresh`() {
+    #expect(
       incrementalWindowRefreshProcessIDs(
         hasCompletedSnapshot: true,
         eventPending: true,
         requiresFullSnapshot: false,
         processIDs: [101],
         coalescedEventRequiresFullSnapshot: true
-      )
-    )
+      ) == nil)
   }
 
-  func testWorkspaceSwitchPlacesVisibleWindowsBeforeParkingOldWorkspace() {
+  @Test
+  func `Workspace switch places visible windows before parking old workspace`() {
     let visible = WindowID(rawValue: 1)
     let parked = Set([WindowID(rawValue: 2), WindowID(rawValue: 3)])
     let all = parked.union([visible])
 
-    XCTAssertEqual(
+    #expect(
       positionWritePhases(
         windowIDs: all,
         parkedWindowIDs: parked,
         stagesVisibleBeforeParking: true
-      ),
-      [Set([visible]), parked]
-    )
-    XCTAssertEqual(
+      ) == [Set([visible]), parked])
+    #expect(
       positionWritePhases(
         windowIDs: all,
         parkedWindowIDs: parked,
         stagesVisibleBeforeParking: false
-      ),
-      [all]
-    )
+      ) == [all])
   }
 
-  func testOnlyIncomingWorkspaceWritesSuppressNativePositionAnimation() {
-    XCTAssertTrue(
+  @Test
+  func `Only incoming workspace writes suppress native position animation`() {
+    #expect(
       suppressesNativePositionAnimation(
         stagesVisibleBeforeParking: true,
         isParked: false,
         isIntermediate: false
-      )
-    )
-    XCTAssertFalse(
+      ))
+    #expect(
       suppressesNativePositionAnimation(
         stagesVisibleBeforeParking: true,
         isParked: true,
         isIntermediate: false
-      )
-    )
-    XCTAssertFalse(
+      ) == false)
+    #expect(
       suppressesNativePositionAnimation(
         stagesVisibleBeforeParking: false,
         isParked: false,
         isIntermediate: false
-      )
-    )
-    XCTAssertFalse(
+      ) == false)
+    #expect(
       suppressesNativePositionAnimation(
         stagesVisibleBeforeParking: true,
         isParked: false,
         isIntermediate: true
-      )
-    )
+      ) == false)
   }
 
-  func testDeferredFocusOnlyAppliesToCurrentSelection() {
+  @Test
+  func `Deferred focus only applies to current selection`() {
     let target = WindowID(rawValue: 1)
 
-    XCTAssertTrue(
+    #expect(
       shouldApplyDeferredFocus(
         targetWindowID: target,
         selectedWindowID: target
-      )
-    )
-    XCTAssertFalse(
+      ))
+    #expect(
       shouldApplyDeferredFocus(
         targetWindowID: target,
         selectedWindowID: WindowID(rawValue: 2)
-      )
-    )
+      ) == false)
   }
 
-  func testExpectedHorizontalCommitLagIsQuarantined() {
-    XCTAssertTrue(
+  @Test
+  func `Expected horizontal commit lag is quarantined`() {
+    #expect(
       frameIsOnExpectedCommitPath(
         actual: Rect(x: 420, y: 40, width: 800, height: 700),
         currentTarget: expectation.target,
         expectation: expectation,
         now: 10.4,
         leftMouseButtonDown: false
-      )
-    )
+      ))
   }
 
-  func testLateIntermediateRollbackRemainsQuarantinedAfterTargetWasObserved() {
+  @Test
+  func `Late intermediate rollback remains quarantined after target was observed`() {
     var observedExpectation = expectation
     observedExpectation.observedAt = 10.2
 
-    XCTAssertTrue(
+    #expect(
       frameIsOnExpectedCommitPath(
         actual: Rect(x: 260, y: 40, width: 800, height: 700),
         currentTarget: expectation.target,
         expectation: observedExpectation,
         now: 10.5,
         leftMouseButtonDown: false
-      )
-    )
+      ))
   }
 
-  func testExpiredOrExternalMovementIsNotQuarantined() {
-    XCTAssertFalse(
+  @Test
+  func `Expired or external movement is not quarantined`() {
+    #expect(
       frameIsOnExpectedCommitPath(
         actual: Rect(x: 420, y: 40, width: 800, height: 700),
         currentTarget: expectation.target,
         expectation: expectation,
         now: 10.7,
         leftMouseButtonDown: false
-      )
-    )
-    XCTAssertFalse(
+      ) == false)
+    #expect(
       frameIsOnExpectedCommitPath(
         actual: Rect(x: 1_400, y: 180, width: 800, height: 700),
         currentTarget: expectation.target,
         expectation: expectation,
         now: 10.4,
         leftMouseButtonDown: false
-      )
-    )
-    XCTAssertFalse(
+      ) == false)
+    #expect(
       frameIsOnExpectedCommitPath(
         actual: Rect(x: 420, y: 40, width: 800, height: 700),
         currentTarget: expectation.target,
         expectation: expectation,
         now: 10.4,
         leftMouseButtonDown: true
-      )
-    )
+      ) == false)
   }
 
-  func testOnePixelStripAnchorsRequireVerifiedOffscreenWrites() {
+  @Test
+  func `One pixel strip anchors require verified offscreen writes`() {
     let monitor = Rect(x: 0, y: 0, width: 1_512, height: 900)
 
-    XCTAssertTrue(
+    #expect(
       requiresVerifiedOffscreenWrite(
         frame: Rect(x: 1_511, y: 40, width: 1_204, height: 860),
         monitorFrames: [monitor]
-      )
-    )
-    XCTAssertTrue(
+      ))
+    #expect(
       requiresVerifiedOffscreenWrite(
         frame: Rect(x: -1_203, y: 40, width: 1_204, height: 860),
         monitorFrames: [monitor]
-      )
-    )
-    XCTAssertFalse(
+      ))
+    #expect(
       requiresVerifiedOffscreenWrite(
         frame: Rect(x: -905, y: 40, width: 1_204, height: 860),
         monitorFrames: [monitor]
-      )
-    )
+      ) == false)
   }
 
-  func testNeighboringMonitorPreventsFalseSliverClassification() {
-    XCTAssertFalse(
+  @Test
+  func `Neighboring monitor prevents false sliver classification`() {
+    #expect(
       requiresVerifiedOffscreenWrite(
         frame: Rect(x: 1_511, y: 40, width: 1_204, height: 860),
         monitorFrames: [
           Rect(x: 0, y: 0, width: 1_512, height: 900),
           Rect(x: 1_512, y: 0, width: 1_920, height: 1_080),
         ]
-      )
-    )
+      ) == false)
   }
 
-  func testAXLatencyClassificationUsesHysteresis() {
-    XCTAssertFalse(
+  @Test
+  func `AX latency classification uses hysteresis`() {
+    #expect(
       axProcessIsLatencySensitive(
         previouslySensitive: false,
         predictedLatencyMS: 11.9
-      )
-    )
-    XCTAssertTrue(
+      ) == false)
+    #expect(
       axProcessIsLatencySensitive(
         previouslySensitive: false,
         predictedLatencyMS: 12
-      )
-    )
-    XCTAssertTrue(
+      ))
+    #expect(
       axProcessIsLatencySensitive(
         previouslySensitive: true,
         predictedLatencyMS: 7
-      )
-    )
-    XCTAssertFalse(
+      ))
+    #expect(
       axProcessIsLatencySensitive(
         previouslySensitive: true,
         predictedLatencyMS: 6.9
-      )
-    )
+      ) == false)
   }
 
-  func testSlowLaneEntryRequiresConsecutiveSamples() {
+  @Test
+  func `Slow lane entry requires consecutive samples`() {
     var streak = ProcessLatencyStreak()
-    XCTAssertFalse(
-      processLatencyEntryIsConfirmed(sampleMS: 120, streak: &streak)
-    )
-    XCTAssertTrue(
-      processLatencyEntryIsConfirmed(sampleMS: 15, streak: &streak)
-    )
+    #expect(processLatencyEntryIsConfirmed(sampleMS: 120, streak: &streak) == false)
+    #expect(processLatencyEntryIsConfirmed(sampleMS: 15, streak: &streak))
   }
 
-  func testSlowLaneEntryIgnoresSingleSpike() {
+  @Test
+  func `Slow lane entry ignores single spike`() {
     var streak = ProcessLatencyStreak()
-    XCTAssertFalse(
-      processLatencyEntryIsConfirmed(sampleMS: 90, streak: &streak)
-    )
-    XCTAssertTrue(
-      processLatencyEntryIsConfirmed(sampleMS: 25, streak: &streak)
-    )
-    XCTAssertFalse(
-      processLatencyEntryIsConfirmed(sampleMS: 4, streak: &streak)
-    )
-    XCTAssertFalse(
-      processLatencyEntryIsConfirmed(sampleMS: 20, streak: &streak)
-    )
-    XCTAssertTrue(
-      processLatencyEntryIsConfirmed(sampleMS: 30, streak: &streak)
-    )
+    #expect(processLatencyEntryIsConfirmed(sampleMS: 90, streak: &streak) == false)
+    #expect(processLatencyEntryIsConfirmed(sampleMS: 25, streak: &streak))
+    #expect(processLatencyEntryIsConfirmed(sampleMS: 4, streak: &streak) == false)
+    #expect(processLatencyEntryIsConfirmed(sampleMS: 20, streak: &streak) == false)
+    #expect(processLatencyEntryIsConfirmed(sampleMS: 30, streak: &streak))
   }
 
-  func testAnimationLanesKeepFastProcessesInterpolated() {
+  @Test
+  func `Animation lanes keep fast processes interpolated`() {
     let fast = WindowID(rawValue: 1)
     let slow = WindowID(rawValue: 2)
 
-    XCTAssertEqual(
+    #expect(
       frameAnimationLanePlan(
         animatedWindowIDs: [fast, slow],
         processIDs: [fast: 101, slow: 202],
         reenteringWindowIDs: [],
         finalOnlyProcessIDs: [202]
-      ),
-      FrameAnimationLanePlan(
-        interpolatedWindowIDs: [fast],
-        finalOnlyWindowIDs: [slow],
-        stagedFinalOnlyReentryWindowIDs: []
       )
-    )
+        == FrameAnimationLanePlan(
+          interpolatedWindowIDs: [fast],
+          finalOnlyWindowIDs: [slow],
+          stagedFinalOnlyReentryWindowIDs: []
+        ))
   }
 
-  func testFinalOnlyReentryKeepsVerifiedStagingWrite() {
+  @Test
+  func `Final only reentry keeps verified staging write`() {
     let fast = WindowID(rawValue: 1)
     let slowReentry = WindowID(rawValue: 2)
 
-    XCTAssertEqual(
+    #expect(
       frameAnimationLanePlan(
         animatedWindowIDs: [fast, slowReentry],
         processIDs: [fast: 101, slowReentry: 202],
         reenteringWindowIDs: [slowReentry],
         finalOnlyProcessIDs: [202]
-      ).stagedFinalOnlyReentryWindowIDs,
-      [slowReentry]
-    )
+      ).stagedFinalOnlyReentryWindowIDs == [slowReentry])
   }
 
-  func testSkippedWindowKeepsPreviousTargetUntilSettlement() {
+  @Test
+  func `Skipped window keeps previous target until settlement`() {
     let skipped = WindowID(rawValue: 1)
     let fast = WindowID(rawValue: 2)
     let previous: [WindowID: Rect] = [
@@ -1316,43 +1255,40 @@ final class FrameCommitTests: XCTestCase {
       skippedWindowIDs: [skipped]
     )
 
-    XCTAssertEqual(next[skipped], previous[skipped])
-    XCTAssertEqual(next[fast], Rect(x: 20, y: 0, width: 400, height: 700))
+    #expect(next[skipped] == previous[skipped])
+    #expect(next[fast] == Rect(x: 20, y: 0, width: 400, height: 700))
   }
 
-  func testSkippedWindowKeepsPreviousParkingStateUntilSettlement() {
+  @Test
+  func `Skipped window keeps previous parking state until settlement`() {
     let skipped = WindowID(rawValue: 1)
     let fast = WindowID(rawValue: 2)
 
-    XCTAssertEqual(
+    #expect(
       hiddenWindowsPreservingSkippedWindows(
         previous: [skipped],
         desired: [fast],
         skippedWindowIDs: [skipped]
-      ),
-      [skipped, fast]
-    )
+      ) == [skipped, fast])
   }
 
-  func testRibbonNavigationNeverPlansSizeWrites() {
-    XCTAssertEqual(
+  @Test
+  func `Ribbon navigation never plans size writes`() {
+    #expect(
       frameWriteIntent(
         reference: Rect(x: 800, y: 0, width: 600, height: 700),
         target: Rect(x: 100, y: 0, width: 1_000, height: 900),
         positionsOnly: true
-      ),
-      FrameWriteIntent(position: true, size: false)
-    )
+      ) == FrameWriteIntent(position: true, size: false))
   }
 
-  func testFrameAnimationInterpolatesPositionAndSize() {
-    XCTAssertEqual(
+  @Test
+  func `Frame animation interpolates position and size`() {
+    #expect(
       interpolatedFrame(
         from: Rect(x: 100, y: 40, width: 600, height: 700),
         to: Rect(x: 40, y: 20, width: 1_000, height: 800),
         progress: 0.25
-      ),
-      Rect(x: 85, y: 35, width: 700, height: 725)
-    )
+      ) == Rect(x: 85, y: 35, width: 700, height: 725))
   }
 }

--- a/Tests/DefiMacOSTests/FrameCommitTransitionTests.swift
+++ b/Tests/DefiMacOSTests/FrameCommitTransitionTests.swift
@@ -167,8 +167,8 @@ struct FrameCommitTransitionTests {
   func onlyHighSignalTraceEventsBecomePersistentAnomalies() {
     #expect(traceEventIsDiagnosticAnomaly("parking-repair wid=1"))
     #expect(traceEventIsDiagnosticAnomaly("slow g=1 pid=2 windows=1 ms=20"))
-    #expect(!traceEventIsDiagnosticAnomaly("sample g=1 i=2 p=0.4"))
-    #expect(!traceEventIsDiagnosticAnomaly("command-plan cg=1 windows=2 ms=2"))
+    #expect(traceEventIsDiagnosticAnomaly("sample g=1 i=2 p=0.4") == false)
+    #expect(traceEventIsDiagnosticAnomaly("command-plan cg=1 windows=2 ms=2") == false)
   }
 
   @Test

--- a/Tests/DefiMacOSTests/HotKeyTests.swift
+++ b/Tests/DefiMacOSTests/HotKeyTests.swift
@@ -1,68 +1,45 @@
 import ApplicationServices
 import DefiConfig
 import Testing
-import XCTest
 
 @testable import DefiMacOS
 
-final class HotKeyTests: XCTestCase {
+struct HotKeyTests {
   private let aliases = [
     "hyper": "Alt + Cmd + Ctrl"
   ]
 
-  func testHyperArrowUsesExpectedKeyCodeAndModifiers() throws {
-    let key = try Key(accelerator: "hyper-left", aliases: aliases)
-
-    XCTAssertEqual(key.code, 123)
-    XCTAssertEqual(
-      key.modifierBits,
-      CGEventFlags([
-        .maskAlternate,
-        .maskCommand,
-        .maskControl,
-      ]).rawValue
-    )
-  }
-
-  func testHyperShiftWorkspaceUsesExpectedKeyCodeAndModifiers() throws {
-    let key = try Key(accelerator: "hyper-shift-1", aliases: aliases)
-
-    XCTAssertEqual(key.code, 18)
-    XCTAssertEqual(
-      key.modifierBits,
-      CGEventFlags([
-        .maskAlternate,
-        .maskCommand,
-        .maskControl,
-        .maskShift,
-      ]).rawValue
-    )
-  }
-
-  func testHyperResizeKeysUseExpectedKeyCodesAndModifiers() throws {
-    let expectedModifierBits = CGEventFlags([
+  @Test(arguments: [
+    ("hyper-left", CGKeyCode(123), false),
+    ("hyper-shift-1", CGKeyCode(18), true),
+    ("hyper-equal", CGKeyCode(24), false),
+    ("hyper-minus", CGKeyCode(27), false),
+    ("hyper-f", CGKeyCode(3), false),
+    ("hyper-backslash", CGKeyCode(42), false),
+    ("hyper-comma", CGKeyCode(43), false),
+    ("hyper-period", CGKeyCode(47), false),
+  ])
+  func `Hyper bindings use expected key codes and modifiers`(
+    testCase: (accelerator: String, code: CGKeyCode, shift: Bool)
+  ) throws {
+    var expectedModifiers = CGEventFlags([
       .maskAlternate,
       .maskCommand,
       .maskControl,
-    ]).rawValue
-
-    let cases: [(accelerator: String, code: CGKeyCode)] = [
-      ("hyper-equal", 24),
-      ("hyper-minus", 27),
-      ("hyper-f", 3),
-      ("hyper-backslash", 42),
-      ("hyper-comma", 43),
-      ("hyper-period", 47),
-    ]
-    for (accelerator, code) in cases {
-      let key = try Key(accelerator: accelerator, aliases: aliases)
-      XCTAssertEqual(key.code, code)
-      XCTAssertEqual(key.modifierBits, expectedModifierBits)
+    ])
+    if testCase.shift {
+      expectedModifiers.insert(.maskShift)
     }
+
+    let key = try Key(accelerator: testCase.accelerator, aliases: aliases)
+
+    #expect(key.code == testCase.code)
+    #expect(key.modifierBits == expectedModifiers.rawValue)
   }
 
   @MainActor
-  func testInvalidBindingDisablesHotKeysButKeepsPointerTrackingConfigured() {
+  @Test
+  func `Invalid binding disables hot keys but keeps pointer tracking configured`() {
     let config = Config(
       input: InputConfig(focusFollowsMouse: true),
       keys: ["unknown-no-such-key": "focus-column left"]
@@ -70,12 +47,9 @@ final class HotKeyTests: XCTestCase {
 
     let manager = HotKeyManager(config: config) { _ in }
 
-    XCTAssertEqual(manager.bindingCount, 0)
-    XCTAssertEqual(
-      manager.bindingError,
-      .invalidAccelerator("unknown-no-such-key")
-    )
-    XCTAssertTrue(manager.tracksPointerMotion)
+    #expect(manager.bindingCount == 0)
+    #expect(manager.bindingError == .invalidAccelerator("unknown-no-such-key"))
+    #expect(manager.tracksPointerMotion)
   }
 }
 

--- a/Tests/DefiMacOSTests/MonitorTests.swift
+++ b/Tests/DefiMacOSTests/MonitorTests.swift
@@ -1,11 +1,11 @@
 import AppKit
 import DefiModel
-import XCTest
+import Testing
 
 @testable import DefiMacOS
 
 @MainActor
-final class MonitorTests: XCTestCase {
+struct MonitorTests {
   private let internalDisplay = MonitorSnapshot(
     id: MonitorID(rawValue: 1),
     frame: Rect(x: 0, y: 0, width: 1_512, height: 901),
@@ -13,7 +13,8 @@ final class MonitorTests: XCTestCase {
     refreshRateHz: 120
   )
 
-  func testMonitorGeometryDetectsDisplayReplacement() {
+  @Test
+  func `Monitor geometry detects display replacement`() {
     let externalDisplay = MonitorSnapshot(
       id: MonitorID(rawValue: 3),
       frame: Rect(x: 0, y: 30, width: 2_560, height: 1_362),
@@ -21,12 +22,11 @@ final class MonitorTests: XCTestCase {
       refreshRateHz: 120
     )
 
-    XCTAssertTrue(
-      monitorGeometryChanged(from: [internalDisplay], to: [externalDisplay])
-    )
+    #expect(monitorGeometryChanged(from: [internalDisplay], to: [externalDisplay]))
   }
 
-  func testMonitorGeometryDetectsVisibleFrameResize() {
+  @Test
+  func `Monitor geometry detects visible frame resize`() {
     let resized = MonitorSnapshot(
       id: internalDisplay.id,
       frame: Rect(x: 0, y: 0, width: 1_512, height: 880),
@@ -34,12 +34,11 @@ final class MonitorTests: XCTestCase {
       refreshRateHz: 120
     )
 
-    XCTAssertTrue(
-      monitorGeometryChanged(from: [internalDisplay], to: [resized])
-    )
+    #expect(monitorGeometryChanged(from: [internalDisplay], to: [resized]))
   }
 
-  func testMonitorGeometryIgnoresRefreshRateOnlyChange() {
+  @Test
+  func `Monitor geometry ignores refresh rate only change`() {
     let changedRefreshRate = MonitorSnapshot(
       id: internalDisplay.id,
       frame: internalDisplay.frame,
@@ -47,12 +46,11 @@ final class MonitorTests: XCTestCase {
       refreshRateHz: 60
     )
 
-    XCTAssertFalse(
-      monitorGeometryChanged(from: [internalDisplay], to: [changedRefreshRate])
-    )
+    #expect(monitorGeometryChanged(from: [internalDisplay], to: [changedRefreshRate]) == false)
   }
 
-  func testMonitorGeometryIgnoresOrdering() {
+  @Test
+  func `Monitor geometry ignores ordering`() {
     let externalDisplay = MonitorSnapshot(
       id: MonitorID(rawValue: 3),
       frame: Rect(x: 1_512, y: 0, width: 2_560, height: 1_362),
@@ -60,15 +58,15 @@ final class MonitorTests: XCTestCase {
       refreshRateHz: 120
     )
 
-    XCTAssertFalse(
+    #expect(
       monitorGeometryChanged(
         from: [internalDisplay, externalDisplay],
         to: [externalDisplay, internalDisplay]
-      )
-    )
+      ) == false)
   }
 
-  func testScreenParameterNotificationIsClassifiedAsDisplayChange() {
+  @Test
+  func `Screen parameter notification is classified as display change`() {
     var receivedKinds: [PlatformEventKind] = []
     let monitor = PlatformEventMonitor { kind, _ in receivedKinds.append(kind) }
     monitor.start()
@@ -79,10 +77,11 @@ final class MonitorTests: XCTestCase {
       object: NSApplication.shared
     )
 
-    XCTAssertEqual(receivedKinds, [.screens])
+    #expect(receivedKinds == [.screens])
   }
 
-  func testTerminationNotificationIncludesApplicationProcessID() {
+  @Test
+  func `Termination notification includes application process ID`() {
     var receivedKind: PlatformEventKind?
     var receivedProcessID: pid_t?
     let monitor = PlatformEventMonitor { kind, processID in
@@ -99,7 +98,7 @@ final class MonitorTests: XCTestCase {
       userInfo: [NSWorkspace.applicationUserInfoKey: application]
     )
 
-    XCTAssertEqual(receivedKind, .applicationTerminated)
-    XCTAssertEqual(receivedProcessID, application.processIdentifier)
+    #expect(receivedKind == .applicationTerminated)
+    #expect(receivedProcessID == application.processIdentifier)
   }
 }

--- a/Tests/DefiMacOSTests/NativeFullscreenTests.swift
+++ b/Tests/DefiMacOSTests/NativeFullscreenTests.swift
@@ -11,13 +11,13 @@ struct NativeFullscreenTests {
     physicalFrame: Rect(x: 0, y: 0, width: 1_512, height: 982)
   )
 
-  @Test
-  func physicalScreenCoverageDetectsTrackedWindow() {
+  @Test(arguments: [1, 2])
+  func `Physical screen coverage detects tracked observations`(observationCount: Int) {
     let window = makeWindow(id: 1, processID: 10, frame: monitor.physicalFrame)
 
     #expect(
       nativeFullscreenWindowIDs(
-        windows: [window],
+        windows: Array(repeating: window, count: observationCount),
         cgWindows: [],
         monitors: [monitor],
         lastFocusedWindowByProcess: [:]
@@ -26,21 +26,7 @@ struct NativeFullscreenTests {
   }
 
   @Test
-  func duplicateTrackedObservationsDoNotCrashDetection() {
-    let window = makeWindow(id: 1, processID: 10, frame: monitor.physicalFrame)
-
-    #expect(
-      nativeFullscreenWindowIDs(
-        windows: [window, window],
-        cgWindows: [],
-        monitors: [monitor],
-        lastFocusedWindowByProcess: [:]
-      ) == [window.id]
-    )
-  }
-
-  @Test
-  func visibleFrameAndPictureInPictureAreNotFullscreen() {
+  func `Visible frame and picture in picture are not fullscreen`() {
     let tiled = makeWindow(id: 1, processID: 10, frame: monitor.frame)
     let pictureInPicture = makeWindow(
       id: 2,
@@ -60,7 +46,7 @@ struct NativeFullscreenTests {
   }
 
   @Test
-  func maximizedSurfaceWithoutItsMissingTopBandIsNotFullscreen() {
+  func `Maximized surface without its missing top band is not fullscreen`() {
     let window = makeWindow(id: 1, processID: 10, frame: monitor.frame)
     let surface = CGWindowRecord(
       id: 99,
@@ -81,7 +67,7 @@ struct NativeFullscreenTests {
   }
 
   @Test
-  func adjacentProcessSurfacesCanCoverThePhysicalScreen() {
+  func `Adjacent process surfaces can cover the physical screen`() {
     let window = makeWindow(id: 1, processID: 10, frame: monitor.frame)
     let surfaces = [
       CGWindowRecord(
@@ -111,7 +97,7 @@ struct NativeFullscreenTests {
   }
 
   @Test
-  func staleOffscreenFullscreenSurfacesDoNotHideVisibleParent() {
+  func `Stale offscreen fullscreen surfaces do not hide visible parent`() {
     let window = makeWindow(id: 1, processID: 10, frame: monitor.frame)
     let surfaces = [
       CGWindowRecord(
@@ -151,7 +137,7 @@ struct NativeFullscreenTests {
   }
 
   @Test
-  func fullscreenHelperSelectsLastFocusedWindowFromItsProcess() {
+  func `Fullscreen helper selects last focused window from its process`() {
     let first = makeWindow(id: 1, processID: 10, frame: monitor.frame)
     let second = makeWindow(id: 2, processID: 10, frame: monitor.frame)
     let helper = CGWindowRecord(
@@ -173,7 +159,7 @@ struct NativeFullscreenTests {
   }
 
   @Test
-  func exactFullscreenSurfaceWinsOverStaleProcessFocus() {
+  func `Exact fullscreen surface wins over stale process focus`() {
     let processID: Int32 = 10
     let staleFocused = makeWindow(
       id: 1,
@@ -215,7 +201,7 @@ struct NativeFullscreenTests {
   }
 
   @Test
-  func remappedFullscreenSurfaceKeepsPreviousLogicalWindowIdentity() {
+  func `Remapped fullscreen surface keeps previous logical window identity`() {
     let surfaceWindow = makeWindow(
       id: 99,
       processID: 10,
@@ -234,7 +220,7 @@ struct NativeFullscreenTests {
   }
 
   @Test
-  func ambiguousFullscreenHelperDoesNotGuess() {
+  func `Ambiguous fullscreen helper does not guess`() {
     let first = makeWindow(id: 1, processID: 10, frame: monitor.frame)
     let second = makeWindow(id: 2, processID: 10, frame: monitor.frame)
     let helper = CGWindowRecord(
@@ -255,15 +241,16 @@ struct NativeFullscreenTests {
     )
   }
 
-  @Test
-  func activeFullscreenWindowRequiresAnOnscreenSurface() {
+  @Test(arguments: [true, false])
+  func `Active fullscreen window requires an onscreen surface`(isOnscreen: Bool) {
     let windowID = WindowID(rawValue: 1)
     let surface = CGWindowRecord(
       id: 1,
       processID: 10,
       layer: 0,
       title: "Video",
-      frame: Rect(x: 0, y: 33, width: 1_512, height: 949)
+      frame: Rect(x: 0, y: 33, width: 1_512, height: 949),
+      isOnscreen: isOnscreen
     )
     let hiddenMenuBand = CGWindowRecord(
       id: 99,
@@ -279,30 +266,13 @@ struct NativeFullscreenTests {
         processIDsByWindowID: [windowID: 10],
         cgWindows: [surface, hiddenMenuBand],
         monitors: [monitor]
-      ) == [windowID]
-    )
-    #expect(
-      activeNativeFullscreenWindowIDs(
-        processIDsByWindowID: [windowID: 10],
-        cgWindows: [
-          CGWindowRecord(
-            id: surface.id,
-            processID: surface.processID,
-            layer: surface.layer,
-            title: surface.title,
-            frame: surface.frame,
-            isOnscreen: false
-          ),
-          hiddenMenuBand,
-        ],
-        monitors: [monitor]
-      ).isEmpty
+      ) == (isOnscreen ? [windowID] : [])
     )
   }
 
   @MainActor
   @Test
-  func automaticFocusWriteIsSkippedForFullscreenWindow() {
+  func `Automatic focus write is skipped for fullscreen window`() {
     let windowID = WindowID(rawValue: 1)
     let platform = MacOSPlatform()
     platform.updateNativeFullscreenWindowIDs([windowID])
@@ -319,7 +289,7 @@ struct NativeFullscreenTests {
 
   @MainActor
   @Test
-  func frameApplicationPreservesFullscreenTarget() {
+  func `Frame application preserves fullscreen target`() {
     let windowID = WindowID(rawValue: 1)
     let original = Rect(x: 0, y: 0, width: 1_512, height: 982)
     let platform = MacOSPlatform()
@@ -338,7 +308,7 @@ struct NativeFullscreenTests {
 
   @MainActor
   @Test
-  func fullscreenExitStartsFrameSettlement() {
+  func `Fullscreen exit starts frame settlement`() {
     let windowID = WindowID(rawValue: 1)
     let platform = MacOSPlatform()
     platform.updateNativeFullscreenWindowIDs([windowID])
@@ -351,7 +321,7 @@ struct NativeFullscreenTests {
 
   @MainActor
   @Test
-  func placeholderManagerTracksOnlyCurrentFullscreenSlots() {
+  func `Placeholder manager tracks only current fullscreen slots`() {
     let manager = NativeFullscreenPlaceholderManager()
     let windowID = WindowID(rawValue: 1)
     let siblingWindowID = WindowID(rawValue: 2)
@@ -377,7 +347,7 @@ struct NativeFullscreenTests {
         appID: "com.apple.TextEdit",
         title: "Other monitor",
         frame: Rect(x: 1_600, y: 100, width: 600, height: 700)
-      )
+      ),
     ]
     manager.sync(
       placeholders,
@@ -409,7 +379,7 @@ struct NativeFullscreenTests {
   }
 
   @Test
-  func activeSpaceChangeForcesFreshTopology() {
+  func `Active space change forces fresh topology`() {
     #expect(windowSnapshotInvalidation(for: .space, processID: nil) == .full)
     #expect(
       nativeFocusedWindowIDAfterEvent(
@@ -420,7 +390,7 @@ struct NativeFullscreenTests {
   }
 
   @Test
-  func transientSpaceGapDoesNotEmitAFullscreenExit() {
+  func `Transient space gap does not emit a fullscreen exit`() {
     let windowID = WindowID(rawValue: 1)
     let entered = stabilizedNativeFullscreenWindowIDs(
       detectedWindowIDs: [windowID],
@@ -446,7 +416,7 @@ struct NativeFullscreenTests {
   }
 
   @Test
-  func inactiveSpaceRetainsFullscreenIdentityWhileProcessStillCoversDisplay() {
+  func `Inactive space retains fullscreen identity while process still covers display`() {
     let windowID = WindowID(rawValue: 1)
     let processID: Int32 = 10
 
@@ -470,7 +440,7 @@ struct NativeFullscreenTests {
   }
 
   @Test
-  func fullscreenSpaceRetainsFocusResourcesFromMaskedSpaces() {
+  func `Fullscreen space retains focus resources from masked spaces`() {
     let visibleID = WindowID(rawValue: 1)
     let maskedID = WindowID(rawValue: 2)
     let removedID = WindowID(rawValue: 3)

--- a/Tests/DefiMacOSTests/PlatformEventTests.swift
+++ b/Tests/DefiMacOSTests/PlatformEventTests.swift
@@ -248,11 +248,10 @@ struct PlatformEventTests {
       )
     )
     #expect(
-      !focusRecoveryIntentIsCurrent(
+      focusRecoveryIntentIsCurrent(
         requestGeneration: 8,
         currentGeneration: 9
-      )
-    )
+      ) == false)
   }
 
   @Test
@@ -264,11 +263,10 @@ struct PlatformEventTests {
       )
     )
     #expect(
-      !focusRecoveryResolutionIsCurrent(
+      focusRecoveryResolutionIsCurrent(
         requestGeneration: 3,
         currentGeneration: 4
-      )
-    )
+      ) == false)
   }
 
   @Test
@@ -277,8 +275,8 @@ struct PlatformEventTests {
     #expect(eventTracksPhysicalPointerMotion(.leftMouseDragged))
     #expect(eventTracksPhysicalPointerMotion(.rightMouseDragged))
     #expect(eventTracksPhysicalPointerMotion(.otherMouseDragged))
-    #expect(!eventTracksPhysicalPointerMotion(.scrollWheel))
-    #expect(!eventTracksPhysicalPointerMotion(.keyDown))
+    #expect(eventTracksPhysicalPointerMotion(.scrollWheel) == false)
+    #expect(eventTracksPhysicalPointerMotion(.keyDown) == false)
   }
 
   @Test
@@ -286,9 +284,9 @@ struct PlatformEventTests {
     #expect(eventIsMouseButtonDown(.leftMouseDown))
     #expect(eventIsMouseButtonDown(.rightMouseDown))
     #expect(eventIsMouseButtonDown(.otherMouseDown))
-    #expect(!eventIsMouseButtonDown(.leftMouseUp))
-    #expect(!eventIsMouseButtonDown(.mouseMoved))
-    #expect(!eventIsMouseButtonDown(.keyDown))
+    #expect(eventIsMouseButtonDown(.leftMouseUp) == false)
+    #expect(eventIsMouseButtonDown(.mouseMoved) == false)
+    #expect(eventIsMouseButtonDown(.keyDown) == false)
   }
 
   @Test
@@ -299,8 +297,8 @@ struct PlatformEventTests {
     #expect(eventTracksGeneralUserInput(.rightMouseDown))
     #expect(eventTracksGeneralUserInput(.otherMouseDown))
     #expect(eventTracksGeneralUserInput(.scrollWheel))
-    #expect(!eventTracksGeneralUserInput(.mouseMoved))
-    #expect(!eventTracksGeneralUserInput(.leftMouseUp))
+    #expect(eventTracksGeneralUserInput(.mouseMoved) == false)
+    #expect(eventTracksGeneralUserInput(.leftMouseUp) == false)
   }
 
   @Test
@@ -492,11 +490,10 @@ struct PlatformEventTests {
   @Test
   func failedActivationDoesNotReportAnUnappliedMutation() {
     #expect(
-      !focusMutationStateAfterActivation(
+      focusMutationStateAfterActivation(
         priorMutationApplied: false,
         activationSucceeded: false
-      )
-    )
+      ) == false)
     #expect(
       focusMutationStateAfterActivation(
         priorMutationApplied: true,
@@ -530,13 +527,12 @@ struct PlatformEventTests {
       )
     )
     #expect(
-      !focusRequestCanBeCancelled(
+      focusRequestCanBeCancelled(
         requestGeneration: 4,
         latestGeneration: 5,
         pendingGeneration: nil,
         activeGeneration: 5
-      )
-    )
+      ) == false)
   }
 
   @Test
@@ -1226,8 +1222,8 @@ struct PlatformEventTests {
   @Test
   func momentumScrollDoesNotSupersedeKeyboardFocus() {
     #expect(eventTracksGeneralUserInput(.scrollWheel, scrollMomentumPhase: 0))
-    #expect(!eventTracksGeneralUserInput(.scrollWheel, scrollMomentumPhase: 1))
-    #expect(!eventTracksGeneralUserInput(.scrollWheel, scrollMomentumPhase: 2))
+    #expect(eventTracksGeneralUserInput(.scrollWheel, scrollMomentumPhase: 1) == false)
+    #expect(eventTracksGeneralUserInput(.scrollWheel, scrollMomentumPhase: 2) == false)
   }
 
   @Test
@@ -1310,20 +1306,22 @@ struct PlatformEventTests {
         rawWindowChanged: false,
         refreshDelay: 0.007,
         deliveryScheduled: false
-      ) == PointerMotionDeliveryPlan(
-        shouldSchedule: true,
-        delay: 0.007
       )
+        == PointerMotionDeliveryPlan(
+          shouldSchedule: true,
+          delay: 0.007
+        )
     )
     #expect(
       pointerMotionDeliveryPlan(
         rawWindowChanged: false,
         refreshDelay: 0.007,
         deliveryScheduled: true
-      ) == PointerMotionDeliveryPlan(
-        shouldSchedule: false,
-        delay: 0.007
       )
+        == PointerMotionDeliveryPlan(
+          shouldSchedule: false,
+          delay: 0.007
+        )
     )
   }
 
@@ -1613,14 +1611,15 @@ struct PlatformEventTests {
     let firstSeenMinimized = AXUIElementCreateApplication(303)
     let unmanagedAuxiliary = AXUIElementCreateApplication(404)
 
-    let required = requiredTopologyWindows(
-      applicationWindows: [
-        7: [current, minimized, firstSeenMinimized, unmanagedAuxiliary]
-      ],
-      managedWindows: [7: [current]],
-      previouslyManagedWindows: [7: [current, minimized]],
-      minimizedWindows: [7: [minimized, firstSeenMinimized]]
-    )[7] ?? []
+    let required =
+      requiredTopologyWindows(
+        applicationWindows: [
+          7: [current, minimized, firstSeenMinimized, unmanagedAuxiliary]
+        ],
+        managedWindows: [7: [current]],
+        previouslyManagedWindows: [7: [current, minimized]],
+        minimizedWindows: [7: [minimized, firstSeenMinimized]]
+      )[7] ?? []
 
     #expect(required.count == 3)
     #expect(required.contains(where: { CFEqual($0, current) }))
@@ -1700,7 +1699,7 @@ struct PlatformEventTests {
     #expect(platform.frameEventPending)
     #expect(platform.pendingFrameProcessIDs == [101])
     #expect(platform.observedFrameEventWindowIDs == [windowID])
-    #expect(!platform.pendingFrameRequiresFullSnapshot)
+    #expect(platform.pendingFrameRequiresFullSnapshot == false)
   }
 
   @Test @MainActor
@@ -1835,7 +1834,7 @@ struct PlatformEventTests {
     _ = normalizer.actions(for: .rightMouseDown, buttonNumber: 1)
 
     let leftUp = normalizer.actions(for: .leftMouseUp)
-    #expect(!leftUp.endsFocusInteraction)
+    #expect(leftUp.endsFocusInteraction == false)
 
     let rightUp = normalizer.actions(for: .rightMouseUp, buttonNumber: 1)
     #expect(rightUp.endsFocusInteraction)
@@ -1861,9 +1860,9 @@ struct PlatformEventTests {
     #expect(eventEndsMouseFocusInteraction(.leftMouseUp))
     #expect(eventEndsMouseFocusInteraction(.rightMouseUp))
     #expect(eventEndsMouseFocusInteraction(.otherMouseUp))
-    #expect(!eventEndsMouseFocusInteraction(.leftMouseDown))
-    #expect(!eventEndsMouseFocusInteraction(.rightMouseDown))
-    #expect(!eventEndsMouseFocusInteraction(.otherMouseDown))
+    #expect(eventEndsMouseFocusInteraction(.leftMouseDown) == false)
+    #expect(eventEndsMouseFocusInteraction(.rightMouseDown) == false)
+    #expect(eventEndsMouseFocusInteraction(.otherMouseDown) == false)
   }
 
   @Test
@@ -1871,9 +1870,9 @@ struct PlatformEventTests {
     #expect(eventStartsMouseFocusInteraction(.leftMouseDown))
     #expect(eventStartsMouseFocusInteraction(.rightMouseDown))
     #expect(eventStartsMouseFocusInteraction(.otherMouseDown))
-    #expect(!eventStartsMouseFocusInteraction(.leftMouseUp))
-    #expect(!eventStartsMouseFocusInteraction(.rightMouseUp))
-    #expect(!eventStartsMouseFocusInteraction(.otherMouseUp))
+    #expect(eventStartsMouseFocusInteraction(.leftMouseUp) == false)
+    #expect(eventStartsMouseFocusInteraction(.rightMouseUp) == false)
+    #expect(eventStartsMouseFocusInteraction(.otherMouseUp) == false)
   }
 
   @Test
@@ -1897,7 +1896,7 @@ struct PlatformEventTests {
     let resetHeldButtons = normalizer.reset()
     let resetEmptyGesture = normalizer.reset()
     #expect(resetHeldButtons)
-    #expect(!resetEmptyGesture)
+    #expect(resetEmptyGesture == false)
     #expect(
       normalizer.actions(for: .leftMouseUp)
         == MouseGestureEventNormalizer.Actions()

--- a/Tests/DefiMacOSTests/WindowDiscoveryTests.swift
+++ b/Tests/DefiMacOSTests/WindowDiscoveryTests.swift
@@ -1,15 +1,15 @@
 import ApplicationServices
 import DefiModel
 import Testing
-import XCTest
 
 @testable import DefiMacOS
 
-final class WindowDiscoveryTests: XCTestCase {
+struct WindowDiscoveryTests {
   private let processID: pid_t = 42
   private let frame = Rect(x: 4, y: 34, width: 2_554, height: 1_354)
 
-  func testTransientWindowOmissionExpiresAfterGracePeriod() {
+  @Test
+  func `Transient window omission expires after grace period`() {
     let windowID = WindowID(rawValue: 42)
     let first = retainedWindowIDsWithinGracePeriod(
       [windowID],
@@ -17,8 +17,8 @@ final class WindowDiscoveryTests: XCTestCase {
       now: 10,
       gracePeriod: 0.75
     )
-    XCTAssertEqual(first.windowIDs, [windowID])
-    XCTAssertEqual(first.deadlines[windowID], 10.75)
+    #expect(first.windowIDs == [windowID])
+    #expect(first.deadlines[windowID] == 10.75)
 
     let pending = retainedWindowIDsWithinGracePeriod(
       [windowID],
@@ -26,7 +26,7 @@ final class WindowDiscoveryTests: XCTestCase {
       now: 10.7,
       gracePeriod: 0.75
     )
-    XCTAssertEqual(pending.windowIDs, [windowID])
+    #expect(pending.windowIDs == [windowID])
 
     let expired = retainedWindowIDsWithinGracePeriod(
       [windowID],
@@ -34,52 +34,50 @@ final class WindowDiscoveryTests: XCTestCase {
       now: 10.75,
       gracePeriod: 0.75
     )
-    XCTAssertTrue(expired.windowIDs.isEmpty)
-    XCTAssertTrue(expired.deadlines.isEmpty)
+    #expect(expired.windowIDs.isEmpty)
+    #expect(expired.deadlines.isEmpty)
   }
 
-  func testTransientProcessDisagreementDefersFocusResolution() {
-    XCTAssertNil(
+  @Test
+  func `Transient process disagreement defers focus resolution`() {
+    #expect(
       consistentFocusedProcessID(
         accessibilityProcessID: 42,
         frontmostProcessID: 7
-      )
-    )
+      ) == nil)
   }
 
-  func testFrontmostNativeFocusEventOverridesStaleAccessibilityProcess() {
-    XCTAssertEqual(
+  @Test
+  func `Frontmost native focus event overrides stale accessibility process`() {
+    #expect(
       consistentFocusedProcessID(
         accessibilityProcessID: 7,
         frontmostProcessID: 42,
         verifiedNativeFocusProcessID: 42
-      ),
-      42
-    )
+      ) == 42)
   }
 
-  func testAccessibilityProcessIsFallbackWithoutFrontmostApplication() {
-    XCTAssertEqual(
+  @Test
+  func `Accessibility process is fallback without frontmost application`() {
+    #expect(
       consistentFocusedProcessID(
         accessibilityProcessID: 42,
         frontmostProcessID: nil
-      ),
-      42
-    )
+      ) == 42)
   }
 
-  func testMatchingFrontmostAndAccessibilityProcessesResolveFocus() {
-    XCTAssertEqual(
+  @Test
+  func `Matching frontmost and accessibility processes resolve focus`() {
+    #expect(
       consistentFocusedProcessID(
         accessibilityProcessID: 42,
         frontmostProcessID: 42
-      ),
-      42
-    )
+      ) == 42)
   }
 
   @MainActor
-  func testPendingNativeFocusReusesStableWindowOnlyAfterProcessVerification() {
+  @Test
+  func `Pending native focus reuses stable window only after process verification`() {
     let platform = MacOSPlatform()
     let window = Window(
       id: WindowID(rawValue: 1),
@@ -91,22 +89,21 @@ final class WindowDiscoveryTests: XCTestCase {
     )
     platform.lastFocusedWindowByProcess[processID] = window.id
 
-    XCTAssertEqual(platform.stableWindowID(processID: processID, in: [window]), window.id)
+    #expect(platform.stableWindowID(processID: processID, in: [window]) == window.id)
 
     platform.nativeFocusEventPending = true
-    XCTAssertNil(platform.stableWindowID(processID: processID, in: [window]))
-    XCTAssertEqual(
+    #expect(platform.stableWindowID(processID: processID, in: [window]) == nil)
+    #expect(
       platform.stableWindowID(
         processID: processID,
         in: [window],
         allowPendingNativeFocus: true
-      ),
-      window.id
-    )
+      ) == window.id)
   }
 
   @MainActor
-  func testPendingNativeFocusAcceptsVerifiedSingleWindowFallback() {
+  @Test
+  func `Pending native focus accepts verified single window fallback`() {
     let platform = MacOSPlatform()
     let window = Window(
       id: WindowID(rawValue: 1),
@@ -119,13 +116,11 @@ final class WindowDiscoveryTests: XCTestCase {
     platform.nativeFocusEventPending = true
     platform.nativeFocusEventProcessIDs = [processID]
 
-    XCTAssertEqual(
-      platform.stableWindowID(processID: processID, in: [window]),
-      window.id
-    )
+    #expect(platform.stableWindowID(processID: processID, in: [window]) == window.id)
   }
 
-  func testFocusedAuxiliaryWindowDoesNotSelectDistantManagedWindow() {
+  @Test
+  func `Focused auxiliary window does not select distant managed window`() {
     let managed = Window(
       id: WindowID(rawValue: 1),
       appID: "com.example.app",
@@ -135,16 +130,16 @@ final class WindowDiscoveryTests: XCTestCase {
       monitorID: MonitorID(rawValue: 1)
     )
 
-    XCTAssertNil(
+    #expect(
       focusedWindowIDMatchingFrame(
         processID: processID,
         focusedFrame: Rect(x: 400, y: 300, width: 500, height: 300),
         windows: [managed]
-      )
-    )
+      ) == nil)
   }
 
-  func testFocusedManagedWindowMatchesSmallSnapshotFrameDrift() {
+  @Test
+  func `Focused managed window matches small snapshot frame drift`() {
     let managed = Window(
       id: WindowID(rawValue: 1),
       appID: "com.example.app",
@@ -154,7 +149,7 @@ final class WindowDiscoveryTests: XCTestCase {
       monitorID: MonitorID(rawValue: 1)
     )
 
-    XCTAssertEqual(
+    #expect(
       focusedWindowIDMatchingFrame(
         processID: processID,
         focusedFrame: Rect(
@@ -164,12 +159,11 @@ final class WindowDiscoveryTests: XCTestCase {
           height: frame.height
         ),
         windows: [managed]
-      ),
-      managed.id
-    )
+      ) == managed.id)
   }
 
-  func testWindowMatchingPrefersExactFrameOverEmptyTitle() {
+  @Test
+  func `Window matching prefers exact frame over empty title`() {
     let exactFrame = CGWindowRecord(
       id: 1,
       processID: processID,
@@ -192,10 +186,11 @@ final class WindowDiscoveryTests: XCTestCase {
       records: [emptyTitleStrip, exactFrame]
     )
 
-    XCTAssertEqual(match?.id, exactFrame.id)
+    #expect(match?.id == exactFrame.id)
   }
 
-  func testWindowMatchingRejectsUnrelatedSurface() {
+  @Test
+  func `Window matching rejects unrelated surface`() {
     let unrelated = CGWindowRecord(
       id: 1,
       processID: processID,
@@ -204,29 +199,28 @@ final class WindowDiscoveryTests: XCTestCase {
       frame: Rect(x: 104, y: 34, width: 2_554, height: 1_354)
     )
 
-    XCTAssertNil(
+    #expect(
       bestCGWindow(
         processID: processID,
         title: "Picture in Picture",
         frame: frame,
         records: [unrelated]
-      )
-    )
+      ) == nil)
   }
 
-  func testFocusRecoveryMatchesUnmanagedAuxiliaryWindowByFrame() {
+  @Test
+  func `Focus recovery matches unmanaged auxiliary window by frame`() {
     let auxiliaryFrame = Rect(x: 400, y: 300, width: 500, height: 300)
 
-    XCTAssertEqual(
+    #expect(
       closestFocusRecoveryWindowIndex(
         target: (auxiliaryFrame, "Preferences"),
         candidates: [(frame, "Main"), (auxiliaryFrame, "Preferences")]
-      ),
-      1
-    )
+      ) == 1)
   }
 
-  func testFocusRecoverySearchesBeyondFirst32Candidates() {
+  @Test
+  func `Focus recovery searches beyond first 32 candidates`() {
     let targetFrame = Rect(x: 400, y: 300, width: 500, height: 300)
     var candidates = Array(
       repeating: (Rect(x: 0, y: 0, width: 100, height: 100), "Other"),
@@ -234,43 +228,41 @@ final class WindowDiscoveryTests: XCTestCase {
     )
     candidates.append((targetFrame, "Preferences"))
 
-    XCTAssertEqual(
+    #expect(
       closestFocusRecoveryWindowIndex(
         target: (targetFrame, "Preferences"),
         candidates: candidates
-      ),
-      32
-    )
+      ) == 32)
   }
 
-  func testFocusRecoveryRejectsDistantAccessibilityWindow() {
-    XCTAssertNil(
+  @Test
+  func `Focus recovery rejects distant accessibility window`() {
+    #expect(
       closestFocusRecoveryWindowIndex(
         target: (
           Rect(x: 400, y: 300, width: 500, height: 300),
           "Preferences"
         ),
         candidates: [(frame, "Main")]
-      )
-    )
+      ) == nil)
   }
 
-  func testFocusRecoveryUsesTitleToBreakGeometryTie() {
+  @Test
+  func `Focus recovery uses title to break geometry tie`() {
     let auxiliaryFrame = Rect(x: 400, y: 300, width: 500, height: 300)
 
-    XCTAssertEqual(
+    #expect(
       closestFocusRecoveryWindowIndex(
         target: (auxiliaryFrame, "Preferences"),
         candidates: [
           (auxiliaryFrame, "Main"),
           (auxiliaryFrame, "Preferences"),
         ]
-      ),
-      1
-    )
+      ) == 1)
   }
 
-  func testWindowMatchingUsesTitleToBreakGeometryTie() {
+  @Test
+  func `Window matching uses title to break geometry tie`() {
     let wrongTitle = CGWindowRecord(
       id: 1,
       processID: processID,
@@ -293,10 +285,11 @@ final class WindowDiscoveryTests: XCTestCase {
       records: [wrongTitle, matchingTitle]
     )
 
-    XCTAssertEqual(match?.id, matchingTitle.id)
+    #expect(match?.id == matchingTitle.id)
   }
 
-  func testPreferredWindowIDRequiresLiveCGRecordFromSameProcess() {
+  @Test
+  func `Preferred window ID requires live CG record from same process`() {
     let live = CGWindowRecord(
       id: 42,
       processID: processID,
@@ -312,7 +305,7 @@ final class WindowDiscoveryTests: XCTestCase {
       frame: frame
     )
 
-    XCTAssertEqual(
+    #expect(
       cgWindowRecordForDiscovery(
         preferredWindowID: WindowID(rawValue: 42),
         processID: processID,
@@ -320,10 +313,8 @@ final class WindowDiscoveryTests: XCTestCase {
         frame: frame,
         records: [live],
         excluding: []
-      )?.id,
-      42
-    )
-    XCTAssertNil(
+      )?.id == 42)
+    #expect(
       cgWindowRecordForDiscovery(
         preferredWindowID: WindowID(rawValue: 42),
         processID: processID,
@@ -331,9 +322,8 @@ final class WindowDiscoveryTests: XCTestCase {
         frame: frame,
         records: [],
         excluding: []
-      )
-    )
-    XCTAssertNil(
+      ) == nil)
+    #expect(
       cgWindowRecordForDiscovery(
         preferredWindowID: WindowID(rawValue: 42),
         processID: processID,
@@ -341,9 +331,8 @@ final class WindowDiscoveryTests: XCTestCase {
         frame: frame,
         records: [recycledByAnotherProcess],
         excluding: []
-      )
-    )
-    XCTAssertNil(
+      ) == nil)
+    #expect(
       cgWindowRecordForDiscovery(
         preferredWindowID: WindowID(rawValue: 42),
         processID: processID,
@@ -351,11 +340,11 @@ final class WindowDiscoveryTests: XCTestCase {
         frame: frame,
         records: [live],
         excluding: [42]
-      )
-    )
+      ) == nil)
   }
 
-  func testAXWindowIDBypassesRedactedWindowServerGeometry() {
+  @Test
+  func `AX window ID bypasses redacted window server geometry`() {
     let live = CGWindowRecord(
       id: 42,
       processID: processID,
@@ -364,7 +353,7 @@ final class WindowDiscoveryTests: XCTestCase {
       frame: Rect(x: 0, y: 940, width: 500, height: 500)
     )
 
-    XCTAssertEqual(
+    #expect(
       cgWindowRecordForDiscovery(
         axWindowID: 42,
         preferredWindowID: nil,
@@ -373,12 +362,11 @@ final class WindowDiscoveryTests: XCTestCase {
         frame: frame,
         records: [live],
         excluding: []
-      )?.id,
-      42
-    )
+      )?.id == 42)
   }
 
-  func testMissingPreferredWindowRecordDoesNotRematchUnrelatedLiveWindow() {
+  @Test
+  func `Missing preferred window record does not rematch unrelated live window`() {
     let otherLiveWindow = CGWindowRecord(
       id: 43,
       processID: processID,
@@ -387,7 +375,7 @@ final class WindowDiscoveryTests: XCTestCase {
       frame: frame
     )
 
-    XCTAssertNil(
+    #expect(
       cgWindowRecordForDiscovery(
         preferredWindowID: WindowID(rawValue: 42),
         processID: processID,
@@ -395,9 +383,8 @@ final class WindowDiscoveryTests: XCTestCase {
         frame: frame,
         records: [otherLiveWindow],
         excluding: []
-      )
-    )
-    XCTAssertEqual(
+      ) == nil)
+    #expect(
       cgWindowRecordForDiscovery(
         preferredWindowID: nil,
         processID: processID,
@@ -405,12 +392,26 @@ final class WindowDiscoveryTests: XCTestCase {
         frame: frame,
         records: [otherLiveWindow],
         excluding: []
-      )?.id,
-      43
-    )
+      )?.id == 43)
   }
 
-  func testAuxiliaryRolesCanMatchFloatingLevelWindowRecords() {
+  @Test(arguments: [
+    (kAXWindowRole, Optional("AXDialog"), false, true),
+    (kAXWindowRole, Optional("AXFloatingWindow"), false, true),
+    (kAXWindowRole, Optional("AXSystemDialog"), false, true),
+    (kAXWindowRole, Optional("AXSystemFloatingWindow"), false, true),
+    (kAXSheetRole, nil, false, true),
+    (kAXWindowRole, Optional(kAXStandardWindowSubrole), false, false),
+    (kAXWindowRole, Optional(kAXUnknownSubrole), true, true),
+  ])
+  func `Window roles select eligible window server layers`(
+    testCase: (
+      role: String,
+      subrole: String?,
+      allowsConfiguredNonzeroLayer: Bool,
+      includesPanel: Bool
+    )
+  ) {
     let normal = CGWindowRecord(
       id: 1,
       processID: processID,
@@ -426,42 +427,22 @@ final class WindowDiscoveryTests: XCTestCase {
       frame: frame
     )
 
-    for (role, subrole) in [
-      (kAXWindowRole, "AXDialog"),
-      (kAXWindowRole, "AXFloatingWindow"),
-      (kAXWindowRole, "AXSystemDialog"),
-      (kAXWindowRole, "AXSystemFloatingWindow"),
-      (kAXSheetRole, nil),
-    ] {
-      XCTAssertEqual(
-        eligibleCGWindowRecords(
-          role: role,
-          for: subrole,
-          in: [normal, panel]
-        ).map(\.id),
-        [normal.id, panel.id]
-      )
-    }
-    XCTAssertEqual(
+    let expected =
+      testCase.includesPanel
+      ? [normal.id, panel.id]
+      : [normal.id]
+
+    #expect(
       eligibleCGWindowRecords(
-        role: kAXWindowRole,
-        for: kAXStandardWindowSubrole,
+        role: testCase.role,
+        for: testCase.subrole,
+        allowsConfiguredNonzeroLayer: testCase.allowsConfiguredNonzeroLayer,
         in: [normal, panel]
-      ).map(\.id),
-      [normal.id]
-    )
-    XCTAssertEqual(
-      eligibleCGWindowRecords(
-        role: kAXWindowRole,
-        for: kAXUnknownSubrole,
-        allowsConfiguredNonzeroLayer: true,
-        in: [normal, panel]
-      ).map(\.id),
-      [normal.id, panel.id]
-    )
+      ).map(\.id) == expected)
   }
 
-  func testWindowFrameSnapshotSelectsRequestedFloatingWindow() {
+  @Test
+  func `Window frame snapshot selects requested floating window`() {
     let requested = CGWindowRecord(
       id: 2,
       processID: processID,
@@ -477,17 +458,16 @@ final class WindowDiscoveryTests: XCTestCase {
       frame: Rect(x: 100, y: 100, width: 800, height: 600)
     )
 
-    XCTAssertEqual(
+    #expect(
       framesByWindowID(
         for: [WindowID(rawValue: UInt64(requested.id))],
         in: [unrelated, requested]
-      ),
-      [WindowID(rawValue: UInt64(requested.id)): frame]
-    )
+      ) == [WindowID(rawValue: UInt64(requested.id)): frame])
   }
 
-  func testStandardClosableResizableWindowIsTiled() {
-    XCTAssertEqual(
+  @Test
+  func `Standard closable resizable window is tiled`() {
+    #expect(
       classifyWindow(
         role: kAXWindowRole,
         subrole: kAXStandardWindowSubrole,
@@ -496,13 +476,12 @@ final class WindowDiscoveryTests: XCTestCase {
         canResize: true,
         configuredFloating: false,
         forceTiling: false
-      ),
-      .tiled
-    )
+      ) == .tiled)
   }
 
-  func testControlLessPictureInPictureWindowFloats() {
-    XCTAssertEqual(
+  @Test
+  func `Control less picture in picture window floats`() {
+    #expect(
       classifyWindow(
         role: kAXWindowRole,
         subrole: kAXStandardWindowSubrole,
@@ -511,34 +490,32 @@ final class WindowDiscoveryTests: XCTestCase {
         canResize: false,
         configuredFloating: false,
         forceTiling: false
-      ),
-      .floating
-    )
+      ) == .floating)
   }
 
-  func testSystemDialogsAndSheetsFloatByDefault() {
-    for (role, subrole) in [
-      (kAXWindowRole, "AXSystemDialog"),
-      (kAXWindowRole, "AXFloatingWindow"),
-      (kAXSheetRole, nil),
-    ] {
-      XCTAssertEqual(
-        classifyWindow(
-          role: role,
-          subrole: subrole,
-          appID: "com.example.app",
-          hasCloseButton: false,
-          canResize: false,
-          configuredFloating: false,
-          forceTiling: false
-        ),
-        .floating
-      )
-    }
+  @Test(arguments: [
+    (kAXWindowRole, Optional("AXSystemDialog")),
+    (kAXWindowRole, Optional("AXFloatingWindow")),
+    (kAXSheetRole, nil),
+  ])
+  func `System dialogs and sheets float by default`(
+    testCase: (role: String, subrole: String?)
+  ) {
+    #expect(
+      classifyWindow(
+        role: testCase.role,
+        subrole: testCase.subrole,
+        appID: "com.example.app",
+        hasCloseButton: false,
+        canResize: false,
+        configuredFloating: false,
+        forceTiling: false
+      ) == .floating)
   }
 
-  func testModalStandardWindowFloatsEvenWhenResizable() {
-    XCTAssertEqual(
+  @Test
+  func `Modal standard window floats even when resizable`() {
+    #expect(
       classifyWindow(
         role: kAXWindowRole,
         subrole: kAXStandardWindowSubrole,
@@ -548,13 +525,12 @@ final class WindowDiscoveryTests: XCTestCase {
         isModal: true,
         configuredFloating: false,
         forceTiling: false
-      ),
-      .floating
-    )
+      ) == .floating)
   }
 
-  func testQuickLookServiceWindowFloatsEvenWhenStandard() {
-    XCTAssertEqual(
+  @Test
+  func `Quick look service window floats even when standard`() {
+    #expect(
       classifyWindow(
         role: kAXWindowRole,
         subrole: kAXStandardWindowSubrole,
@@ -563,13 +539,12 @@ final class WindowDiscoveryTests: XCTestCase {
         canResize: true,
         configuredFloating: false,
         forceTiling: false
-      ),
-      .floating
-    )
+      ) == .floating)
   }
 
-  func testConfiguredFloatingTracksUnknownAuxiliaryWindow() {
-    XCTAssertEqual(
+  @Test
+  func `Configured floating tracks unknown auxiliary window`() {
+    #expect(
       classifyWindow(
         role: kAXWindowRole,
         subrole: kAXUnknownSubrole,
@@ -578,115 +553,110 @@ final class WindowDiscoveryTests: XCTestCase {
         canResize: false,
         configuredFloating: true,
         forceTiling: false
-      ),
-      .floating
-    )
+      ) == .floating)
   }
 
-  func testTransientCloseButtonFailurePreservesManagedWindow() {
-    XCTAssertTrue(
+  @Test
+  func `Transient close button failure preserves managed window`() {
+    #expect(
       shouldTreatWindowAsClosable(
         error: .cannotComplete,
         hasValue: false,
         wasPreviouslyManaged: true
-      )
-    )
-    XCTAssertFalse(
+      ))
+    #expect(
       shouldTreatWindowAsClosable(
         error: .cannotComplete,
         hasValue: false,
         wasPreviouslyManaged: false
-      )
-    )
+      ) == false)
   }
 
-  func testTransientMetadataFailurePreservesPreviousDisposition() {
-    let cases: [(WindowDisposition?, WindowDisposition)] = [
-      (nil, WindowDisposition.unavailable),
-      (.tiled, .tiled),
-      (.floating, .floating),
-    ]
-    for (closeButtonError, sizeSettableError) in [
+  @Test(
+    arguments: [
       (AXError.cannotComplete, AXError.success),
-      (.success, .cannotComplete),
-    ] {
-      for (previous, expected) in cases {
-        XCTAssertEqual(
-          fallbackDispositionForTransientWindowMetadata(
-            role: kAXWindowRole,
-            subrole: kAXStandardWindowSubrole,
-            closeButtonError: closeButtonError,
-            sizeSettableError: sizeSettableError,
-            previousDisposition: previous
-          ),
-          expected
-        )
-      }
-    }
-    XCTAssertNil(
+      (AXError.success, AXError.cannotComplete),
+    ],
+    [
+      (Optional<WindowDisposition>.none, WindowDisposition.unavailable),
+      (WindowDisposition.tiled, .tiled),
+      (WindowDisposition.floating, .floating),
+    ])
+  func `Transient metadata failure preserves previous disposition`(
+    errors: (closeButton: AXError, sizeSettable: AXError),
+    dispositions: (previous: WindowDisposition?, expected: WindowDisposition)
+  ) {
+    #expect(
+      fallbackDispositionForTransientWindowMetadata(
+        role: kAXWindowRole,
+        subrole: kAXStandardWindowSubrole,
+        closeButtonError: errors.closeButton,
+        sizeSettableError: errors.sizeSettable,
+        previousDisposition: dispositions.previous
+      ) == dispositions.expected)
+  }
+
+  @Test
+  func `Successful metadata does not need a fallback disposition`() {
+    #expect(
       fallbackDispositionForTransientWindowMetadata(
         role: kAXWindowRole,
         subrole: kAXStandardWindowSubrole,
         closeButtonError: .success,
         sizeSettableError: .success,
         previousDisposition: .floating
-      )
-    )
+      ) == nil)
   }
 
-  func testUnsupportedSizeAttributeMeansFixedSize() {
-    XCTAssertFalse(
+  @Test
+  func `Unsupported size attribute means fixed size`() {
+    #expect(
       windowCanResize(
         sizeSettableError: .attributeUnsupported,
         isSettable: false
-      )
-    )
-    XCTAssertTrue(
+      ) == false)
+    #expect(
       windowCanResize(
         sizeSettableError: .cannotComplete,
         isSettable: false
-      )
-    )
+      ))
   }
 
-  func testTransientModalReadPreservesCachedValue() {
-    XCTAssertEqual(
+  @Test
+  func `Transient modal read preserves cached value`() {
+    #expect(
       resolvedWindowModalState(
         error: .cannotComplete,
         observedValue: nil,
         cachedValue: true
-      ),
-      true
-    )
-    XCTAssertNil(
+      ) == true)
+    #expect(
       resolvedWindowModalState(
         error: .cannotComplete,
         observedValue: nil,
         cachedValue: nil
-      )
-    )
-    XCTAssertEqual(
+      ) == nil)
+    #expect(
       resolvedWindowModalState(
         error: .attributeUnsupported,
         observedValue: nil,
         cachedValue: true
-      ),
-      false
-    )
+      ) == false)
   }
 
-  func testMissingCloseButtonRemainsUnmanaged() {
-    XCTAssertFalse(
+  @Test
+  func `Missing close button remains unmanaged`() {
+    #expect(
       shouldTreatWindowAsClosable(
         error: .noValue,
         hasValue: false,
         wasPreviouslyManaged: true
-      )
-    )
+      ) == false)
   }
 
-  func testForceTilingOverridesWindowShapeFilter() {
-    XCTAssertEqual(
+  @Test
+  func `Force tiling overrides window shape filter`() {
+    #expect(
       classifyWindow(
         role: kAXWindowRole,
         subrole: kAXUnknownSubrole,
@@ -695,45 +665,43 @@ final class WindowDiscoveryTests: XCTestCase {
         canResize: false,
         configuredFloating: false,
         forceTiling: true
-      ),
-      .tiled
-    )
+      ) == .tiled)
   }
 
-  func testApplicationActivationSelectsTargetWithUnmanagedAuxiliaryWindows() {
-    XCTAssertTrue(
+  @Test
+  func `Application activation selects target with unmanaged auxiliary windows`() {
+    #expect(
       shouldSelectSpecificWindow(
         activatesApplication: true,
         hasUnmanagedAuxiliaryWindows: true,
         hasMultipleManagedWindows: false,
         focusWritePending: false,
         targetWasLastFocused: true
-      )
-    )
+      ))
   }
 
-  func testStableSingleWindowFocusKeepsFastPath() {
-    XCTAssertFalse(
+  @Test
+  func `Stable single window focus keeps fast path`() {
+    #expect(
       shouldSelectSpecificWindow(
         activatesApplication: true,
         hasUnmanagedAuxiliaryWindows: false,
         hasMultipleManagedWindows: false,
         focusWritePending: false,
         targetWasLastFocused: true
-      )
-    )
+      ) == false)
   }
 
-  func testFrontmostSingleWindowDefersSelectionToAsyncValidation() {
-    XCTAssertFalse(
+  @Test
+  func `Frontmost single window defers selection to async validation`() {
+    #expect(
       shouldSelectSpecificWindow(
         activatesApplication: false,
         hasUnmanagedAuxiliaryWindows: true,
         hasMultipleManagedWindows: false,
         focusWritePending: false,
         targetWasLastFocused: true
-      )
-    )
+      ) == false)
   }
 }
 
@@ -773,8 +741,8 @@ struct WindowClassificationReviewFeedbackTests {
   }
 
   @Test func repeatedBatchFailuresDisableBatchedAttributeReads() {
-    #expect(!shouldDisableBatchedWindowAttributeReads(failureCount: 1))
-    #expect(!shouldDisableBatchedWindowAttributeReads(failureCount: 2))
+    #expect(shouldDisableBatchedWindowAttributeReads(failureCount: 1) == false)
+    #expect(shouldDisableBatchedWindowAttributeReads(failureCount: 2) == false)
     #expect(shouldDisableBatchedWindowAttributeReads(failureCount: 3))
   }
 

--- a/Tests/DefiMacOSTests/WindowSnapshotStabilityTests.swift
+++ b/Tests/DefiMacOSTests/WindowSnapshotStabilityTests.swift
@@ -31,11 +31,10 @@ struct WindowSnapshotStabilityTests {
       )
     )
     #expect(
-      !preparedCGWindowInventoryIsCurrent(
+      preparedCGWindowInventoryIsCurrent(
         capturedGeneration: 4,
         currentGeneration: 5
-      )
-    )
+      ) == false)
   }
 
   @Test func preparedAttributesAreRejectedAfterInputOrObservationChanges() {
@@ -53,7 +52,7 @@ struct WindowSnapshotStabilityTests {
       )
     )
     #expect(
-      !preparedAXWindowAttributesAreCurrent(
+      preparedAXWindowAttributesAreCurrent(
         capturedGeneration: 4,
         currentGeneration: 5,
         capturedInputTimestamp: 10,
@@ -62,10 +61,9 @@ struct WindowSnapshotStabilityTests {
         currentWindowIDs: windowIDs,
         capturedProcessIDs: [42],
         currentProcessIDs: [42]
-      )
-    )
+      ) == false)
     #expect(
-      !preparedAXWindowAttributesAreCurrent(
+      preparedAXWindowAttributesAreCurrent(
         capturedGeneration: 4,
         currentGeneration: 4,
         capturedInputTimestamp: 10,
@@ -74,8 +72,7 @@ struct WindowSnapshotStabilityTests {
         currentWindowIDs: windowIDs,
         capturedProcessIDs: [42],
         currentProcessIDs: [42]
-      )
-    )
+      ) == false)
   }
 
   @Test func applicationInventoryUsesEventsAndBoundedWatchdog() {
@@ -101,12 +98,11 @@ struct WindowSnapshotStabilityTests {
       )
     )
     #expect(
-      !applicationInventoryRefreshIsRequired(
+      applicationInventoryRefreshIsRequired(
         hasCompletedSnapshot: true,
         topologyRequiresFullSnapshot: false,
         forced: false
-      )
-    )
+      ) == false)
   }
 
   @Test func windowListUsesCacheUntilTopologyOrWatchdogInvalidation() {
@@ -132,12 +128,11 @@ struct WindowSnapshotStabilityTests {
       )
     )
     #expect(
-      !applicationWindowListRefreshIsRequired(
+      applicationWindowListRefreshIsRequired(
         hasCachedWindows: true,
         refreshesAllWindowLists: false,
         topologyProcessWasInvalidated: false
-      )
-    )
+      ) == false)
   }
 
   @Test func windowListWatchdogRetriesPreviouslyUnmatchedWindows() {
@@ -163,12 +158,11 @@ struct WindowSnapshotStabilityTests {
       )
     )
     #expect(
-      !unmatchedWindowCacheRequiresFullRetry(
+      unmatchedWindowCacheRequiresFullRetry(
         eventRequiresFullSnapshot: false,
         forceFullWindowRefresh: false,
         forceWindowListRefresh: false
-      )
-    )
+      ) == false)
   }
 
   @Test func unavailableNewWindowUsesDeduplicatedShortRetry() {
@@ -206,23 +200,20 @@ struct WindowSnapshotStabilityTests {
       )
     )
     #expect(
-      !cgWindowInventoryRetryIsRequired(
+      cgWindowInventoryRetryIsRequired(
         attempts: nil,
         forceWindowListRefresh: true
-      )
-    )
+      ) == false)
     #expect(
-      !cgWindowInventoryRetryIsRequired(
+      cgWindowInventoryRetryIsRequired(
         attempts: 3,
         forceWindowListRefresh: true
-      )
-    )
+      ) == false)
     #expect(
-      !cgWindowInventoryRetryIsRequired(
+      cgWindowInventoryRetryIsRequired(
         attempts: 0,
         forceWindowListRefresh: false
-      )
-    )
+      ) == false)
   }
 
   @Test func snapshotDurationPercentilesAreBoundedAndDeterministic() {

--- a/Tests/DefiModelTests/ModelTests.swift
+++ b/Tests/DefiModelTests/ModelTests.swift
@@ -1,8 +1,9 @@
 import DefiModel
-import XCTest
+import Testing
 
-final class ModelTests: XCTestCase {
-  func testConstructorsUseSafeDefaults() {
+struct ModelTests {
+  @Test
+  func `Constructors use safe defaults`() {
     let window = Window(
       id: WindowID(rawValue: 1),
       appID: "app",
@@ -12,101 +13,97 @@ final class ModelTests: XCTestCase {
     let column = Column(window: WindowID(rawValue: 1), width: .fraction(0.72))
     let workspace = Workspace(id: WorkspaceID(rawValue: "1"))
 
-    XCTAssertNil(window.role)
-    XCTAssertNil(window.processID)
-    XCTAssertFalse(window.floating)
-    XCTAssertFalse(window.forceTiling)
-    XCTAssertFalse(window.intrinsicSize)
-    XCTAssertEqual(column.focusedWindow, 0)
-    XCTAssertNil(column.preMaximizedWidth)
-    XCTAssertEqual(workspace.focusedColumn, 0)
-    XCTAssertTrue(workspace.columns.isEmpty)
-    XCTAssertTrue(workspace.floatingWindows.isEmpty)
+    #expect(window.role == nil)
+    #expect(window.processID == nil)
+    #expect(window.floating == false)
+    #expect(window.forceTiling == false)
+    #expect(window.intrinsicSize == false)
+    #expect(column.focusedWindow == 0)
+    #expect(column.preMaximizedWidth == nil)
+    #expect(workspace.focusedColumn == 0)
+    #expect(workspace.columns.isEmpty)
+    #expect(workspace.floatingWindows.isEmpty)
   }
 
-  func testOnlyFollowingWorkspaceCommandsActivateWorkspace() {
-    XCTAssertTrue(
-      Command.switchWorkspace(WorkspaceID(rawValue: "web")).activatesWorkspace
-    )
-    XCTAssertTrue(
-      Command.moveWindowToWorkspace(WorkspaceID(rawValue: "web")).activatesWorkspace
-    )
-    XCTAssertFalse(
-      Command.sendWindowToWorkspace(WorkspaceID(rawValue: "web")).activatesWorkspace
-    )
-    XCTAssertFalse(Command.focusColumn(.right).activatesWorkspace)
-    XCTAssertFalse(Command.cycleWidth(.next).activatesWorkspace)
-    XCTAssertTrue(
-      Command.moveWindowToWorkspace(WorkspaceID(rawValue: "web"))
-        .movesWindowBetweenWorkspaces
-    )
-    XCTAssertTrue(
-      Command.sendWindowToWorkspace(WorkspaceID(rawValue: "web"))
-        .movesWindowBetweenWorkspaces
-    )
-    XCTAssertFalse(
-      Command.switchWorkspace(WorkspaceID(rawValue: "web"))
-        .movesWindowBetweenWorkspaces
-    )
+  @Test(arguments: [
+    (Command.switchWorkspace(WorkspaceID(rawValue: "web")), true, false),
+    (Command.moveWindowToWorkspace(WorkspaceID(rawValue: "web")), true, true),
+    (Command.sendWindowToWorkspace(WorkspaceID(rawValue: "web")), false, true),
+    (Command.focusColumn(.right), false, false),
+    (Command.cycleWidth(.next), false, false),
+  ])
+  func `Workspace command behavior is explicit`(
+    testCase: (command: Command, activatesWorkspace: Bool, movesWindow: Bool)
+  ) {
+    #expect(testCase.command.activatesWorkspace == testCase.activatesWorkspace)
+    #expect(testCase.command.movesWindowBetweenWorkspaces == testCase.movesWindow)
   }
 
-  func testParsesSharedCommands() throws {
-    XCTAssertEqual(try parseCommand("focus-column left"), .focusColumn(.left))
-    XCTAssertEqual(try parseCommand("focus-column first"), .focusColumn(.first))
-    XCTAssertEqual(try parseCommand("focus-window last"), .focusWindow(.last))
-    XCTAssertEqual(try parseCommand("move-column last"), .moveColumn(.last))
-    XCTAssertEqual(try parseCommand("move-window down"), .moveWindow(.down))
-    XCTAssertEqual(
-      try parseCommand("move-column-to-monitor left"),
-      .moveColumnToMonitor(.left)
-    )
-    XCTAssertEqual(
-      try parseCommand("move-window-to-monitor up"),
-      .moveWindowToMonitor(.up)
-    )
-    XCTAssertEqual(try parseCommand("focus-floating next"), .focusFloating(.next))
-    XCTAssertEqual(
-      try parseCommand("workspace sim"),
-      .switchWorkspace(WorkspaceID(rawValue: "sim"))
-    )
-    XCTAssertEqual(try parseCommand("maximize-column"), .maximizeColumn)
-    XCTAssertEqual(try parseCommand("toggle-floating"), .toggleFloating)
-    XCTAssertEqual(try parseCommand("activate-floating"), .activateFloating)
+  @Test(arguments: [
+    ("focus-column left", Command.focusColumn(.left)),
+    ("focus-column first", Command.focusColumn(.first)),
+    ("focus-window last", Command.focusWindow(.last)),
+    ("move-column last", Command.moveColumn(.last)),
+    ("move-window down", Command.moveWindow(.down)),
+    ("move-column-to-monitor left", Command.moveColumnToMonitor(.left)),
+    ("move-window-to-monitor up", Command.moveWindowToMonitor(.up)),
+    ("focus-floating next", Command.focusFloating(.next)),
+    ("workspace sim", Command.switchWorkspace(WorkspaceID(rawValue: "sim"))),
+    ("maximize-column", Command.maximizeColumn),
+    ("toggle-floating", Command.toggleFloating),
+    ("activate-floating", Command.activateFloating),
+  ])
+  func `Parses shared commands`(
+    testCase: (input: String, expected: Command)
+  ) throws {
+    #expect(try parseCommand(testCase.input) == testCase.expected)
   }
 
-  func testRejectsInvalidMoveDirection() {
-    XCTAssertThrowsError(try parseCommand("move-window right")) { error in
-      XCTAssertEqual(error as? CommandParseError, .invalidDirection("right"))
-    }
-    XCTAssertThrowsError(try parseCommand("move-column-to-monitor next")) {
-      error in
-      XCTAssertEqual(error as? CommandParseError, .invalidDirection("next"))
+  @Test(arguments: [
+    ("move-window right", CommandParseError.invalidDirection("right")),
+    ("move-column-to-monitor next", CommandParseError.invalidDirection("next")),
+  ])
+  func `Rejects invalid move directions`(
+    testCase: (input: String, expectedError: CommandParseError)
+  ) {
+    #expect(throws: testCase.expectedError) {
+      try parseCommand(testCase.input)
     }
   }
 
-  func testRejectsObsoleteFullscreenCommandName() {
-    XCTAssertThrowsError(try parseCommand("toggle-fullscreen")) { error in
-      XCTAssertEqual(
-        error as? CommandParseError,
-        .unknownCommand("toggle-fullscreen")
-      )
+  @Test
+  func `Rejects obsolete fullscreen command name`() {
+    #expect(throws: CommandParseError.unknownCommand("toggle-fullscreen")) {
+      try parseCommand("toggle-fullscreen")
     }
   }
 
-  func testManagedLayoutResizeCommandsAreExplicit() {
-    XCTAssertTrue(Command.cycleWidth(.next).resizesManagedLayout)
-    XCTAssertTrue(Command.maximizeColumn.resizesManagedLayout)
-    XCTAssertTrue(Command.joinWindow(.left).resizesManagedLayout)
-    XCTAssertTrue(Command.unjoinWindows.resizesManagedLayout)
-    XCTAssertTrue(Command.moveColumnToMonitor(.right).resizesManagedLayout)
-    XCTAssertTrue(Command.moveWindowToMonitor(.right).movesWindowsAcrossMonitors)
-    XCTAssertFalse(Command.focusColumn(.right).resizesManagedLayout)
-    XCTAssertFalse(Command.toggleFloating.resizesManagedLayout)
+  @Test(arguments: [
+    (Command.cycleWidth(.next), true, false),
+    (Command.maximizeColumn, true, false),
+    (Command.joinWindow(.left), true, false),
+    (Command.unjoinWindows, true, false),
+    (Command.moveColumnToMonitor(.right), true, true),
+    (Command.moveWindowToMonitor(.right), true, true),
+    (Command.focusColumn(.right), false, false),
+    (Command.toggleFloating, false, false),
+  ])
+  func `Managed layout command behavior is explicit`(
+    testCase: (command: Command, resizesLayout: Bool, crossesMonitors: Bool)
+  ) {
+    #expect(testCase.command.resizesManagedLayout == testCase.resizesLayout)
+    #expect(
+      testCase.command.movesWindowsAcrossMonitors == testCase.crossesMonitors)
   }
 
-  func testFloatingFocusCommandsRequestExplicitFocus() {
-    XCTAssertTrue(Command.activateFloating.explicitlyFocusesFloating)
-    XCTAssertTrue(Command.focusFloating(.next).explicitlyFocusesFloating)
-    XCTAssertFalse(Command.toggleFloating.explicitlyFocusesFloating)
+  @Test(arguments: [
+    (Command.activateFloating, true),
+    (Command.focusFloating(.next), true),
+    (Command.toggleFloating, false),
+  ])
+  func `Floating focus behavior is explicit`(
+    testCase: (command: Command, expected: Bool)
+  ) {
+    #expect(testCase.command.explicitlyFocusesFloating == testCase.expected)
   }
 }

--- a/Tests/DefiRuntimeTests/FloatingWindowTests.swift
+++ b/Tests/DefiRuntimeTests/FloatingWindowTests.swift
@@ -1,13 +1,14 @@
 import DefiConfig
 import DefiModel
-import XCTest
+import Testing
 
 @testable import DefiRuntime
 
-final class FloatingWindowTests: XCTestCase {
+struct FloatingWindowTests {
   private let monitorID = MonitorID(rawValue: 1)
 
-  func testFloatingLayerActivationAndCyclingWrap() throws {
+  @Test
+  func `Floating layer activation and cycling wrap`() throws {
     var state = RuntimeState(config: Config())
     state.attachMonitor(monitorID)
     let tiled = window(40)
@@ -17,16 +18,24 @@ final class FloatingWindowTests: XCTestCase {
       try discoverWindow(floater, decision: RuleDecision(), state: &state)
     }
 
-    XCTAssertEqual(state.selectedWindowID(on: monitorID), tiled.id)
+    #expect(state.selectedWindowID(on: monitorID) == tiled.id)
     try reduce(.activateFloating, on: monitorID, state: &state)
-    XCTAssertEqual(state.selectedWindowID(on: monitorID), floaters[0].id)
+    #expect(state.selectedWindowID(on: monitorID) == floaters[0].id)
     try reduce(.focusFloating(.previous), on: monitorID, state: &state)
-    XCTAssertEqual(state.selectedWindowID(on: monitorID), floaters[1].id)
+    #expect(state.selectedWindowID(on: monitorID) == floaters[1].id)
     try reduce(.focusFloating(.next), on: monitorID, state: &state)
-    XCTAssertEqual(state.selectedWindowID(on: monitorID), floaters[0].id)
+    #expect(state.selectedWindowID(on: monitorID) == floaters[0].id)
   }
 
-  func testTiledCommandsPreserveFocusedFloaterWithoutColumns() throws {
+  @Test(arguments: [
+    Command.focusColumn(.next),
+    .focusWindow(.next),
+    .cycleWidth(.next),
+    .maximizeColumn,
+  ])
+  func `Tiled commands preserve focused floater without columns`(
+    command: Command
+  ) throws {
     var state = RuntimeState(config: Config())
     state.attachMonitor(monitorID)
     let floaters = [window(43, floating: true), window(44, floating: true)]
@@ -36,19 +45,14 @@ final class FloatingWindowTests: XCTestCase {
     try reduce(.activateFloating, on: monitorID, state: &state)
     try reduce(.focusFloating(.next), on: monitorID, state: &state)
 
-    for command in [
-      Command.focusColumn(.next),
-      .focusWindow(.next),
-      .cycleWidth(.next),
-      .maximizeColumn,
-    ] {
-      try reduce(command, on: monitorID, state: &state)
-      XCTAssertEqual(state.selectedWindowID(on: monitorID), floaters[1].id)
-      XCTAssertEqual(state.monitors[0].workspaces[0].focusedLayer, .floating)
-    }
+    try reduce(command, on: monitorID, state: &state)
+
+    #expect(state.selectedWindowID(on: monitorID) == floaters[1].id)
+    #expect(state.monitors[0].workspaces[0].focusedLayer == .floating)
   }
 
-  func testToggleFloatingUsesFallbackSelectedFloaterWithoutColumns() throws {
+  @Test
+  func `Toggle floating uses fallback selected floater without columns`() throws {
     var state = RuntimeState(config: Config())
     state.attachMonitor(monitorID)
     let floaters = [window(50, floating: true), window(51, floating: true)]
@@ -60,12 +64,13 @@ final class FloatingWindowTests: XCTestCase {
 
     try reduce(.toggleFloating, on: monitorID, state: &state)
 
-    XCTAssertEqual(state.monitors[0].workspaces[0].floatingWindows, [floaters[0].id])
-    XCTAssertEqual(state.monitors[0].workspaces[0].columns[0].windows, [floaters[1].id])
-    XCTAssertEqual(state.windows[floaters[1].id]?.floatingOrigin, .user)
+    #expect(state.monitors[0].workspaces[0].floatingWindows == [floaters[0].id])
+    #expect(state.monitors[0].workspaces[0].columns[0].windows == [floaters[1].id])
+    #expect(state.windows[floaters[1].id]?.floatingOrigin == .user)
   }
 
-  func testTilingLastFocusedFloaterClampsRemainingSelection() throws {
+  @Test
+  func `Tiling last focused floater clamps remaining selection`() throws {
     var state = RuntimeState(config: Config())
     state.attachMonitor(monitorID)
     let floaters = [window(52, floating: true), window(53, floating: true)]
@@ -78,33 +83,33 @@ final class FloatingWindowTests: XCTestCase {
     try reduce(.toggleFloating, on: monitorID, state: &state)
     try reduce(.activateFloating, on: monitorID, state: &state)
 
-    XCTAssertEqual(state.monitors[0].workspaces[0].focusedFloatingWindow, 0)
-    XCTAssertEqual(state.selectedWindowID(on: monitorID), floaters[0].id)
+    #expect(state.monitors[0].workspaces[0].focusedFloatingWindow == 0)
+    #expect(state.selectedWindowID(on: monitorID) == floaters[0].id)
   }
 
-  func testFloatingFocusCommandRequiresValidFloatingSelection() {
+  @Test
+  func `Floating focus command requires valid floating selection`() {
     let tiled = WindowID(rawValue: 70)
     let floating = WindowID(rawValue: 71)
 
-    XCTAssertFalse(
+    #expect(
       commandShouldFocusWindow(
         .activateFloating,
         previousSelectedWindowID: tiled,
         selectedWindowID: tiled,
         selectedFloatingWindowID: nil
-      )
-    )
-    XCTAssertTrue(
+      ) == false)
+    #expect(
       commandShouldFocusWindow(
         .focusFloating(.next),
         previousSelectedWindowID: floating,
         selectedWindowID: floating,
         selectedFloatingWindowID: floating
-      )
-    )
+      ))
   }
 
-  func testNativeFloatingFocusActivatesItsWorkspace() throws {
+  @Test
+  func `Native floating focus activates its workspace`() throws {
     let tools = WorkspaceID(rawValue: "tools")
     var state = RuntimeState(
       config: Config(workspaces: WorkspacesConfig(names: ["dev", tools.rawValue]))
@@ -117,12 +122,13 @@ final class FloatingWindowTests: XCTestCase {
       state: &state
     )
 
-    XCTAssertTrue(focusWindow(floater.id, state: &state))
-    XCTAssertEqual(state.monitors[0].activeWorkspace, tools)
-    XCTAssertEqual(state.selectedWindowID(on: monitorID), floater.id)
+    #expect(focusWindow(floater.id, state: &state))
+    #expect(state.monitors[0].activeWorkspace == tools)
+    #expect(state.selectedWindowID(on: monitorID) == floater.id)
   }
 
-  func testMoveFocusedFloaterPreservesLayer() throws {
+  @Test
+  func `Move focused floater preserves layer`() throws {
     let tools = WorkspaceID(rawValue: "tools")
     var state = RuntimeState(
       config: Config(workspaces: WorkspacesConfig(names: ["dev", tools.rawValue]))
@@ -141,13 +147,14 @@ final class FloatingWindowTests: XCTestCase {
 
     try reduce(.moveWindowToWorkspace(tools), on: monitorID, state: &state)
 
-    XCTAssertEqual(state.monitors[0].activeWorkspace, tools)
-    XCTAssertEqual(state.monitors[0].workspaces[1].floatingWindows, [floater.id])
-    XCTAssertEqual(state.selectedWindowID(on: monitorID), floater.id)
-    XCTAssertNil(state.suspendedTiledPlacements[floater.id])
+    #expect(state.monitors[0].activeWorkspace == tools)
+    #expect(state.monitors[0].workspaces[1].floatingWindows == [floater.id])
+    #expect(state.selectedWindowID(on: monitorID) == floater.id)
+    #expect(state.suspendedTiledPlacements[floater.id] == nil)
   }
 
-  func testMoveFocusedTileSelectsTiledLayerInTargetWorkspace() throws {
+  @Test
+  func `Move focused tile selects tiled layer in target workspace`() throws {
     let tools = WorkspaceID(rawValue: "tools")
     var state = RuntimeState(
       config: Config(workspaces: WorkspacesConfig(names: ["dev", tools.rawValue]))
@@ -166,12 +173,13 @@ final class FloatingWindowTests: XCTestCase {
 
     try reduce(.moveWindowToWorkspace(tools), on: monitorID, state: &state)
 
-    XCTAssertEqual(state.monitors[0].activeWorkspace, tools)
-    XCTAssertEqual(state.monitors[0].workspaces[1].focusedLayer, .tiled)
-    XCTAssertEqual(state.selectedWindowID(on: monitorID), tile.id)
+    #expect(state.monitors[0].activeWorkspace == tools)
+    #expect(state.monitors[0].workspaces[1].focusedLayer == .tiled)
+    #expect(state.selectedWindowID(on: monitorID) == tile.id)
   }
 
-  func testMoveFallbackSelectedFloaterWithoutColumns() throws {
+  @Test
+  func `Move fallback selected floater without columns`() throws {
     let tools = WorkspaceID(rawValue: "tools")
     var state = RuntimeState(
       config: Config(workspaces: WorkspacesConfig(names: ["dev", tools.rawValue]))
@@ -179,17 +187,18 @@ final class FloatingWindowTests: XCTestCase {
     state.attachMonitor(monitorID)
     let floater = window(62, floating: true)
     try discoverWindow(floater, decision: RuleDecision(), state: &state)
-    XCTAssertEqual(state.monitors[0].workspaces[0].focusedLayer, .tiled)
+    #expect(state.monitors[0].workspaces[0].focusedLayer == .tiled)
 
     try reduce(.moveWindowToWorkspace(tools), on: monitorID, state: &state)
 
-    XCTAssertEqual(state.monitors[0].activeWorkspace, tools)
-    XCTAssertTrue(state.monitors[0].workspaces[0].floatingWindows.isEmpty)
-    XCTAssertEqual(state.monitors[0].workspaces[1].floatingWindows, [floater.id])
-    XCTAssertEqual(state.selectedWindowID(on: monitorID), floater.id)
+    #expect(state.monitors[0].activeWorkspace == tools)
+    #expect(state.monitors[0].workspaces[0].floatingWindows.isEmpty)
+    #expect(state.monitors[0].workspaces[1].floatingWindows == [floater.id])
+    #expect(state.selectedWindowID(on: monitorID) == floater.id)
   }
 
-  func testFollowFocusSelectsNewFloatingWindow() throws {
+  @Test
+  func `Follow focus selects new floating window`() throws {
     let tools = WorkspaceID(rawValue: "tools")
     var state = RuntimeState(
       config: Config(workspaces: WorkspacesConfig(names: ["dev", tools.rawValue]))
@@ -210,12 +219,13 @@ final class FloatingWindowTests: XCTestCase {
       state: &state
     )
 
-    XCTAssertEqual(state.monitors[0].activeWorkspace, tools)
-    XCTAssertEqual(state.monitors[0].workspaces[1].focusedLayer, .floating)
-    XCTAssertEqual(state.selectedWindowID(on: monitorID), followed.id)
+    #expect(state.monitors[0].activeWorkspace == tools)
+    #expect(state.monitors[0].workspaces[1].focusedLayer == .floating)
+    #expect(state.selectedWindowID(on: monitorID) == followed.id)
   }
 
-  func testFollowFocusSelectsNewTiledWindowFromFloatingLayer() throws {
+  @Test
+  func `Follow focus selects new tiled window from floating layer`() throws {
     let tools = WorkspaceID(rawValue: "tools")
     var state = RuntimeState(
       config: Config(workspaces: WorkspacesConfig(names: ["dev", tools.rawValue]))
@@ -237,12 +247,13 @@ final class FloatingWindowTests: XCTestCase {
       state: &state
     )
 
-    XCTAssertEqual(state.monitors[0].activeWorkspace, tools)
-    XCTAssertEqual(state.monitors[0].workspaces[1].focusedLayer, .tiled)
-    XCTAssertEqual(state.selectedWindowID(on: monitorID), followed.id)
+    #expect(state.monitors[0].activeWorkspace == tools)
+    #expect(state.monitors[0].workspaces[1].focusedLayer == .tiled)
+    #expect(state.selectedWindowID(on: monitorID) == followed.id)
   }
 
-  func testAutomaticFloaterReclassifiesAsTiledWithoutStealingFocus() throws {
+  @Test
+  func `Automatic floater reclassifies as tiled without stealing focus`() throws {
     let config = Config()
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)
@@ -258,14 +269,15 @@ final class FloatingWindowTests: XCTestCase {
     reconcileWindows([selectedTile, observed], config: config, state: &state)
 
     let workspace = state.monitors[0].workspaces[0]
-    XCTAssertTrue(workspace.floatingWindows.isEmpty)
-    XCTAssertEqual(workspace.columns.flatMap(\.windows), [selectedTile.id, automatic.id])
-    XCTAssertEqual(state.windows[automatic.id]?.floating, false)
-    XCTAssertNil(state.windows[automatic.id]?.floatingOrigin)
-    XCTAssertEqual(state.selectedWindowID(on: monitorID), selectedTile.id)
+    #expect(workspace.floatingWindows.isEmpty)
+    #expect(workspace.columns.flatMap(\.windows) == [selectedTile.id, automatic.id])
+    #expect(state.windows[automatic.id]?.floating == false)
+    #expect(state.windows[automatic.id]?.floatingOrigin == nil)
+    #expect(state.selectedWindowID(on: monitorID) == selectedTile.id)
   }
 
-  func testExistingTileBecomingModalReclassifiesAsAutomaticFloater() throws {
+  @Test
+  func `Existing tile becoming modal reclassifies as automatic floater`() throws {
     let config = Config()
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)
@@ -281,14 +293,15 @@ final class FloatingWindowTests: XCTestCase {
     reconcileWindows([selectedTile, observed], config: config, state: &state)
 
     let workspace = state.monitors[0].workspaces[0]
-    XCTAssertEqual(workspace.floatingWindows, [modalTile.id])
-    XCTAssertEqual(workspace.columns.flatMap(\.windows), [selectedTile.id])
-    XCTAssertEqual(state.windows[modalTile.id]?.floating, true)
-    XCTAssertEqual(state.windows[modalTile.id]?.floatingOrigin, .automatic)
-    XCTAssertEqual(state.selectedWindowID(on: monitorID), selectedTile.id)
+    #expect(workspace.floatingWindows == [modalTile.id])
+    #expect(workspace.columns.flatMap(\.windows) == [selectedTile.id])
+    #expect(state.windows[modalTile.id]?.floating == true)
+    #expect(state.windows[modalTile.id]?.floatingOrigin == .automatic)
+    #expect(state.selectedWindowID(on: monitorID) == selectedTile.id)
   }
 
-  func testTemporaryModalRestoresStackAndColumnWidth() throws {
+  @Test
+  func `Temporary modal restores stack and column width`() throws {
     let config = Config()
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)
@@ -317,13 +330,14 @@ final class FloatingWindowTests: XCTestCase {
     reconcileWindows([sibling, observedTiled], config: config, state: &state)
 
     let restored = state.monitors[0].workspaces[0]
-    XCTAssertEqual(restored.columns.count, 1)
-    XCTAssertEqual(restored.columns[0].windows, [sibling.id, modal.id])
-    XCTAssertEqual(restored.columns[0].width, .pixels(913))
-    XCTAssertEqual(restored.columns[0].preMaximizedWidth, .fraction(0.7))
+    #expect(restored.columns.count == 1)
+    #expect(restored.columns[0].windows == [sibling.id, modal.id])
+    #expect(restored.columns[0].width == .pixels(913))
+    #expect(restored.columns[0].preMaximizedWidth == .fraction(0.7))
   }
 
-  func testTemporaryModalPreservesSiblingWidthEdits() throws {
+  @Test
+  func `Temporary modal preserves sibling width edits`() throws {
     let config = Config()
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)
@@ -349,10 +363,11 @@ final class FloatingWindowTests: XCTestCase {
 
     reconcileWindows([sibling, observedTiled], config: config, state: &state)
 
-    XCTAssertEqual(state.monitors[0].workspaces[0].columns[0].width, .pixels(950))
+    #expect(state.monitors[0].workspaces[0].columns[0].width == .pixels(950))
   }
 
-  func testConcurrentTemporaryModalsRestoreOriginalStackOrder() throws {
+  @Test
+  func `Concurrent temporary modals restore original stack order`() throws {
     let config = Config()
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)
@@ -383,13 +398,11 @@ final class FloatingWindowTests: XCTestCase {
     secondTiled.floating = false
     reconcileWindows([firstTiled, secondTiled, windows[2]], config: config, state: &state)
 
-    XCTAssertEqual(
-      state.monitors[0].workspaces[0].columns[0].windows,
-      windows.map(\.id)
-    )
+    #expect(state.monitors[0].workspaces[0].columns[0].windows == windows.map(\.id))
   }
 
-  func testConcurrentStandaloneModalsRestoreOriginalColumnOrder() throws {
+  @Test
+  func `Concurrent standalone modals restore original column order`() throws {
     let config = Config()
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)
@@ -416,13 +429,11 @@ final class FloatingWindowTests: XCTestCase {
     secondTiled.floating = false
     reconcileWindows([firstTiled, secondTiled, windows[2]], config: config, state: &state)
 
-    XCTAssertEqual(
-      state.monitors[0].workspaces[0].columns.map(\.windows),
-      windows.map { [$0.id] }
-    )
+    #expect(state.monitors[0].workspaces[0].columns.map(\.windows) == windows.map { [$0.id] })
   }
 
-  func testRestoredModalRestoresInactiveColumnFocus() throws {
+  @Test
+  func `Restored modal restores inactive column focus`() throws {
     let config = Config()
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)
@@ -447,11 +458,12 @@ final class FloatingWindowTests: XCTestCase {
     modal.floating = false
     reconcileWindows([windows[0], windows[1], modal], config: config, state: &state)
 
-    XCTAssertEqual(state.monitors[0].workspaces[0].columns[1].focusedWindow, 1)
-    XCTAssertEqual(state.selectedWindowID(on: monitorID), windows[0].id)
+    #expect(state.monitors[0].workspaces[0].columns[1].focusedWindow == 1)
+    #expect(state.selectedWindowID(on: monitorID) == windows[0].id)
   }
 
-  func testRestoredModalPreservesNewerFocusInsideItsStack() throws {
+  @Test
+  func `Restored modal preserves newer focus inside its stack`() throws {
     let config = Config()
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)
@@ -484,14 +496,12 @@ final class FloatingWindowTests: XCTestCase {
       state: &state
     )
 
-    XCTAssertEqual(
-      state.monitors[0].workspaces[0].columns[0].focusedWindow,
-      2
-    )
-    XCTAssertEqual(state.selectedWindowID(on: monitorID), windows[2].id)
+    #expect(state.monitors[0].workspaces[0].columns[0].focusedWindow == 2)
+    #expect(state.selectedWindowID(on: monitorID) == windows[2].id)
   }
 
-  func testManualTilingClearsSuspendedModalPlacement() throws {
+  @Test
+  func `Manual tiling clears suspended modal placement`() throws {
     let config = Config()
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)
@@ -508,11 +518,12 @@ final class FloatingWindowTests: XCTestCase {
 
     try reduce(.toggleFloating, on: monitorID, state: &state)
 
-    XCTAssertNil(state.suspendedTiledPlacements[modal.id])
-    XCTAssertEqual(state.windows[modal.id]?.floatingOrigin, .user)
+    #expect(state.suspendedTiledPlacements[modal.id] == nil)
+    #expect(state.windows[modal.id]?.floatingOrigin == .user)
   }
 
-  func testRestoredModalKeepsFocusedWindowIdentityAfterColumnShift() throws {
+  @Test
+  func `Restored modal keeps focused window identity after column shift`() throws {
     let config = Config()
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)
@@ -524,21 +535,21 @@ final class FloatingWindowTests: XCTestCase {
     var observedModal = modal
     observedModal.floating = true
     observedModal.floatingOrigin = .automatic
-    reconcileWindows([modal, selected].map { $0.id == modal.id ? observedModal : $0 }, config: config, state: &state)
+    reconcileWindows(
+      [modal, selected].map { $0.id == modal.id ? observedModal : $0 }, config: config,
+      state: &state)
     var observedTiled = modal
     observedTiled.floating = false
     observedTiled.floatingOrigin = nil
 
     reconcileWindows([observedTiled, selected], config: config, state: &state)
 
-    XCTAssertEqual(state.selectedWindowID(on: monitorID), selected.id)
-    XCTAssertEqual(
-      state.monitors[0].workspaces[0].columns.flatMap(\.windows),
-      [modal.id, selected.id]
-    )
+    #expect(state.selectedWindowID(on: monitorID) == selected.id)
+    #expect(state.monitors[0].workspaces[0].columns.flatMap(\.windows) == [modal.id, selected.id])
   }
 
-  func testFocusedTileBecomingModalRemainsSelectedAsFloater() throws {
+  @Test
+  func `Focused tile becoming modal remains selected as floater`() throws {
     let config = Config()
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)
@@ -551,11 +562,12 @@ final class FloatingWindowTests: XCTestCase {
     reconcileWindows([observed], config: config, state: &state)
 
     let workspace = state.monitors[0].workspaces[0]
-    XCTAssertEqual(workspace.focusedLayer, .floating)
-    XCTAssertEqual(state.selectedWindowID(on: monitorID), modalTile.id)
+    #expect(workspace.focusedLayer == .floating)
+    #expect(state.selectedWindowID(on: monitorID) == modalTile.id)
   }
 
-  func testManualTileOverrideSurvivesAutomaticFloatingObservation() throws {
+  @Test
+  func `Manual tile override survives automatic floating observation`() throws {
     let config = Config()
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)
@@ -569,13 +581,14 @@ final class FloatingWindowTests: XCTestCase {
     reconcileWindows([observed], config: config, state: &state)
 
     let workspace = state.monitors[0].workspaces[0]
-    XCTAssertTrue(workspace.floatingWindows.isEmpty)
-    XCTAssertEqual(workspace.columns.flatMap(\.windows), [manualTile.id])
-    XCTAssertEqual(state.windows[manualTile.id]?.floating, false)
-    XCTAssertEqual(state.windows[manualTile.id]?.floatingOrigin, .user)
+    #expect(workspace.floatingWindows.isEmpty)
+    #expect(workspace.columns.flatMap(\.windows) == [manualTile.id])
+    #expect(state.windows[manualTile.id]?.floating == false)
+    #expect(state.windows[manualTile.id]?.floatingOrigin == .user)
   }
 
-  func testForcedTileSurvivesAutomaticFloatingObservation() throws {
+  @Test
+  func `Forced tile survives automatic floating observation`() throws {
     let config = Config()
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)
@@ -593,13 +606,14 @@ final class FloatingWindowTests: XCTestCase {
     reconcileWindows([observed], config: config, state: &state)
 
     let workspace = state.monitors[0].workspaces[0]
-    XCTAssertTrue(workspace.floatingWindows.isEmpty)
-    XCTAssertEqual(workspace.columns.flatMap(\.windows), [forcedTile.id])
-    XCTAssertEqual(state.windows[forcedTile.id]?.floating, false)
-    XCTAssertEqual(state.windows[forcedTile.id]?.forceTiling, true)
+    #expect(workspace.floatingWindows.isEmpty)
+    #expect(workspace.columns.flatMap(\.windows) == [forcedTile.id])
+    #expect(state.windows[forcedTile.id]?.floating == false)
+    #expect(state.windows[forcedTile.id]?.forceTiling == true)
   }
 
-  func testFocusedAutomaticFloaterRemainsSelectedWhenReclassified() throws {
+  @Test
+  func `Focused automatic floater remains selected when reclassified`() throws {
     let config = Config()
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)
@@ -615,11 +629,12 @@ final class FloatingWindowTests: XCTestCase {
 
     reconcileWindows([selectedTile, observed], config: config, state: &state)
 
-    XCTAssertEqual(state.monitors[0].workspaces[0].focusedLayer, .tiled)
-    XCTAssertEqual(state.selectedWindowID(on: monitorID), automatic.id)
+    #expect(state.monitors[0].workspaces[0].focusedLayer == .tiled)
+    #expect(state.selectedWindowID(on: monitorID) == automatic.id)
   }
 
-  func testUserFloatingOverrideSurvivesTiledObservation() throws {
+  @Test
+  func `User floating override survives tiled observation`() throws {
     let config = Config()
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)
@@ -632,12 +647,13 @@ final class FloatingWindowTests: XCTestCase {
 
     reconcileWindows([observed], config: config, state: &state)
 
-    XCTAssertEqual(state.monitors[0].workspaces[0].floatingWindows, [userFloater.id])
-    XCTAssertEqual(state.windows[userFloater.id]?.floating, true)
-    XCTAssertEqual(state.windows[userFloater.id]?.floatingOrigin, .user)
+    #expect(state.monitors[0].workspaces[0].floatingWindows == [userFloater.id])
+    #expect(state.windows[userFloater.id]?.floating == true)
+    #expect(state.windows[userFloater.id]?.floatingOrigin == .user)
   }
 
-  func testDraggedFloaterMovesToTargetMonitorActiveWorkspace() throws {
+  @Test
+  func `Dragged floater moves to target monitor active workspace`() throws {
     let externalMonitorID = MonitorID(rawValue: 2)
     let tools = WorkspaceID(rawValue: "tools")
     var state = RuntimeState(
@@ -656,17 +672,15 @@ final class FloatingWindowTests: XCTestCase {
       column: Column(window: floater.id, width: .pixels(900))
     )
 
-    XCTAssertTrue(
-      moveFloatingWindow(floater.id, to: externalMonitorID, state: &state)
-    )
+    #expect(moveFloatingWindow(floater.id, to: externalMonitorID, state: &state))
 
-    XCTAssertTrue(state.monitors[0].workspaces[0].floatingWindows.isEmpty)
-    XCTAssertEqual(state.monitors[0].workspaces[0].focusedLayer, .tiled)
-    XCTAssertEqual(state.monitors[1].workspaces[1].floatingWindows, [floater.id])
-    XCTAssertEqual(state.monitors[1].workspaces[1].focusedLayer, .floating)
-    XCTAssertEqual(state.selectedWindowID(on: externalMonitorID), floater.id)
-    XCTAssertEqual(state.windows[floater.id]?.monitorID, externalMonitorID)
-    XCTAssertNil(state.suspendedTiledPlacements[floater.id])
+    #expect(state.monitors[0].workspaces[0].floatingWindows.isEmpty)
+    #expect(state.monitors[0].workspaces[0].focusedLayer == .tiled)
+    #expect(state.monitors[1].workspaces[1].floatingWindows == [floater.id])
+    #expect(state.monitors[1].workspaces[1].focusedLayer == .floating)
+    #expect(state.selectedWindowID(on: externalMonitorID) == floater.id)
+    #expect(state.windows[floater.id]?.monitorID == externalMonitorID)
+    #expect(state.suspendedTiledPlacements[floater.id] == nil)
   }
 
   private func window(_ rawValue: UInt64, floating: Bool = false) -> Window {

--- a/Tests/DefiRuntimeTests/MouseReorderingTests.swift
+++ b/Tests/DefiRuntimeTests/MouseReorderingTests.swift
@@ -2,8 +2,8 @@ import DefiConfig
 import DefiCore
 import DefiModel
 import DefiRuntime
+import Numerics
 import Testing
-import XCTest
 
 struct MouseReorderingTests {
   private let monitorID = MonitorID(rawValue: 1)
@@ -541,7 +541,12 @@ struct MouseReorderingTests {
     )
 
     #expect(update.shouldFinish == false)
-    XCTAssertEqual(update.settlement.nextCheckAt, 10.35, accuracy: 0.000_1)
+    #expect(
+      update.settlement.nextCheckAt.isApproximatelyEqual(
+        to: 10.35,
+        absoluteTolerance: 0.000_1
+      )
+    )
   }
 
   @Test

--- a/Tests/DefiRuntimeTests/MouseReorderingTests.swift
+++ b/Tests/DefiRuntimeTests/MouseReorderingTests.swift
@@ -5,16 +5,17 @@ import DefiRuntime
 import Testing
 import XCTest
 
-final class MouseReorderingTests: XCTestCase {
+struct MouseReorderingTests {
   private let monitorID = MonitorID(rawValue: 1)
   private let viewport = Rect(x: 0, y: 0, width: 1_000, height: 700)
 
-  func testHorizontalDragReordersColumnsAfterCrossingNeighborCenter() throws {
+  @Test
+  func `Horizontal drag reorders columns after crossing neighbor center`() throws {
     var state = try makeState(windowCount: 3)
     let draggedID = WindowID(rawValue: 1)
     let target = try targetFrame(for: draggedID, state: state)
 
-    XCTAssertTrue(
+    #expect(
       reorderTiledWindowAfterMouseDrag(
         draggedID,
         actualFrame: Rect(
@@ -25,26 +26,24 @@ final class MouseReorderingTests: XCTestCase {
         ),
         state: &state,
         viewports: [monitorID: viewport]
-      )
-    )
-    XCTAssertEqual(
-      state.monitors[0].workspaces[0].columns.map(\.windows),
-      [
+      ))
+    #expect(
+      state.monitors[0].workspaces[0].columns.map(\.windows) == [
         [WindowID(rawValue: 2)],
         [WindowID(rawValue: 1)],
         [WindowID(rawValue: 3)],
-      ]
-    )
-    XCTAssertEqual(state.monitors[0].workspaces[0].focusedColumn, 1)
+      ])
+    #expect(state.monitors[0].workspaces[0].focusedColumn == 1)
   }
 
-  func testVerticalDragReordersWindowsWithinStack() throws {
+  @Test
+  func `Vertical drag reorders windows within stack`() throws {
     var state = try makeState(windowCount: 2)
     try reduce(.joinWindow(.left), on: monitorID, state: &state)
     let draggedID = WindowID(rawValue: 1)
     let target = try targetFrame(for: draggedID, state: state)
 
-    XCTAssertTrue(
+    #expect(
       reorderTiledWindowAfterMouseDrag(
         draggedID,
         actualFrame: Rect(
@@ -55,22 +54,22 @@ final class MouseReorderingTests: XCTestCase {
         ),
         state: &state,
         viewports: [monitorID: viewport]
-      )
-    )
-    XCTAssertEqual(
-      state.monitors[0].workspaces[0].columns[0].windows,
-      [WindowID(rawValue: 2), WindowID(rawValue: 1)]
-    )
-    XCTAssertEqual(state.monitors[0].workspaces[0].columns[0].focusedWindow, 1)
+      ))
+    #expect(
+      state.monitors[0].workspaces[0].columns[0].windows == [
+        WindowID(rawValue: 2), WindowID(rawValue: 1),
+      ])
+    #expect(state.monitors[0].workspaces[0].columns[0].focusedWindow == 1)
   }
 
-  func testHorizontalDragLeftReordersWithOffscreenPreviousColumn() throws {
+  @Test
+  func `Horizontal drag left reorders with offscreen previous column`() throws {
     var state = try makeState(windowCount: 2)
     state.monitors[0].workspaces[0].scrollOffset = 0.8
     let draggedID = WindowID(rawValue: 2)
     let target = try targetFrame(for: draggedID, state: state)
 
-    XCTAssertTrue(
+    #expect(
       reorderTiledWindowAfterMouseDrag(
         draggedID,
         actualFrame: Rect(
@@ -81,20 +80,20 @@ final class MouseReorderingTests: XCTestCase {
         ),
         state: &state,
         viewports: [monitorID: viewport]
-      )
-    )
-    XCTAssertEqual(
-      state.monitors[0].workspaces[0].columns.map(\.windows),
-      [[WindowID(rawValue: 2)], [WindowID(rawValue: 1)]]
-    )
+      ))
+    #expect(
+      state.monitors[0].workspaces[0].columns.map(\.windows) == [
+        [WindowID(rawValue: 2)], [WindowID(rawValue: 1)],
+      ])
   }
 
-  func testSmallHorizontalDragKeepsColumnOrder() throws {
+  @Test
+  func `Small horizontal drag keeps column order`() throws {
     var state = try makeState(windowCount: 2)
     let draggedID = WindowID(rawValue: 1)
     let target = try targetFrame(for: draggedID, state: state)
 
-    XCTAssertFalse(
+    #expect(
       reorderTiledWindowAfterMouseDrag(
         draggedID,
         actualFrame: Rect(
@@ -105,15 +104,15 @@ final class MouseReorderingTests: XCTestCase {
         ),
         state: &state,
         viewports: [monitorID: viewport]
-      )
-    )
-    XCTAssertEqual(
-      state.monitors[0].workspaces[0].columns.map(\.windows),
-      [[WindowID(rawValue: 1)], [WindowID(rawValue: 2)]]
-    )
+      ) == false)
+    #expect(
+      state.monitors[0].workspaces[0].columns.map(\.windows) == [
+        [WindowID(rawValue: 1)], [WindowID(rawValue: 2)],
+      ])
   }
 
-  func testLiveHorizontalSwapDoesNotOscillateAtSamePointerPosition() throws {
+  @Test
+  func `Live horizontal swap does not oscillate at same pointer position`() throws {
     var state = try makeState(windowCount: 2)
     let draggedID = WindowID(rawValue: 1)
     let target = try targetFrame(for: draggedID, state: state)
@@ -124,27 +123,26 @@ final class MouseReorderingTests: XCTestCase {
       height: target.height
     )
 
-    XCTAssertTrue(
+    #expect(
       reorderTiledWindowAfterMouseDrag(
         draggedID,
         actualFrame: draggedFrame,
         initialFrame: target,
         state: &state,
         viewports: [monitorID: viewport]
-      )
-    )
-    XCTAssertFalse(
+      ))
+    #expect(
       reorderTiledWindowAfterMouseDrag(
         draggedID,
         actualFrame: draggedFrame,
         initialFrame: target,
         state: &state,
         viewports: [monitorID: viewport]
-      )
-    )
+      ) == false)
   }
 
-  func testUnequalWidthColumnsDoNotOscillateAtSamePointerPosition() throws {
+  @Test
+  func `Unequal width columns do not oscillate at same pointer position`() throws {
     var state = try makeState(windowCount: 2)
     state.monitors[0].workspaces[0].columns[0].width = .pixels(300)
     state.monitors[0].workspaces[0].columns[1].width = .pixels(700)
@@ -161,32 +159,31 @@ final class MouseReorderingTests: XCTestCase {
       height: initialFrame.height
     )
 
-    XCTAssertTrue(
+    #expect(
       reorderTiledWindowAfterMouseDrag(
         draggedID,
         actualFrame: draggedFrame,
         initialFrame: initialFrame,
         state: &state,
         viewports: [monitorID: viewport]
-      )
-    )
-    XCTAssertFalse(
+      ))
+    #expect(
       reorderTiledWindowAfterMouseDrag(
         draggedID,
         actualFrame: draggedFrame,
         initialFrame: initialFrame,
         state: &state,
         viewports: [monitorID: viewport]
-      )
-    )
+      ) == false)
   }
 
-  func testScrollAnchorPreservesViewportAfterReorderFocusChanges() throws {
+  @Test
+  func `Scroll anchor preserves viewport after reorder focus changes`() throws {
     var state = try makeState(windowCount: 2)
     let firstID = WindowID(rawValue: 1)
     state.monitors[0].workspaces[0].scrollOffset = 0.25
     state.monitors[0].workspaces[0].targetScrollOffset = 0.25
-    let anchor = try XCTUnwrap(
+    let anchor = try #require(
       workspaceScrollAnchor(containing: firstID, state: state)
     )
 
@@ -197,11 +194,12 @@ final class MouseReorderingTests: XCTestCase {
     )
     restoreWorkspaceScroll(anchor, state: &state)
 
-    XCTAssertEqual(state.monitors[0].workspaces[0].scrollOffset, 0.25)
-    XCTAssertEqual(state.monitors[0].workspaces[0].targetScrollOffset, 0.25)
+    #expect(state.monitors[0].workspaces[0].scrollOffset == 0.25)
+    #expect(state.monitors[0].workspaces[0].targetScrollOffset == 0.25)
   }
 
-  func testMouseGestureScrollAnchorSurvivesNonCrossingUpdates() throws {
+  @Test
+  func `Mouse gesture scroll anchor survives non crossing updates`() throws {
     var state = try makeState(windowCount: 2)
     let draggedID = WindowID(rawValue: 2)
     state.monitors[0].workspaces[0].scrollOffset = 0.25
@@ -222,56 +220,54 @@ final class MouseReorderingTests: XCTestCase {
       state: state
     )
 
-    XCTAssertEqual(preservedAnchor?.scrollOffset, 0.25)
-    XCTAssertNil(
+    #expect(preservedAnchor?.scrollOffset == 0.25)
+    #expect(
       resolvedMouseGestureScrollAnchor(
         current: preservedAnchor,
         gestureWindowID: draggedID,
         mouseGestureActive: false,
         state: state
-      )
-    )
+      ) == nil)
   }
 
-  func testFocusedTiledWindowStartsMouseGestureBeforeFrameMoves() throws {
+  @Test
+  func `Focused tiled window starts mouse gesture before frame moves`() throws {
     let state = try makeState(windowCount: 2)
     let focusedID = WindowID(rawValue: 2)
 
-    XCTAssertEqual(
+    #expect(
       mouseGestureTiledWindowID(
         translatedWindowID: nil,
         activeWindowID: nil,
         mouseFocusIntentWindowID: focusedID,
         focusedWindowID: focusedID,
         state: state
-      ),
-      focusedID
-    )
+      ) == focusedID)
   }
 
-  func testActiveGestureWindowRejectsUnrelatedTranslatedCandidate() throws {
+  @Test
+  func `Active gesture window rejects unrelated translated candidate`() throws {
     let state = try makeState(windowCount: 2)
     let translatedID = WindowID(rawValue: 2)
     let activeID = WindowID(rawValue: 1)
 
-    XCTAssertEqual(
+    #expect(
       mouseGestureTiledWindowID(
         translatedWindowID: translatedID,
         activeWindowID: activeID,
         mouseFocusIntentWindowID: activeID,
         focusedWindowID: activeID,
         state: state
-      ),
-      activeID
-    )
+      ) == activeID)
   }
 
-  func testReleaseOnlyGestureRecoversPreviousObservedFrame() {
+  @Test
+  func `Release only gesture recovers previous observed frame`() {
     let windowID = WindowID(rawValue: 2)
     let previousFrame = Rect(x: 800, y: 0, width: 784, height: 684)
     let releasedFrame = Rect(x: 200, y: 0, width: 784, height: 684)
 
-    XCTAssertEqual(
+    #expect(
       resolvedMouseGestureInitialFrame(
         currentInitialFrame: nil,
         gestureWindowID: windowID,
@@ -280,48 +276,43 @@ final class MouseReorderingTests: XCTestCase {
         leftMouseButtonDown: false,
         previousObservedFrames: [windowID: previousFrame],
         actualFrame: releasedFrame
-      ),
-      previousFrame
-    )
+      ) == previousFrame)
   }
 
-  func testMouseGestureOriginUsesDisplayedAnimationPosition() {
+  @Test
+  func `Mouse gesture origin uses displayed animation position`() {
     let observedFrame = Rect(x: 0, y: 20, width: 784, height: 684)
 
-    XCTAssertEqual(
+    #expect(
       resolvedMouseGestureOriginFrame(
         observedFrame: observedFrame,
         displayedX: 320,
         displayedY: 40
-      ),
-      Rect(x: 320, y: 40, width: 784, height: 684)
-    )
-    XCTAssertEqual(
+      ) == Rect(x: 320, y: 40, width: 784, height: 684))
+    #expect(
       resolvedMouseGestureOriginFrame(
         observedFrame: observedFrame,
         displayedX: nil,
         displayedY: nil
-      ),
-      observedFrame
-    )
+      ) == observedFrame)
   }
 
-  func testMouseGestureOriginUsesDisplayedAnimationSize() {
+  @Test
+  func `Mouse gesture origin uses displayed animation size`() {
     let observedFrame = Rect(x: 0, y: 20, width: 784, height: 684)
 
-    XCTAssertEqual(
+    #expect(
       resolvedMouseGestureOriginFrame(
         observedFrame: observedFrame,
         displayedX: 320,
         displayedY: 40,
         displayedWidth: 640,
         displayedHeight: 600
-      ),
-      Rect(x: 320, y: 40, width: 640, height: 600)
-    )
+      ) == Rect(x: 320, y: 40, width: 640, height: 600))
   }
 
-  func testLiveDragCanCrossMultipleColumnsAcrossUpdates() throws {
+  @Test
+  func `Live drag can cross multiple columns across updates`() throws {
     var state = try makeState(windowCount: 3)
     let draggedID = WindowID(rawValue: 1)
     let target = try targetFrame(for: draggedID, state: state)
@@ -332,40 +323,37 @@ final class MouseReorderingTests: XCTestCase {
       height: target.height
     )
 
-    XCTAssertTrue(
+    #expect(
       reorderTiledWindowAfterMouseDrag(
         draggedID,
         actualFrame: draggedFrame,
         initialFrame: target,
         state: &state,
         viewports: [monitorID: viewport]
-      )
-    )
-    XCTAssertTrue(
+      ))
+    #expect(
       reorderTiledWindowAfterMouseDrag(
         draggedID,
         actualFrame: draggedFrame,
         initialFrame: target,
         state: &state,
         viewports: [monitorID: viewport]
-      )
-    )
-    XCTAssertEqual(
-      state.monitors[0].workspaces[0].columns.map(\.windows),
-      [
+      ))
+    #expect(
+      state.monitors[0].workspaces[0].columns.map(\.windows) == [
         [WindowID(rawValue: 2)],
         [WindowID(rawValue: 3)],
         [WindowID(rawValue: 1)],
-      ]
-    )
+      ])
   }
 
-  func testReleaseOnlyDragCrossesMultipleColumnsInOneSync() throws {
+  @Test
+  func `Release only drag crosses multiple columns in one sync`() throws {
     var state = try makeState(windowCount: 4)
     let draggedID = WindowID(rawValue: 1)
     let target = try targetFrame(for: draggedID, state: state)
 
-    XCTAssertTrue(
+    #expect(
       reorderTiledWindowAfterCompletedMouseDrag(
         draggedID,
         actualFrame: Rect(
@@ -377,21 +365,19 @@ final class MouseReorderingTests: XCTestCase {
         initialFrame: target,
         state: &state,
         viewports: [monitorID: viewport]
-      )
-    )
-    XCTAssertEqual(
-      state.monitors[0].workspaces[0].columns.map(\.windows),
-      [
+      ))
+    #expect(
+      state.monitors[0].workspaces[0].columns.map(\.windows) == [
         [WindowID(rawValue: 2)],
         [WindowID(rawValue: 3)],
         [WindowID(rawValue: 4)],
         [WindowID(rawValue: 1)],
-      ]
-    )
+      ])
   }
 
-  func testLiveMouseSyncBypassesPendingReorderAnimation() {
-    XCTAssertTrue(
+  @Test
+  func `Live mouse sync bypasses pending reorder animation`() {
+    #expect(
       desktopSynchronizationIsReady(
         scrollAnimationActive: false,
         animatedWritesPending: true,
@@ -399,9 +385,8 @@ final class MouseReorderingTests: XCTestCase {
         needsDesktopSync: true,
         periodicSyncDue: false,
         commandQuietPeriodElapsed: false
-      )
-    )
-    XCTAssertFalse(
+      ))
+    #expect(
       desktopSynchronizationIsReady(
         scrollAnimationActive: false,
         animatedWritesPending: true,
@@ -409,12 +394,12 @@ final class MouseReorderingTests: XCTestCase {
         needsDesktopSync: true,
         periodicSyncDue: false,
         commandQuietPeriodElapsed: true
-      )
-    )
+      ) == false)
   }
 
-  func testNativeFocusSyncBypassesCommandQuietPeriod() {
-    XCTAssertTrue(
+  @Test
+  func `Native focus sync bypasses command quiet period`() {
+    #expect(
       desktopSynchronizationIsReady(
         scrollAnimationActive: false,
         animatedWritesPending: false,
@@ -423,12 +408,12 @@ final class MouseReorderingTests: XCTestCase {
         periodicSyncDue: false,
         commandQuietPeriodElapsed: false,
         nativeFocusSyncPending: true
-      )
-    )
+      ))
   }
 
-  func testLifecycleEventBypassesCommandQuietPeriod() {
-    XCTAssertTrue(
+  @Test
+  func `Lifecycle event bypasses command quiet period`() {
+    #expect(
       desktopSynchronizationIsReady(
         scrollAnimationActive: false,
         animatedWritesPending: false,
@@ -437,9 +422,8 @@ final class MouseReorderingTests: XCTestCase {
         periodicSyncDue: false,
         commandQuietPeriodElapsed: false,
         lifecycleEventPending: true
-      )
-    )
-    XCTAssertFalse(
+      ))
+    #expect(
       desktopSynchronizationIsReady(
         scrollAnimationActive: true,
         animatedWritesPending: false,
@@ -448,12 +432,12 @@ final class MouseReorderingTests: XCTestCase {
         periodicSyncDue: false,
         commandQuietPeriodElapsed: false,
         lifecycleEventPending: true
-      )
-    )
+      ) == false)
   }
 
-  func testNativeFocusSyncBypassesPendingAnimationWrites() {
-    XCTAssertTrue(
+  @Test
+  func `Native focus sync bypasses pending animation writes`() {
+    #expect(
       desktopSynchronizationIsReady(
         scrollAnimationActive: false,
         animatedWritesPending: true,
@@ -462,9 +446,8 @@ final class MouseReorderingTests: XCTestCase {
         periodicSyncDue: false,
         commandQuietPeriodElapsed: false,
         nativeFocusSyncPending: true
-      )
-    )
-    XCTAssertTrue(
+      ))
+    #expect(
       desktopSynchronizationIsReady(
         scrollAnimationActive: true,
         animatedWritesPending: true,
@@ -473,12 +456,12 @@ final class MouseReorderingTests: XCTestCase {
         periodicSyncDue: false,
         commandQuietPeriodElapsed: false,
         nativeFocusSyncPending: true
-      )
-    )
+      ))
   }
 
-  func testFrameDebtBypassesCommandQuietPeriod() {
-    XCTAssertTrue(
+  @Test
+  func `Frame debt bypasses command quiet period`() {
+    #expect(
       desktopSynchronizationIsReady(
         scrollAnimationActive: false,
         animatedWritesPending: false,
@@ -487,28 +470,27 @@ final class MouseReorderingTests: XCTestCase {
         periodicSyncDue: false,
         commandQuietPeriodElapsed: false,
         frameDebtPending: true
-      )
-    )
+      ))
   }
 
-  func testMouseReorderAnimationSurvivesLaterDragSamples() {
-    XCTAssertFalse(
+  @Test
+  func `Mouse reorder animation survives later drag samples`() {
+    #expect(
       mouseGestureAnimationCancellationIsNeeded(
         mouseReorderAnimationActive: true,
         scrollAnimationActive: false,
         animatedWritesPending: true
-      )
-    )
-    XCTAssertTrue(
+      ) == false)
+    #expect(
       mouseGestureAnimationCancellationIsNeeded(
         mouseReorderAnimationActive: false,
         scrollAnimationActive: true,
         animatedWritesPending: true
-      )
-    )
+      ))
   }
 
-  func testPostReleaseSettlementWaitsForStableLateFrame() {
+  @Test
+  func `Post release settlement waits for stable late frame`() {
     let initial = Rect(x: 0, y: 0, width: 500, height: 700)
     let released = Rect(x: 300, y: 0, width: 500, height: 700)
     let late = Rect(x: 700, y: 0, width: 500, height: 700)
@@ -527,8 +509,8 @@ final class MouseReorderingTests: XCTestCase {
       now: 10.1,
       animationPending: false
     )
-    XCTAssertFalse(changed.shouldFinish)
-    XCTAssertTrue(changed.settlement.observedPostReleaseChange)
+    #expect(changed.shouldFinish == false)
+    #expect(changed.settlement.observedPostReleaseChange)
 
     let stable = advanceMouseGestureSettlement(
       changed.settlement,
@@ -536,10 +518,11 @@ final class MouseReorderingTests: XCTestCase {
       now: 10.16,
       animationPending: false
     )
-    XCTAssertTrue(stable.shouldFinish)
+    #expect(stable.shouldFinish)
   }
 
-  func testPostReleaseSettlementWaitsForReorderAnimation() {
+  @Test
+  func `Post release settlement waits for reorder animation`() {
     let frame = Rect(x: 300, y: 0, width: 500, height: 700)
     let settlement = MouseGestureSettlement(
       generation: 4,
@@ -557,11 +540,12 @@ final class MouseReorderingTests: XCTestCase {
       animationPending: true
     )
 
-    XCTAssertFalse(update.shouldFinish)
+    #expect(update.shouldFinish == false)
     XCTAssertEqual(update.settlement.nextCheckAt, 10.35, accuracy: 0.000_1)
   }
 
-  func testPostReleaseSettlementFinishesAtDeadlineWithoutLateFrame() {
+  @Test
+  func `Post release settlement finishes at deadline without late frame`() {
     let frame = Rect(x: 300, y: 0, width: 500, height: 700)
     let settlement = MouseGestureSettlement(
       generation: 4,
@@ -579,49 +563,47 @@ final class MouseReorderingTests: XCTestCase {
       animationPending: false
     )
 
-    XCTAssertTrue(update.shouldFinish)
+    #expect(update.shouldFinish)
   }
 
-  func testSlowPostReleaseSettlementGetsLongerDeadline() {
-    XCTAssertEqual(mouseGestureSettlementMaximumDuration(latencySensitive: false), 0.25)
-    XCTAssertEqual(mouseGestureSettlementMaximumDuration(latencySensitive: true), 0.8)
+  @Test
+  func `Slow post release settlement gets longer deadline`() {
+    #expect(mouseGestureSettlementMaximumDuration(latencySensitive: false) == 0.25)
+    #expect(mouseGestureSettlementMaximumDuration(latencySensitive: true) == 0.8)
   }
 
-  func testPostReleaseSettlementUsesLateFrameForWidthLearning() {
+  @Test
+  func `Post release settlement uses late frame for width learning`() {
     let external = Rect(x: 0, y: 0, width: 600, height: 700)
     let late = Rect(x: 0, y: 0, width: 800, height: 700)
 
-    XCTAssertEqual(
+    #expect(
       mouseGestureWidthLearningFrame(
         externallyChangedFrame: external,
         actualFrame: late,
         postReleaseSettlementActive: true
-      ),
-      external
-    )
-    XCTAssertEqual(
+      ) == external)
+    #expect(
       mouseGestureWidthLearningFrame(
         externallyChangedFrame: nil,
         actualFrame: late,
         postReleaseSettlementActive: true
-      ),
-      late
-    )
-    XCTAssertNil(
+      ) == late)
+    #expect(
       mouseGestureWidthLearningFrame(
         externallyChangedFrame: nil,
         actualFrame: late,
         postReleaseSettlementActive: false
-      )
-    )
+      ) == nil)
   }
 
-  func testResizeIsNotClassifiedAsTranslation() throws {
+  @Test
+  func `Resize is not classified as translation`() throws {
     let state = try makeState(windowCount: 1)
     let windowID = WindowID(rawValue: 1)
     let target = try targetFrame(for: windowID, state: state)
 
-    XCTAssertNil(
+    #expect(
       mouseTranslatedTiledWindowID(
         candidateWindowIDs: [windowID],
         externallyChangedFrames: [
@@ -634,16 +616,16 @@ final class MouseReorderingTests: XCTestCase {
         ],
         state: state,
         viewports: [monitorID: viewport]
-      )
-    )
+      ) == nil)
   }
 
-  func testResizeWithPositionChangeDoesNotReorderColumn() throws {
+  @Test
+  func `Resize with position change does not reorder column`() throws {
     var state = try makeState(windowCount: 2)
     let windowID = WindowID(rawValue: 1)
     let target = try targetFrame(for: windowID, state: state)
 
-    XCTAssertFalse(
+    #expect(
       reorderTiledWindowAfterMouseDrag(
         windowID,
         actualFrame: Rect(
@@ -654,20 +636,20 @@ final class MouseReorderingTests: XCTestCase {
         ),
         state: &state,
         viewports: [monitorID: viewport]
-      )
-    )
-    XCTAssertEqual(
-      state.monitors[0].workspaces[0].columns.map(\.windows),
-      [[WindowID(rawValue: 1)], [WindowID(rawValue: 2)]]
-    )
+      ) == false)
+    #expect(
+      state.monitors[0].workspaces[0].columns.map(\.windows) == [
+        [WindowID(rawValue: 1)], [WindowID(rawValue: 2)],
+      ])
   }
 
-  func testTranslationCandidateFindsMovedTiledWindow() throws {
+  @Test
+  func `Translation candidate finds moved tiled window`() throws {
     let state = try makeState(windowCount: 1)
     let windowID = WindowID(rawValue: 1)
     let target = try targetFrame(for: windowID, state: state)
 
-    XCTAssertEqual(
+    #expect(
       mouseTranslatedTiledWindowID(
         candidateWindowIDs: [windowID],
         externallyChangedFrames: [
@@ -680,19 +662,18 @@ final class MouseReorderingTests: XCTestCase {
         ],
         state: state,
         viewports: [monitorID: viewport]
-      ),
-      windowID
-    )
+      ) == windowID)
   }
 
-  func testTranslationCandidateIgnoresUnrelatedMismatch() throws {
+  @Test
+  func `Translation candidate ignores unrelated mismatch`() throws {
     let state = try makeState(windowCount: 2)
     let firstID = WindowID(rawValue: 1)
     let secondID = WindowID(rawValue: 2)
     let firstTarget = try targetFrame(for: firstID, state: state)
     let secondTarget = try targetFrame(for: secondID, state: state)
 
-    XCTAssertEqual(
+    #expect(
       mouseTranslatedTiledWindowID(
         candidateWindowIDs: [secondID],
         externallyChangedFrames: [
@@ -711,17 +692,16 @@ final class MouseReorderingTests: XCTestCase {
         ],
         state: state,
         viewports: [monitorID: viewport]
-      ),
-      secondID
-    )
+      ) == secondID)
   }
 
-  func testTranslationCandidateIgnoresFloatingWindows() throws {
+  @Test
+  func `Translation candidate ignores floating windows`() throws {
     var state = try makeState(windowCount: 1)
     try reduce(.toggleFloating, on: monitorID, state: &state)
     let windowID = WindowID(rawValue: 1)
 
-    XCTAssertNil(
+    #expect(
       mouseTranslatedTiledWindowID(
         candidateWindowIDs: [windowID],
         externallyChangedFrames: [
@@ -729,8 +709,7 @@ final class MouseReorderingTests: XCTestCase {
         ],
         state: state,
         viewports: [monitorID: viewport]
-      )
-    )
+      ) == nil)
   }
 
   private func makeState(windowCount: Int) throws -> RuntimeState {
@@ -757,7 +736,7 @@ final class MouseReorderingTests: XCTestCase {
 
   private func targetFrame(for windowID: WindowID, state: RuntimeState) throws -> Rect {
     let workspace = state.monitors[0].workspaces[0]
-    return try XCTUnwrap(
+    return try #require(
       computeLayout(
         workspace: workspace,
         viewport: viewport,

--- a/Tests/DefiRuntimeTests/NativeFocusTests.swift
+++ b/Tests/DefiRuntimeTests/NativeFocusTests.swift
@@ -247,15 +247,14 @@ struct NativeFocusTests {
       )
     )
     #expect(
-      !nativeFocusMutationIsReady(
+      nativeFocusMutationIsReady(
         nativeFocusChanged: true,
         mouseInteractionEnded: false,
         leftMouseButtonDown: false,
         mouseReleaseFocusIntentCurrent: false,
         keyboardFocusIntentCurrent: false,
         nativeFocusSuppressed: true
-      )
-    )
+      ) == false)
   }
 
   @Test
@@ -473,12 +472,11 @@ struct NativeFocusTests {
       )
     )
     #expect(
-      !cancelledFocusTargetsRequestedWindow(
+      cancelledFocusTargetsRequestedWindow(
         requestedWindowID: requestedWindowID,
         requestedWindowIsNativelyFocused: false,
         cancellingFocusTargetWindowID: WindowID(rawValue: 3)
-      )
-    )
+      ) == false)
   }
 
   @Test
@@ -611,25 +609,23 @@ struct NativeFocusTests {
       )
     )
     #expect(
-      !pendingWorkspaceFocusIsPreserved(
+      pendingWorkspaceFocusIsPreserved(
         pendingMonitorID: monitor,
         commandMonitorID: MonitorID(rawValue: 2),
         requestedWorkspaceID: workspace,
         activeWorkspaceID: workspace,
         requestedWindowID: window,
         selectedWindowID: window
-      )
-    )
+      ) == false)
     #expect(
-      !pendingWorkspaceFocusIsPreserved(
+      pendingWorkspaceFocusIsPreserved(
         pendingMonitorID: monitor,
         commandMonitorID: monitor,
         requestedWorkspaceID: workspace,
         activeWorkspaceID: workspace,
         requestedWindowID: window,
         selectedWindowID: WindowID(rawValue: 3)
-      )
-    )
+      ) == false)
   }
 
   @Test
@@ -778,11 +774,12 @@ struct NativeFocusTests {
         decision: decision,
         focusGuard: guardToken,
         newlyCreated: true
-      ) == GuardedWindowRemovalFocusAction(
-        windowID: fixture.localFallback.id,
-        monitorID: monitorID,
-        inputTimestamp: 10
       )
+        == GuardedWindowRemovalFocusAction(
+          windowID: fixture.localFallback.id,
+          monitorID: monitorID,
+          inputTimestamp: 10
+        )
     )
     #expect(
       guardedWindowRemovalFocusAction(
@@ -852,11 +849,12 @@ struct NativeFocusTests {
         decision: secondDecision,
         focusGuard: secondGuard,
         newlyCreated: true
-      ) == GuardedWindowRemovalFocusAction(
-        windowID: finalWindow.id,
-        monitorID: monitorID,
-        inputTimestamp: 10
       )
+        == GuardedWindowRemovalFocusAction(
+          windowID: finalWindow.id,
+          monitorID: monitorID,
+          inputTimestamp: 10
+        )
     )
     #expect(firstGuard.monitorID == secondGuard.monitorID)
   }

--- a/Tests/DefiRuntimeTests/NativeFullscreenRuntimeTests.swift
+++ b/Tests/DefiRuntimeTests/NativeFullscreenRuntimeTests.swift
@@ -9,7 +9,7 @@ struct NativeFullscreenRuntimeTests {
   private let monitorID = MonitorID(rawValue: 1)
 
   @Test
-  func entryCompactsStripAndKeepsTargetAfterRightEdge() throws {
+  func `Entry compacts strip and keeps target after right edge`() throws {
     var state = try makeState()
     let fullscreenID = WindowID(rawValue: 2)
     state.monitors[0].workspaces[0].columns[1].width = .pixels(420)
@@ -38,7 +38,7 @@ struct NativeFullscreenRuntimeTests {
   }
 
   @Test
-  func fullscreenSpaceDoesNotForgetWindowsHiddenFromDiscovery() throws {
+  func `Fullscreen space does not forget windows hidden from discovery`() throws {
     var state = try makeState()
     let fullscreenID = WindowID(rawValue: 2)
 
@@ -54,7 +54,7 @@ struct NativeFullscreenRuntimeTests {
   }
 
   @Test
-  func fullscreenDoesNotConsumeAnAutomaticFloatPlacement() throws {
+  func `Fullscreen does not consume an automatic float placement`() throws {
     var state = try makeState()
     let fullscreenID = WindowID(rawValue: 2)
     let placement = SuspendedTiledPlacement(
@@ -94,7 +94,7 @@ struct NativeFullscreenRuntimeTests {
   }
 
   @Test
-  func fullscreenTargetRemainsNavigableButCannotBeMutated() throws {
+  func `Fullscreen target remains navigable but cannot be mutated`() throws {
     var state = try makeState()
     let fullscreenID = WindowID(rawValue: 2)
     reconcileWindows(
@@ -116,7 +116,7 @@ struct NativeFullscreenRuntimeTests {
   }
 
   @Test
-  func fullscreenPlaceholderCanDriveRibbonScroll() throws {
+  func `Fullscreen placeholder can drive ribbon scroll`() throws {
     var state = try makeState()
     let fullscreenID = WindowID(rawValue: 2)
     let viewport = Rect(x: 0, y: 0, width: 1_000, height: 800)
@@ -144,7 +144,7 @@ struct NativeFullscreenRuntimeTests {
   }
 
   @Test
-  func exitRestoresExactSlotAndWidthWithoutChangingSelection() throws {
+  func `Exit restores exact slot and width without changing selection`() throws {
     var state = try makeState()
     let fullscreenID = WindowID(rawValue: 2)
     state.monitors[0].workspaces[0].columns[1].width = .pixels(420)
@@ -171,7 +171,7 @@ struct NativeFullscreenRuntimeTests {
   }
 
   @Test
-  func firstWidthCycleAfterFullscreenReevaluatesTheWindowMinimum() throws {
+  func `First width cycle after fullscreen reevaluates the window minimum`() throws {
     var state = try makeState()
     let fullscreenID = WindowID(rawValue: 2)
     reconcileWindows(
@@ -196,7 +196,7 @@ struct NativeFullscreenRuntimeTests {
   }
 
   @Test
-  func multipleFullscreenTargetsKeepOriginalOrder() throws {
+  func `Multiple fullscreen targets keep original order`() throws {
     var state = try makeState()
     reconcileWindows(
       orderedWindows(in: state),
@@ -209,7 +209,7 @@ struct NativeFullscreenRuntimeTests {
   }
 
   @Test
-  func stackedWindowReturnsToItsExactPosition() throws {
+  func `Stacked window returns to its exact position`() throws {
     var state = try makeState()
     let fullscreenID = WindowID(rawValue: 2)
     state.monitors[0].workspaces[0].columns = [
@@ -239,7 +239,7 @@ struct NativeFullscreenRuntimeTests {
   }
 
   @Test
-  func joiningTowardFullscreenColumnDoesNothing() throws {
+  func `Joining toward fullscreen column does nothing`() throws {
     var state = try makeState()
     let fullscreenID = WindowID(rawValue: 2)
     reconcileWindows(

--- a/Tests/DefiRuntimeTests/PlacementPreferencesTests.swift
+++ b/Tests/DefiRuntimeTests/PlacementPreferencesTests.swift
@@ -1,12 +1,13 @@
 import DefiConfig
 import DefiModel
 import DefiRuntime
-import XCTest
+import Testing
 
-final class PlacementPreferencesTests: XCTestCase {
+struct PlacementPreferencesTests {
   private let monitorID = MonitorID(rawValue: 1)
 
-  func testReconcileRestoresPersistedApplicationWorkspace() throws {
+  @Test
+  func `Reconcile restores persisted application workspace`() throws {
     let config = Config(workspaces: WorkspacesConfig(names: ["dev", "web"]))
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)
@@ -33,13 +34,11 @@ final class PlacementPreferencesTests: XCTestCase {
       state: &state
     )
 
-    XCTAssertEqual(
-      state.location(containing: window.id)?.workspaceID,
-      WorkspaceID(rawValue: "web")
-    )
+    #expect(state.location(containing: window.id)?.workspaceID == WorkspaceID(rawValue: "web"))
   }
 
-  func testConfiguredRuleOverridesPersistedApplicationWorkspace() throws {
+  @Test
+  func `Configured rule overrides persisted application workspace`() throws {
     let config = Config(
       workspaces: WorkspacesConfig(names: ["dev", "web"]),
       rules: [Rule(appID: "com.example.chat", workspace: "dev")]
@@ -68,13 +67,11 @@ final class PlacementPreferencesTests: XCTestCase {
       state: &state
     )
 
-    XCTAssertEqual(
-      state.location(containing: window.id)?.workspaceID,
-      WorkspaceID(rawValue: "dev")
-    )
+    #expect(state.location(containing: window.id)?.workspaceID == WorkspaceID(rawValue: "dev"))
   }
 
-  func testAutomaticFloaterIgnoresPersistedApplicationPlacement() throws {
+  @Test
+  func `Automatic floater ignores persisted application placement`() throws {
     let externalMonitorID = MonitorID(rawValue: 2)
     let config = Config(workspaces: WorkspacesConfig(names: ["dev", "web"]))
     var state = RuntimeState(config: config)
@@ -105,14 +102,12 @@ final class PlacementPreferencesTests: XCTestCase {
       state: &state
     )
 
-    XCTAssertEqual(state.location(containing: window.id)?.monitorID, monitorID)
-    XCTAssertEqual(
-      state.location(containing: window.id)?.workspaceID,
-      WorkspaceID(rawValue: "dev")
-    )
+    #expect(state.location(containing: window.id)?.monitorID == monitorID)
+    #expect(state.location(containing: window.id)?.workspaceID == WorkspaceID(rawValue: "dev"))
   }
 
-  func testAutomaticFloaterRestoresWorkspaceOnlyPreferenceOnCurrentMonitor() throws {
+  @Test
+  func `Automatic floater restores workspace only preference on current monitor`() throws {
     let config = Config(workspaces: WorkspacesConfig(names: ["dev", "web"]))
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)
@@ -139,13 +134,11 @@ final class PlacementPreferencesTests: XCTestCase {
     tiled.floatingOrigin = nil
     reconcileWindows([tiled], config: config, placementPreferences: preferences, state: &state)
 
-    XCTAssertEqual(
-      state.location(containing: window.id)?.workspaceID,
-      WorkspaceID(rawValue: "web")
-    )
+    #expect(state.location(containing: window.id)?.workspaceID == WorkspaceID(rawValue: "web"))
   }
 
-  func testInvalidatingPreferenceRemovesAutomaticFloaterDestination() {
+  @Test
+  func `Invalidating preference removes automatic floater destination`() {
     let window = Window(
       id: WindowID(rawValue: 4),
       appID: "com.example.Chat",
@@ -165,11 +158,12 @@ final class PlacementPreferencesTests: XCTestCase {
 
     preferences.invalidatePreference(for: window)
 
-    XCTAssertNil(preferences.preference(for: window))
-    XCTAssertEqual(preferences.suppressedWindowIDs, [window.id])
+    #expect(preferences.preference(for: window) == nil)
+    #expect(preferences.suppressedWindowIDs == [window.id])
   }
 
-  func testSuppressedPreferenceSurvivesSiblingRecordingUntilReclassification() throws {
+  @Test
+  func `Suppressed preference survives sibling recording until reclassification`() throws {
     let config = Config(workspaces: WorkspacesConfig(names: ["dev", "web"]))
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)
@@ -201,32 +195,24 @@ final class PlacementPreferencesTests: XCTestCase {
 
     preferences.invalidatePreference(for: automatic)
     preferences.recordPlacements(from: state)
-    XCTAssertNil(preferences.preference(for: automatic))
-    XCTAssertEqual(
-      preferences.preference(for: sibling)?.workspaceID,
-      WorkspaceID(rawValue: "dev")
-    )
+    #expect(preferences.preference(for: automatic) == nil)
+    #expect(preferences.preference(for: sibling)?.workspaceID == WorkspaceID(rawValue: "dev"))
 
     var reclassified = automatic
     reclassified.floating = false
     reclassified.floatingOrigin = nil
     state.windows[automatic.id] = reclassified
     preferences.recordPlacements(from: state)
-    XCTAssertTrue(preferences.suppressedWindowIDs.isEmpty)
-    XCTAssertEqual(
-      preferences.preference(for: reclassified)?.workspaceID,
-      WorkspaceID(rawValue: "dev")
-    )
+    #expect(preferences.suppressedWindowIDs.isEmpty)
+    #expect(preferences.preference(for: reclassified)?.workspaceID == WorkspaceID(rawValue: "dev"))
 
     state.windows[automatic.id] = nil
     preferences.recordPlacements(from: state)
-    XCTAssertEqual(
-      preferences.preference(for: sibling)?.workspaceID,
-      WorkspaceID(rawValue: "dev")
-    )
+    #expect(preferences.preference(for: sibling)?.workspaceID == WorkspaceID(rawValue: "dev"))
   }
 
-  func testRecordingPlacementsKeepsClosedApplicationPreferences() throws {
+  @Test
+  func `Recording placements keeps closed application preferences`() throws {
     let config = Config(workspaces: WorkspacesConfig(names: ["dev", "web"]))
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)
@@ -252,17 +238,14 @@ final class PlacementPreferencesTests: XCTestCase {
 
     preferences.recordPlacements(from: state)
 
-    XCTAssertEqual(
-      preferences.applications["com.example.chat"]?.workspaceID,
-      WorkspaceID(rawValue: "web")
-    )
-    XCTAssertEqual(
-      preferences.applications["com.example.closed"]?.workspaceID,
-      WorkspaceID(rawValue: "dev")
-    )
+    #expect(
+      preferences.applications["com.example.chat"]?.workspaceID == WorkspaceID(rawValue: "web"))
+    #expect(
+      preferences.applications["com.example.closed"]?.workspaceID == WorkspaceID(rawValue: "dev"))
   }
 
-  func testRecordingSharedWorkspaceAcrossMonitorsOmitsMonitor() throws {
+  @Test
+  func `Recording shared workspace across monitors omits monitor`() throws {
     let config = Config(workspaces: WorkspacesConfig(names: ["dev", "web"]))
     let externalMonitorID = MonitorID(rawValue: 2)
     var state = RuntimeState(config: config)
@@ -295,13 +278,13 @@ final class PlacementPreferencesTests: XCTestCase {
 
     preferences.recordPlacements(from: state)
 
-    XCTAssertEqual(
-      preferences.applications["com.example.chat"],
-      WindowPlacementPreference(workspaceID: WorkspaceID(rawValue: "web"))
-    )
+    #expect(
+      preferences.applications["com.example.chat"]
+        == WindowPlacementPreference(workspaceID: WorkspaceID(rawValue: "web")))
   }
 
-  func testRecordingFallbackRetainsDisconnectedMonitor() throws {
+  @Test
+  func `Recording fallback retains disconnected monitor`() throws {
     let config = Config(workspaces: WorkspacesConfig(names: ["dev", "web"]))
     let disconnectedMonitorID = MonitorID(rawValue: 99)
     var state = RuntimeState(config: config)
@@ -329,13 +312,11 @@ final class PlacementPreferencesTests: XCTestCase {
 
     preferences.recordPlacements(from: state)
 
-    XCTAssertEqual(
-      preferences.applications["com.example.chat"]?.monitorID,
-      disconnectedMonitorID
-    )
+    #expect(preferences.applications["com.example.chat"]?.monitorID == disconnectedMonitorID)
   }
 
-  func testDisconnectMigratesLiveWindowWithoutOverwritingPreferredMonitor() throws {
+  @Test
+  func `Disconnect migrates live window without overwriting preferred monitor`() throws {
     let config = Config(workspaces: WorkspacesConfig(names: ["dev", "web"]))
     let externalMonitorID = MonitorID(rawValue: 2)
     var state = RuntimeState(config: config)
@@ -364,17 +345,15 @@ final class PlacementPreferencesTests: XCTestCase {
 
     state.retainMonitors([monitorID])
 
-    XCTAssertEqual(state.location(containing: window.id)?.monitorID, monitorID)
+    #expect(state.location(containing: window.id)?.monitorID == monitorID)
 
     preferences.recordPlacements(from: state)
 
-    XCTAssertEqual(
-      preferences.applications["com.example.chat"]?.monitorID,
-      externalMonitorID
-    )
+    #expect(preferences.applications["com.example.chat"]?.monitorID == externalMonitorID)
   }
 
-  func testAutomaticFloatersDoNotAffectPlacementPreferences() throws {
+  @Test
+  func `Automatic floaters do not affect placement preferences`() throws {
     let config = Config(workspaces: WorkspacesConfig(names: ["dev", "web"]))
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)
@@ -404,13 +383,11 @@ final class PlacementPreferencesTests: XCTestCase {
 
     preferences.recordPlacements(from: state)
 
-    XCTAssertEqual(
-      preferences.applications[normal.appID]?.workspaceID,
-      WorkspaceID(rawValue: "dev")
-    )
+    #expect(preferences.applications[normal.appID]?.workspaceID == WorkspaceID(rawValue: "dev"))
   }
 
-  func testInitiallyAutomaticWindowUsesPersistedPlacementWhenTiled() throws {
+  @Test
+  func `Initially automatic window uses persisted placement when tiled`() throws {
     let config = Config(workspaces: WorkspacesConfig(names: ["dev", "web"]))
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)
@@ -448,9 +425,6 @@ final class PlacementPreferencesTests: XCTestCase {
       state: &state
     )
 
-    XCTAssertEqual(
-      state.location(containing: window.id)?.workspaceID,
-      WorkspaceID(rawValue: "web")
-    )
+    #expect(state.location(containing: window.id)?.workspaceID == WorkspaceID(rawValue: "web"))
   }
 }

--- a/Tests/DefiRuntimeTests/PointerFocusTests.swift
+++ b/Tests/DefiRuntimeTests/PointerFocusTests.swift
@@ -22,7 +22,7 @@ struct PointerFocusTests {
         pointerWindowIsReady: false,
         targetAccepted: false,
         logicalFocusWindowID: logicalWindowID
-    ) == logicalWindowID
+      ) == logicalWindowID
     )
   }
 
@@ -161,7 +161,7 @@ struct PointerFocusTests {
     state.windows[descendantID]?.appID = "app"
     state.windows[descendantID]?.transientOwnerID = modalID
 
-    #expect(!modalAllowsPointerFocus(ownerID, state: state))
+    #expect(modalAllowsPointerFocus(ownerID, state: state) == false)
     #expect(modalAllowsPointerFocus(modalID, state: state))
     #expect(modalAllowsPointerFocus(descendantID, state: state))
   }
@@ -374,47 +374,43 @@ struct PointerFocusTests {
       )
     )
     #expect(
-      !pointerFocusRetryIsCurrent(
+      pointerFocusRetryIsCurrent(
         pendingWindowID: windowID,
         windowUnderPointerID: WindowID(rawValue: 43),
         requestGeneration: 4,
         currentGeneration: 4,
         pointerTimestamp: 12,
         latestUserInputTimestamp: 12
-      )
-    )
+      ) == false)
     #expect(
-      !pointerFocusRetryIsCurrent(
+      pointerFocusRetryIsCurrent(
         pendingWindowID: windowID,
         windowUnderPointerID: windowID,
         requestGeneration: 4,
         currentGeneration: 4,
         pointerTimestamp: 12,
         latestUserInputTimestamp: 13
-      )
-    )
+      ) == false)
   }
 
   @Test
   func newerPointerTransitionInvalidatesRequestWithoutGeneralInput() {
     #expect(
-      !pointerFocusRequestIsCurrent(
+      pointerFocusRequestIsCurrent(
         requestGeneration: 4,
         currentGeneration: 5,
         pointerTimestamp: 12,
         latestUserInputTimestamp: 12
-      )
-    )
+      ) == false)
     #expect(
-      !pointerFocusRetryIsCurrent(
+      pointerFocusRetryIsCurrent(
         pendingWindowID: WindowID(rawValue: 42),
         windowUnderPointerID: WindowID(rawValue: 42),
         requestGeneration: 4,
         currentGeneration: 5,
         pointerTimestamp: 12,
         latestUserInputTimestamp: 12
-      )
-    )
+      ) == false)
   }
 
   @Test
@@ -426,11 +422,10 @@ struct PointerFocusTests {
       )
     )
     #expect(
-      !pointerFocusIntentIsCurrent(
+      pointerFocusIntentIsCurrent(
         pointerTimestamp: 12,
         latestUserInputTimestamp: 13
-      )
-    )
+      ) == false)
   }
 
   @Test
@@ -442,11 +437,10 @@ struct PointerFocusTests {
       )
     )
     #expect(
-      !cancelledPointerFocusShouldRearm(
+      cancelledPointerFocusShouldRearm(
         pointerTimestamp: 12,
         latestUserInputTimestamp: 13
-      )
-    )
+      ) == false)
   }
 
   @Test
@@ -468,26 +462,23 @@ struct PointerFocusTests {
       )
     )
     #expect(
-      !commandFocusIsPreserved(
+      commandFocusIsPreserved(
         pendingWindowID: WindowID(rawValue: 43),
         submittedWindowID: nil,
         selectedWindowID: windowID
-      )
-    )
+      ) == false)
     #expect(
-      !commandFocusIsPreserved(
+      commandFocusIsPreserved(
         pendingWindowID: nil,
         submittedWindowID: WindowID(rawValue: 43),
         selectedWindowID: windowID
-      )
-    )
+      ) == false)
     #expect(
-      !commandFocusIsPreserved(
+      commandFocusIsPreserved(
         pendingWindowID: nil,
         submittedWindowID: nil,
         selectedWindowID: windowID
-      )
-    )
+      ) == false)
   }
 
   @Test
@@ -503,21 +494,19 @@ struct PointerFocusTests {
       )
     )
     #expect(
-      !commandFocusCompletionIsCurrent(
+      commandFocusCompletionIsCurrent(
         submittedWindowID: nil,
         submittedGeneration: nil,
         completedWindowID: windowID,
         completedGeneration: 4
-      )
-    )
+      ) == false)
     #expect(
-      !commandFocusCompletionIsCurrent(
+      commandFocusCompletionIsCurrent(
         submittedWindowID: WindowID(rawValue: 43),
         submittedGeneration: 5,
         completedWindowID: windowID,
         completedGeneration: 4
-      )
-    )
+      ) == false)
   }
 
   @Test
@@ -560,21 +549,19 @@ struct PointerFocusTests {
       )
     )
     #expect(
-      !focusTargetIsReady(
+      focusTargetIsReady(
         targetMonitorID: monitorID,
         targetWindowID: targetWindowID,
         scrollingMonitorIDs: [monitorID],
         pendingFrameWindowIDs: []
-      )
-    )
+      ) == false)
     #expect(
-      !focusTargetIsReady(
+      focusTargetIsReady(
         targetMonitorID: monitorID,
         targetWindowID: targetWindowID,
         scrollingMonitorIDs: [],
         pendingFrameWindowIDs: [targetWindowID]
-      )
-    )
+      ) == false)
     #expect(
       focusTargetIsReady(
         targetMonitorID: monitorID,
@@ -590,12 +577,11 @@ struct PointerFocusTests {
     let otherMonitorID = MonitorID(rawValue: 2)
 
     #expect(
-      !focusMonitorIsReady(
+      focusMonitorIsReady(
         targetMonitorID: monitorID,
         scrollingMonitorIDs: [],
         pendingFrameMonitorIDs: [monitorID]
-      )
-    )
+      ) == false)
     #expect(
       focusMonitorIsReady(
         targetMonitorID: monitorID,

--- a/Tests/DefiRuntimeTests/RuntimeFocusTests.swift
+++ b/Tests/DefiRuntimeTests/RuntimeFocusTests.swift
@@ -1,12 +1,14 @@
 import DefiConfig
 import DefiModel
 import DefiRuntime
+import Testing
 import XCTest
 
-final class RuntimeFocusTests: XCTestCase {
+struct RuntimeFocusTests {
   private let monitorID = MonitorID(rawValue: 1)
 
-  func testChangedStateRejectsBoundaryFocusNoOp() throws {
+  @Test
+  func `Changed state rejects boundary focus no op`() throws {
     var state = RuntimeState(config: Config())
     state.attachMonitor(monitorID)
     for id in 1...2 {
@@ -32,16 +34,14 @@ final class RuntimeFocusTests: XCTestCase {
     let rejected = try changedState(
       after: .focusColumn(.left), on: monitorID, from: state
     )
-    XCTAssertEqual(
-      rejected?.monitors[0].workspaces[0].focusedColumn,
-      state.monitors[0].workspaces[0].focusedColumn
-    )
-    XCTAssertNotNil(
-      try changedState(after: .focusColumn(.right), on: monitorID, from: state)
-    )
+    #expect(
+      rejected?.monitors[0].workspaces[0].focusedColumn
+        == state.monitors[0].workspaces[0].focusedColumn)
+    #expect(try changedState(after: .focusColumn(.right), on: monitorID, from: state) != nil)
   }
 
-  func testExternalFocusActivatesContainingWorkspace() throws {
+  @Test
+  func `External focus activates containing workspace`() throws {
     let config = Config(workspaces: WorkspacesConfig(names: ["dev", "web"]))
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)
@@ -57,14 +57,15 @@ final class RuntimeFocusTests: XCTestCase {
       decision: RuleDecision(workspace: WorkspaceID(rawValue: "web")),
       state: &state
     )
-    XCTAssertEqual(state.monitors[0].activeWorkspace, WorkspaceID(rawValue: "dev"))
+    #expect(state.monitors[0].activeWorkspace == WorkspaceID(rawValue: "dev"))
 
-    XCTAssertTrue(focusWindow(window.id, state: &state))
+    #expect(focusWindow(window.id, state: &state))
 
-    XCTAssertEqual(state.monitors[0].activeWorkspace, WorkspaceID(rawValue: "web"))
+    #expect(state.monitors[0].activeWorkspace == WorkspaceID(rawValue: "web"))
   }
 
-  func testExternalFocusSynchronizesNeverScrollUsingRealViewport() throws {
+  @Test
+  func `External focus synchronizes never scroll using real viewport`() throws {
     let config = Config()
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)
@@ -104,7 +105,8 @@ final class RuntimeFocusTests: XCTestCase {
     )
   }
 
-  func testNativeFocusAlignsFocusedColumnToLeftEdge() throws {
+  @Test
+  func `Native focus aligns focused column to left edge`() throws {
     let config = Config()
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)

--- a/Tests/DefiRuntimeTests/RuntimeFocusTests.swift
+++ b/Tests/DefiRuntimeTests/RuntimeFocusTests.swift
@@ -1,8 +1,8 @@
 import DefiConfig
 import DefiModel
 import DefiRuntime
+import Numerics
 import Testing
-import XCTest
 
 struct RuntimeFocusTests {
   private let monitorID = MonitorID(rawValue: 1)
@@ -98,10 +98,11 @@ struct RuntimeFocusTests {
       viewports: [monitorID: Rect(x: 0, y: 0, width: 1_000, height: 700)]
     )
 
-    XCTAssertEqual(
-      state.monitors[0].workspaces[0].targetScrollOffset,
-      0.1,
-      accuracy: 0.001
+    #expect(
+      state.monitors[0].workspaces[0].targetScrollOffset.isApproximatelyEqual(
+        to: 0.1,
+        absoluteTolerance: 0.001
+      )
     )
   }
 
@@ -129,10 +130,11 @@ struct RuntimeFocusTests {
       viewports: [monitorID: Rect(x: 0, y: 0, width: 1_000, height: 700)]
     )
 
-    XCTAssertEqual(
-      state.monitors[0].workspaces[0].targetScrollOffset,
-      0,
-      accuracy: 0.001
+    #expect(
+      state.monitors[0].workspaces[0].targetScrollOffset.isApproximatelyEqual(
+        to: 0,
+        absoluteTolerance: 0.001
+      )
     )
   }
 

--- a/Tests/DefiRuntimeTests/RuntimeMonitorTests.swift
+++ b/Tests/DefiRuntimeTests/RuntimeMonitorTests.swift
@@ -2,14 +2,14 @@ import DefiConfig
 import DefiCore
 import DefiModel
 import Testing
-import XCTest
 
 @testable import DefiRuntime
 
-final class RuntimeMonitorTests: XCTestCase {
+struct RuntimeMonitorTests {
   private let monitorID = MonitorID(rawValue: 1)
 
-  func testReservedEdgesAreReducedPerMonitor() throws {
+  @Test
+  func `Reserved edges are reduced per monitor`() throws {
     let externalID = MonitorID(rawValue: 2)
     var state = RuntimeState(config: Config())
     state.attachMonitor(monitorID)
@@ -22,18 +22,16 @@ final class RuntimeMonitorTests: XCTestCase {
       state: &state
     )
 
-    XCTAssertEqual(
-      state.reservedEdgesByMonitor[monitorID],
-      ReservedEdges(top: 36, bottom: 12)
-    )
-    XCTAssertNil(state.reservedEdgesByMonitor[externalID])
+    #expect(state.reservedEdgesByMonitor[monitorID] == ReservedEdges(top: 36, bottom: 12))
+    #expect(state.reservedEdgesByMonitor[externalID] == nil)
 
     try reduce(.clearReservedEdges([monitorID]), state: &state)
 
-    XCTAssertNil(state.reservedEdgesByMonitor[monitorID])
+    #expect(state.reservedEdgesByMonitor[monitorID] == nil)
   }
 
-  func testDisplayResizeScalesPixelAndPreMaximizedWidths() {
+  @Test
+  func `Display resize scales pixel and pre maximized widths`() {
     let config = Config()
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)
@@ -57,17 +55,12 @@ final class RuntimeMonitorTests: XCTestCase {
       ]
     )
 
-    XCTAssertEqual(
-      state.monitors[0].workspaces[0].columns[0].preMaximizedWidth,
-      .pixels(400)
-    )
-    XCTAssertEqual(
-      state.monitors[0].workspaces[0].columns[1].width,
-      .pixels(500)
-    )
+    #expect(state.monitors[0].workspaces[0].columns[0].preMaximizedWidth == .pixels(400))
+    #expect(state.monitors[0].workspaces[0].columns[1].width == .pixels(500))
   }
 
-  func testDisconnectedMonitorMergesAndScalesColumnsIntoRemainingDisplay() {
+  @Test
+  func `Disconnected monitor merges and scales columns into remaining display`() {
     let externalID = MonitorID(rawValue: 2)
     let config = Config(workspaces: WorkspacesConfig(names: ["dev"]))
     var state = RuntimeState(config: config)
@@ -88,14 +81,12 @@ final class RuntimeMonitorTests: XCTestCase {
       ]
     )
 
-    XCTAssertEqual(state.monitors.count, 1)
-    XCTAssertEqual(
-      state.monitors[0].workspaces[0].columns[0].width,
-      .pixels(600)
-    )
+    #expect(state.monitors.count == 1)
+    #expect(state.monitors[0].workspaces[0].columns[0].width == .pixels(600))
   }
 
-  func testDisconnectedMonitorMigratesAndScalesSuspendedPlacement() {
+  @Test
+  func `Disconnected monitor migrates and scales suspended placement`() {
     let externalID = MonitorID(rawValue: 2)
     let workspaceID = WorkspaceID(rawValue: "dev")
     let modalID = WindowID(rawValue: 10)
@@ -133,24 +124,24 @@ final class RuntimeMonitorTests: XCTestCase {
       ]
     )
 
-    XCTAssertEqual(
-      state.suspendedTiledPlacements[modalID],
-      SuspendedTiledPlacement(
-        monitorID: monitorID,
-        workspaceID: workspaceID,
-        columnIndex: 2,
-        windowIndex: 0,
-        column: Column(
-          windows: [modalID],
-          focusedWindow: 0,
-          width: .pixels(600),
-          preMaximizedWidth: .pixels(400)
-        )
-      )
-    )
+    #expect(
+      state.suspendedTiledPlacements[modalID]
+        == SuspendedTiledPlacement(
+          monitorID: monitorID,
+          workspaceID: workspaceID,
+          columnIndex: 2,
+          windowIndex: 0,
+          column: Column(
+            windows: [modalID],
+            focusedWindow: 0,
+            width: .pixels(600),
+            preMaximizedWidth: .pixels(400)
+          )
+        ))
   }
 
-  func testDisconnectedMonitorPlacesMigratedSuspensionAfterTargetSuspensions() {
+  @Test
+  func `Disconnected monitor places migrated suspension after target suspensions`() {
     let externalID = MonitorID(rawValue: 2)
     let workspaceID = WorkspaceID(rawValue: "dev")
     let targetModalID = WindowID(rawValue: 8)
@@ -188,10 +179,11 @@ final class RuntimeMonitorTests: XCTestCase {
       ]
     )
 
-    XCTAssertEqual(state.suspendedTiledPlacements[sourceModalID]?.columnIndex, 3)
+    #expect(state.suspendedTiledPlacements[sourceModalID]?.columnIndex == 3)
   }
 
-  func testDisconnectedMonitorPlacesMigrationAfterHighestSuspendedColumn() {
+  @Test
+  func `Disconnected monitor places migration after highest suspended column`() {
     let externalID = MonitorID(rawValue: 2)
     let workspaceID = WorkspaceID(rawValue: "dev")
     let targetModalID = WindowID(rawValue: 8)
@@ -226,10 +218,11 @@ final class RuntimeMonitorTests: XCTestCase {
       ]
     )
 
-    XCTAssertEqual(state.suspendedTiledPlacements[sourceModalID]?.columnIndex, 4)
+    #expect(state.suspendedTiledPlacements[sourceModalID]?.columnIndex == 4)
   }
 
-  func testReboundFocusMonitorRequiresMigratedWindowToRemainSelected() {
+  @Test
+  func `Rebound focus monitor requires migrated window to remain selected`() {
     let externalID = MonitorID(rawValue: 2)
     let config = Config(workspaces: WorkspacesConfig(names: ["dev"]))
     var state = RuntimeState(config: config)
@@ -253,36 +246,28 @@ final class RuntimeMonitorTests: XCTestCase {
       ]
     )
 
-    XCTAssertNil(
+    #expect(
       state.reboundFocusMonitorID(
         for: WindowID(rawValue: 9),
         requestedWorkspaceID: WorkspaceID(rawValue: "dev")
-      )
-    )
+      ) == nil)
     state.monitors[0].workspaces[0].focusedColumn = 1
-    XCTAssertEqual(
+    #expect(
       state.reboundFocusMonitorID(
         for: WindowID(rawValue: 9),
         requestedWorkspaceID: WorkspaceID(rawValue: "dev")
-      ),
-      monitorID
-    )
+      ) == monitorID)
   }
 
-  func testEachMonitorOwnsIndependentNineWorkspaces() throws {
+  @Test
+  func `Each monitor owns independent nine workspaces`() throws {
     let externalID = MonitorID(rawValue: 2)
     var state = RuntimeState(config: Config())
     state.attachMonitor(monitorID)
     state.attachMonitor(externalID)
 
-    XCTAssertEqual(
-      state.monitors[0].workspaces.map(\.id.rawValue),
-      (1...9).map(String.init)
-    )
-    XCTAssertEqual(
-      state.monitors[1].workspaces.map(\.id.rawValue),
-      (1...9).map(String.init)
-    )
+    #expect(state.monitors[0].workspaces.map(\.id.rawValue) == (1...9).map(String.init))
+    #expect(state.monitors[1].workspaces.map(\.id.rawValue) == (1...9).map(String.init))
 
     try reduce(
       .switchWorkspace(WorkspaceID(rawValue: "5")),
@@ -290,17 +275,16 @@ final class RuntimeMonitorTests: XCTestCase {
       state: &state
     )
 
-    XCTAssertEqual(
-      state.monitors.first(where: { $0.id == monitorID })?.activeWorkspace,
-      WorkspaceID(rawValue: "1")
-    )
-    XCTAssertEqual(
-      state.monitors.first(where: { $0.id == externalID })?.activeWorkspace,
-      WorkspaceID(rawValue: "5")
-    )
+    #expect(
+      state.monitors.first(where: { $0.id == monitorID })?.activeWorkspace
+        == WorkspaceID(rawValue: "1"))
+    #expect(
+      state.monitors.first(where: { $0.id == externalID })?.activeWorkspace
+        == WorkspaceID(rawValue: "5"))
   }
 
-  func testMoveColumnToMonitorKeepsStackScalesPixelsAndMovesTransient() throws {
+  @Test
+  func `Move column to monitor keeps stack scales pixels and moves transient`() throws {
     let externalID = MonitorID(rawValue: 2)
     let transientIDs = [12, 7, 14, 3, 11, 5, 13, 4].map(windowID)
     var state = twoMonitorState(externalID: externalID)
@@ -341,23 +325,16 @@ final class RuntimeMonitorTests: XCTestCase {
       viewports: monitorFrames(externalID: externalID)
     )
 
-    XCTAssertTrue(state.monitors[0].workspaces[0].columns.isEmpty)
-    XCTAssertEqual(
-      state.monitors[1].workspaces[0].columns[1].windows,
-      [windowID(1), windowID(2)]
-    )
-    XCTAssertEqual(state.monitors[1].workspaces[0].columns[1].width, .pixels(2_000))
-    XCTAssertEqual(
-      state.monitors[1].workspaces[0].floatingWindows,
-      transientIDs
-    )
-    XCTAssertEqual(state.selectedWindowID(on: externalID), WindowID(rawValue: 2))
-    XCTAssertTrue(
-      transientIDs.allSatisfy { state.windows[$0]?.monitorID == externalID }
-    )
+    #expect(state.monitors[0].workspaces[0].columns.isEmpty)
+    #expect(state.monitors[1].workspaces[0].columns[1].windows == [windowID(1), windowID(2)])
+    #expect(state.monitors[1].workspaces[0].columns[1].width == .pixels(2_000))
+    #expect(state.monitors[1].workspaces[0].floatingWindows == transientIDs)
+    #expect(state.selectedWindowID(on: externalID) == WindowID(rawValue: 2))
+    #expect(transientIDs.allSatisfy { state.windows[$0]?.monitorID == externalID })
   }
 
-  func testMoveWindowToMonitorCreatesIndependentColumn() throws {
+  @Test
+  func `Move window to monitor creates independent column`() throws {
     let externalID = MonitorID(rawValue: 2)
     var state = twoMonitorState(externalID: externalID)
     state.monitors[0].workspaces[0].columns = [
@@ -380,19 +357,14 @@ final class RuntimeMonitorTests: XCTestCase {
       viewports: monitorFrames(externalID: externalID)
     )
 
-    XCTAssertEqual(
-      state.monitors[0].workspaces[0].columns[0].windows,
-      [windowID(1)]
-    )
-    XCTAssertEqual(
-      state.monitors[1].workspaces[0].columns[0].windows,
-      [windowID(2)]
-    )
-    XCTAssertEqual(state.monitors[1].workspaces[0].columns[0].width, .fraction(0.6))
-    XCTAssertEqual(state.selectedWindowID(on: externalID), WindowID(rawValue: 2))
+    #expect(state.monitors[0].workspaces[0].columns[0].windows == [windowID(1)])
+    #expect(state.monitors[1].workspaces[0].columns[0].windows == [windowID(2)])
+    #expect(state.monitors[1].workspaces[0].columns[0].width == .fraction(0.6))
+    #expect(state.selectedWindowID(on: externalID) == WindowID(rawValue: 2))
   }
 
-  func testMoveToMissingSpatialMonitorIsStrictNoOp() throws {
+  @Test
+  func `Move to missing spatial monitor is strict no op`() throws {
     var state = twoMonitorState(externalID: MonitorID(rawValue: 2))
     state.monitors[0].workspaces[0].columns = [
       Column(window: windowID(1), width: .fraction(0.5))
@@ -411,7 +383,7 @@ final class RuntimeMonitorTests: XCTestCase {
       monitorFrames: monitorFrames(externalID: MonitorID(rawValue: 2))
     )
 
-    XCTAssertNil(changed)
+    #expect(changed == nil)
   }
 
   private func twoMonitorState(externalID: MonitorID) -> RuntimeState {
@@ -809,15 +781,19 @@ struct MonitorMoveFocusTests {
       Column(window: $0, width: .fraction(0.5))
     }
     state.monitors[0].workspaces[0].focusedColumn = 2
-    state.windows = Dictionary(uniqueKeysWithValues: windowIDs.map {
-      ($0, Window(
-        id: $0,
-        appID: "app",
-        title: "Window \($0.rawValue)",
-        frame: Rect(x: 0, y: 0, width: 500, height: 700),
-        monitorID: sourceID
-      ))
-    })
+    state.windows = Dictionary(
+      uniqueKeysWithValues: windowIDs.map {
+        (
+          $0,
+          Window(
+            id: $0,
+            appID: "app",
+            title: "Window \($0.rawValue)",
+            frame: Rect(x: 0, y: 0, width: 500, height: 700),
+            monitorID: sourceID
+          )
+        )
+      })
 
     try reduce(
       .moveColumnToMonitor(.right),

--- a/Tests/DefiRuntimeTests/RuntimeWidthLearningTests.swift
+++ b/Tests/DefiRuntimeTests/RuntimeWidthLearningTests.swift
@@ -3,7 +3,6 @@ import DefiCore
 import DefiModel
 import DefiRuntime
 import Testing
-import XCTest
 
 struct RuntimeMinimumWidthTests {
   @Test
@@ -104,10 +103,11 @@ struct RuntimeMinimumWidthTests {
   }
 }
 
-final class RuntimeWidthLearningTests: XCTestCase {
+struct RuntimeWidthLearningTests {
   private let monitorID = MonitorID(rawValue: 1)
 
-  func testMouseResizeLearnsRealColumnWidth() throws {
+  @Test
+  func `Mouse resize learns real column width`() throws {
     let config = Config()
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)
@@ -128,14 +128,12 @@ final class RuntimeWidthLearningTests: XCTestCase {
       viewports: [monitorID: Rect(x: 0, y: 0, width: 1_000, height: 700)]
     )
 
-    XCTAssertTrue(learned)
-    XCTAssertEqual(
-      state.monitors[0].workspaces[0].columns[0].width,
-      .pixels(600)
-    )
+    #expect(learned)
+    #expect(state.monitors[0].workspaces[0].columns[0].width == .pixels(600))
   }
 
-  func testMouseResizeDoesNotOverwriteIntrinsicWidth() throws {
+  @Test
+  func `Mouse resize does not overwrite intrinsic width`() throws {
     let config = Config()
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)
@@ -152,17 +150,17 @@ final class RuntimeWidthLearningTests: XCTestCase {
       state: &state
     )
 
-    XCTAssertFalse(
+    #expect(
       learnTiledWindowWidth(
         window.id,
         actualFrame: Rect(x: 8, y: 8, width: 404, height: 684),
         state: &state,
         viewports: [monitorID: Rect(x: 0, y: 0, width: 1_000, height: 700)]
-      )
-    )
+      ) == false)
   }
 
-  func testMaximizedWidthCannotBeLearnedFromAXDrift() throws {
+  @Test
+  func `Maximized width cannot be learned from AX drift`() throws {
     let config = Config()
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)
@@ -176,22 +174,15 @@ final class RuntimeWidthLearningTests: XCTestCase {
     try discoverWindow(window, decision: RuleDecision(), state: &state)
     try reduce(.maximizeColumn, on: monitorID, state: &state)
 
-    XCTAssertFalse(
+    #expect(
       learnTiledWindowWidth(
         window.id,
         actualFrame: Rect(x: 8, y: 8, width: 784, height: 684),
         state: &state,
         viewports: [monitorID: Rect(x: 0, y: 0, width: 1_000, height: 700)]
-      )
-    )
-    XCTAssertEqual(
-      state.monitors[0].workspaces[0].columns[0].width,
-      .fraction(1)
-    )
-    XCTAssertEqual(
-      state.monitors[0].workspaces[0].columns[0].preMaximizedWidth,
-      .fraction(0.8)
-    )
+      ) == false)
+    #expect(state.monitors[0].workspaces[0].columns[0].width == .fraction(1))
+    #expect(state.monitors[0].workspaces[0].columns[0].preMaximizedWidth == .fraction(0.8))
   }
 
 }

--- a/Tests/DefiRuntimeTests/WindowLifecycleTests.swift
+++ b/Tests/DefiRuntimeTests/WindowLifecycleTests.swift
@@ -1,12 +1,13 @@
 import DefiConfig
 import DefiModel
 import DefiRuntime
-import XCTest
+import Testing
 
-final class WindowLifecycleTests: XCTestCase {
+struct WindowLifecycleTests {
   private let monitorID = MonitorID(rawValue: 1)
 
-  func testDiscoveryUsesRuleWorkspaceAndFollowFocus() throws {
+  @Test
+  func `Discovery uses rule workspace and follow focus`() throws {
     let config = Config(
       workspaces: WorkspacesConfig(names: ["dev", "web"]),
       rules: [Rule(appID: "browser", workspace: "web", followFocus: true)]
@@ -28,11 +29,12 @@ final class WindowLifecycleTests: XCTestCase {
       state: &state
     )
 
-    XCTAssertEqual(state.monitors[0].activeWorkspace, WorkspaceID(rawValue: "web"))
-    XCTAssertEqual(state.monitors[0].workspaces[1].columns[0].windows, [window.id])
+    #expect(state.monitors[0].activeWorkspace == WorkspaceID(rawValue: "web"))
+    #expect(state.monitors[0].workspaces[1].columns[0].windows == [window.id])
   }
 
-  func testTransientInheritsOwnersWorkspaceWithoutActivatingIt() throws {
+  @Test
+  func `Transient inherits owners workspace without activating it`() throws {
     let config = Config(workspaces: WorkspacesConfig(names: ["dev", "web"]))
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)
@@ -62,11 +64,12 @@ final class WindowLifecycleTests: XCTestCase {
 
     try discoverWindow(dialog, decision: RuleDecision(), state: &state)
 
-    XCTAssertEqual(state.monitors[0].activeWorkspace, WorkspaceID(rawValue: "dev"))
-    XCTAssertEqual(state.location(containing: dialog.id)?.workspaceID, WorkspaceID(rawValue: "web"))
+    #expect(state.monitors[0].activeWorkspace == WorkspaceID(rawValue: "dev"))
+    #expect(state.location(containing: dialog.id)?.workspaceID == WorkspaceID(rawValue: "web"))
   }
 
-  func testBackgroundTransientIgnoresFollowFocusRule() throws {
+  @Test
+  func `Background transient ignores follow focus rule`() throws {
     let web = WorkspaceID(rawValue: "web")
     let config = Config(
       workspaces: WorkspacesConfig(names: ["dev", web.rawValue]),
@@ -96,8 +99,8 @@ final class WindowLifecycleTests: XCTestCase {
 
     reconcileWindows([owner, dialog], config: config, state: &state)
 
-    XCTAssertEqual(state.monitors[0].activeWorkspace, WorkspaceID(rawValue: "dev"))
-    XCTAssertEqual(state.location(containing: dialog.id)?.workspaceID, web)
+    #expect(state.monitors[0].activeWorkspace == WorkspaceID(rawValue: "dev"))
+    #expect(state.location(containing: dialog.id)?.workspaceID == web)
 
     reconcileWindows([owner], config: config, state: &state)
     reconcileWindows(
@@ -107,10 +110,11 @@ final class WindowLifecycleTests: XCTestCase {
       state: &state
     )
 
-    XCTAssertEqual(state.monitors[0].activeWorkspace, web)
+    #expect(state.monitors[0].activeWorkspace == web)
   }
 
-  func testMoveWindowToWorkspaceFollows() throws {
+  @Test
+  func `Move window to workspace follows`() throws {
     let config = Config(workspaces: WorkspacesConfig(names: ["dev", "web"]))
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)
@@ -129,12 +133,13 @@ final class WindowLifecycleTests: XCTestCase {
       state: &state
     )
 
-    XCTAssertEqual(state.monitors[0].activeWorkspace, WorkspaceID(rawValue: "web"))
-    XCTAssertEqual(state.monitors[0].workspaces[1].columns[0].windows, [window.id])
-    XCTAssertTrue(state.monitors[0].workspaces[0].columns.isEmpty)
+    #expect(state.monitors[0].activeWorkspace == WorkspaceID(rawValue: "web"))
+    #expect(state.monitors[0].workspaces[1].columns[0].windows == [window.id])
+    #expect(state.monitors[0].workspaces[0].columns.isEmpty)
   }
 
-  func testReconcileRemovesClosedWindow() throws {
+  @Test
+  func `Reconcile removes closed window`() throws {
     let config = Config()
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)
@@ -149,11 +154,12 @@ final class WindowLifecycleTests: XCTestCase {
 
     reconcileWindows([], config: config, state: &state)
 
-    XCTAssertTrue(state.windows.isEmpty)
-    XCTAssertTrue(state.monitors[0].workspaces[0].columns.isEmpty)
+    #expect(state.windows.isEmpty)
+    #expect(state.monitors[0].workspaces[0].columns.isEmpty)
   }
 
-  func testReconcilePreservesIntrinsicDimensionsAfterAppliedGaps() throws {
+  @Test
+  func `Reconcile preserves intrinsic dimensions after applied gaps`() throws {
     let config = Config()
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)
@@ -180,11 +186,12 @@ final class WindowLifecycleTests: XCTestCase {
 
     reconcileWindows([observedAfterLayout], config: config, state: &state)
 
-    XCTAssertEqual(state.windows[initial.id]?.frame.width, 320)
-    XCTAssertEqual(state.windows[initial.id]?.frame.height, 640)
+    #expect(state.windows[initial.id]?.frame.width == 320)
+    #expect(state.windows[initial.id]?.frame.height == 640)
   }
 
-  func testReconcileAdoptsExternalIntrinsicResize() throws {
+  @Test
+  func `Reconcile adopts external intrinsic resize`() throws {
     let config = Config()
     var state = RuntimeState(config: config)
     state.attachMonitor(monitorID)
@@ -216,8 +223,8 @@ final class WindowLifecycleTests: XCTestCase {
       state: &state
     )
 
-    XCTAssertEqual(state.windows[initial.id]?.frame.width, 430)
-    XCTAssertEqual(state.windows[initial.id]?.frame.height, 860)
+    #expect(state.windows[initial.id]?.frame.width == 430)
+    #expect(state.windows[initial.id]?.frame.height == 860)
   }
 
 }


### PR DESCRIPTION
## Summary

- Convert the test suite from XCTest to Swift Testing.
- Replace XCTest assertions with `#expect` and `#require`.
- Consolidate repeated cases using parameterized `@Test` arguments.

## Testing

- Not run.