### PR TITLE
Defer right-window size commits until movement completes

### DIFF
--- a/Sources/DefiMacOS/AXFrameCoordinatorAnimation.swift
+++ b/Sources/DefiMacOS/AXFrameCoordinatorAnimation.swift
@@ -44,7 +44,18 @@ extension AXFrameCoordinator {
           write.isReentering ? windowID : nil
         }
       ),
-      finalOnlyProcessIDs: finalOnlyProcessIDs
+      finalOnlyProcessIDs: finalOnlyProcessIDs,
+      horizontallyMovingResizeWindowIDs: Set(
+        animatedWrites.compactMap { windowID, write in
+          asynchronousSizeWriteIsRequired(
+            sizeChanged: write.sizeChanged,
+            synchronousWriteSucceeded: write.synchronousSizeWriteSucceeded,
+            animatesSize: write.animatesSize
+          ) && abs(write.fromPoint.x - write.point.x) >= 0.5
+            ? windowID
+            : nil
+        }
+      )
     )
     let interpolatedWrites = animatedWrites.filter {
       lanePlan.interpolatedWindowIDs.contains($0.key)
@@ -52,9 +63,21 @@ extension AXFrameCoordinator {
     let finalOnlyWrites = animatedWrites.filter {
       lanePlan.finalOnlyWindowIDs.contains($0.key)
     }
+    let deferredSizeWrites = interpolatedWrites.filter {
+      lanePlan.deferredSizeWindowIDs.contains($0.key)
+    }
     var loopWrites = interpolatedWrites
+    // Move first; one final size write must not block the animation clock.
+    for (windowID, write) in deferredSizeWrites {
+      loopWrites[windowID] = positionOnlyAnimationWrite(
+        write,
+        holding: write.fromSize
+      )
+    }
     let sizeCommitCandidates = interpolatedWrites.filter {
-      !$0.value.isReentering && !$0.value.requiresVerifiedOffscreenWrite
+      !lanePlan.deferredSizeWindowIDs.contains($0.key)
+        && !$0.value.isReentering
+        && !$0.value.requiresVerifiedOffscreenWrite
         && asynchronousSizeWriteIsRequired(
           sizeChanged: $0.value.sizeChanged,
           synchronousWriteSucceeded: $0.value.synchronousSizeWriteSucceeded,
@@ -68,23 +91,9 @@ extension AXFrameCoordinator {
       )
       for (windowID, write) in sizeCommitCandidates
       where committedWindowIDs.contains(windowID) {
-        loopWrites[windowID] = AsyncPositionWrite(
-          element: write.element,
-          application: write.application,
-          processID: write.processID,
-          fromPoint: write.fromPoint,
-          point: write.point,
-          fromSize: write.size,
-          size: write.size,
-          positionChanged: write.positionChanged,
-          sizeChanged: write.sizeChanged,
-          animatesSize: false,
-          synchronousSizeWriteSucceeded: true,
-          enhancedUIWasEnabled: write.enhancedUIWasEnabled,
-          timeoutSeconds: write.timeoutSeconds,
-          isParked: write.isParked,
-          isReentering: write.isReentering,
-          requiresVerifiedOffscreenWrite: write.requiresVerifiedOffscreenWrite
+        loopWrites[windowID] = positionOnlyAnimationWrite(
+          write,
+          holding: write.size
         )
       }
     }
@@ -422,6 +431,25 @@ extension AXFrameCoordinator {
     let laneResult = laneAccumulator.result
     applied += laneResult.applied
     stale += laneResult.stale
+    if !deferredSizeWrites.isEmpty,
+      isCurrent(generation: frame.generation)
+    {
+      let deferredSizeWindowIDs = Set(deferredSizeWrites.keys)
+      let committedWindowIDs = commitFinalSizesOnce(
+        deferredSizeWrites,
+        generation: frame.generation
+      )
+      lock.lock()
+      var successfulWindowIDs = successfulFinalWritesByGeneration[
+        frame.generation,
+        default: []
+      ]
+      successfulWindowIDs.subtract(deferredSizeWindowIDs)
+      successfulWindowIDs.formUnion(committedWindowIDs)
+      successfulFinalWritesByGeneration[frame.generation] = successfulWindowIDs
+      lock.unlock()
+      publishCompletedBorderGeometry(deferredSizeWrites)
+    }
     finalOnlyGroup.wait()
     let finalOnlyResult = finalOnlyResultStore.result
     if let finalOnlyResult {

--- a/Sources/DefiMacOS/AXFrameCoordinatorWrites.swift
+++ b/Sources/DefiMacOS/AXFrameCoordinatorWrites.swift
@@ -710,10 +710,12 @@ extension AXFrameCoordinator {
           }
           guard writeResult.succeeded else { continue }
           succeeded.insert(windowID)
+          let completedPoint = completedPosition(for: windowID)
+            ?? write.fromPoint
           recordInternalFrameWrite(
             Rect(
-              x: write.fromPoint.x,
-              y: write.fromPoint.y,
+              x: completedPoint.x,
+              y: completedPoint.y,
               width: write.size.width,
               height: write.size.height
             ),

--- a/Sources/DefiMacOS/FrameCommit.swift
+++ b/Sources/DefiMacOS/FrameCommit.swift
@@ -85,6 +85,30 @@ struct AsyncPositionWrite: @unchecked Sendable {
   let requiresVerifiedOffscreenWrite: Bool
 }
 
+func positionOnlyAnimationWrite(
+  _ write: AsyncPositionWrite,
+  holding size: CGSize
+) -> AsyncPositionWrite {
+  AsyncPositionWrite(
+    element: write.element,
+    application: write.application,
+    processID: write.processID,
+    fromPoint: write.fromPoint,
+    point: write.point,
+    fromSize: size,
+    size: size,
+    positionChanged: write.positionChanged,
+    sizeChanged: write.sizeChanged,
+    animatesSize: false,
+    synchronousSizeWriteSucceeded: true,
+    enhancedUIWasEnabled: write.enhancedUIWasEnabled,
+    timeoutSeconds: write.timeoutSeconds,
+    isParked: write.isParked,
+    isReentering: write.isReentering,
+    requiresVerifiedOffscreenWrite: write.requiresVerifiedOffscreenWrite
+  )
+}
+
 func frameApplicationReference(
   pendingCorrection: Rect?,
   settlingReference: Rect?,
@@ -332,24 +356,30 @@ struct FrameAnimationLanePlan: Equatable, Sendable {
   let interpolatedWindowIDs: Set<WindowID>
   let finalOnlyWindowIDs: Set<WindowID>
   let stagedFinalOnlyReentryWindowIDs: Set<WindowID>
+  let deferredSizeWindowIDs: Set<WindowID>
 }
 
 func frameAnimationLanePlan(
   animatedWindowIDs: Set<WindowID>,
   processIDs: [WindowID: pid_t],
   reenteringWindowIDs: Set<WindowID>,
-  finalOnlyProcessIDs: Set<pid_t>
+  finalOnlyProcessIDs: Set<pid_t>,
+  horizontallyMovingResizeWindowIDs: Set<WindowID>
 ) -> FrameAnimationLanePlan {
   let finalOnlyWindowIDs = Set(
     animatedWindowIDs.filter { windowID in
       processIDs[windowID].map(finalOnlyProcessIDs.contains) ?? false
     }
   )
+  let interpolatedWindowIDs = animatedWindowIDs.subtracting(finalOnlyWindowIDs)
   return FrameAnimationLanePlan(
-    interpolatedWindowIDs: animatedWindowIDs.subtracting(finalOnlyWindowIDs),
+    interpolatedWindowIDs: interpolatedWindowIDs,
     finalOnlyWindowIDs: finalOnlyWindowIDs,
     stagedFinalOnlyReentryWindowIDs: finalOnlyWindowIDs.intersection(
       reenteringWindowIDs
+    ),
+    deferredSizeWindowIDs: horizontallyMovingResizeWindowIDs.intersection(
+      interpolatedWindowIDs
     )
   )
 }

--- a/Tests/DefiMacOSTests/FrameCommitTests.swift
+++ b/Tests/DefiMacOSTests/FrameCommitTests.swift
@@ -1257,12 +1257,35 @@ struct FrameCommitTests {
         animatedWindowIDs: [fast, slow],
         processIDs: [fast: 101, slow: 202],
         reenteringWindowIDs: [],
-        finalOnlyProcessIDs: [202]
+        finalOnlyProcessIDs: [202],
+        horizontallyMovingResizeWindowIDs: []
       )
         == FrameAnimationLanePlan(
           interpolatedWindowIDs: [fast],
           finalOnlyWindowIDs: [slow],
-          stagedFinalOnlyReentryWindowIDs: []
+          stagedFinalOnlyReentryWindowIDs: [],
+          deferredSizeWindowIDs: []
+        ))
+  }
+
+  @Test
+  func `Horizontally moving resize animates before its final size commit`() {
+    let resizing = WindowID(rawValue: 1)
+    let translating = WindowID(rawValue: 2)
+
+    #expect(
+      frameAnimationLanePlan(
+        animatedWindowIDs: [resizing, translating],
+        processIDs: [resizing: 101, translating: 202],
+        reenteringWindowIDs: [],
+        finalOnlyProcessIDs: [],
+        horizontallyMovingResizeWindowIDs: [resizing]
+      )
+        == FrameAnimationLanePlan(
+          interpolatedWindowIDs: [resizing, translating],
+          finalOnlyWindowIDs: [],
+          stagedFinalOnlyReentryWindowIDs: [],
+          deferredSizeWindowIDs: [resizing]
         ))
   }
 
@@ -1276,7 +1299,8 @@ struct FrameCommitTests {
         animatedWindowIDs: [fast, slowReentry],
         processIDs: [fast: 101, slowReentry: 202],
         reenteringWindowIDs: [slowReentry],
-        finalOnlyProcessIDs: [202]
+        finalOnlyProcessIDs: [202],
+        horizontallyMovingResizeWindowIDs: []
       ).stagedFinalOnlyReentryWindowIDs == [slowReentry])
   }
 


### PR DESCRIPTION
## Summary

- Keep horizontally moving resize windows position-only during animation.
- Commit their final size after movement completes.
- Preserve completed position when recording asynchronous frame writes.
- Add coverage for deferred-size animation lane planning.

## Testing

- Not run.