### PR TITLE
fix: restore menu bar quit action

### DIFF
--- a/Sources/DefiDaemon/DefiDaemon.swift
+++ b/Sources/DefiDaemon/DefiDaemon.swift
@@ -329,7 +329,11 @@ final class Daemon: NSObject {
     }
     if config.menuBar.enabled {
       menuBar = MenuBarController { [weak self] command in
-        _ = self?.handle(command)
+        if command == "quit" {
+          self?.requestShutdown()
+        } else {
+          _ = self?.handle(command)
+        }
       }
     }
     installIPCSource()


### PR DESCRIPTION
## Summary

- route the menu bar "Quit Defi" action through the daemon shutdown path
- keep workspace menu actions on the normal command handling path

## Test plan

- `swift build`
- `swift test`
- `./script/build_and_run.sh --verify`
- clicked "Quit Defi" in the installed menu bar and confirmed the daemon stopped