### PR TITLE
feat(config): live reload configuration

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -14,12 +14,11 @@ Launch the daemon with another file when needed:
 ~/Applications/Defi.app/Contents/MacOS/defi-daemon --config /path/to/config.toml
 ```
 
-Config loads once when the daemon starts. Restart the installed service after
-editing the default file:
-
-```sh
-~/Applications/Defi.app/Contents/MacOS/defi service restart
-```
+Defi reloads the file after each save. Invalid changes keep the last valid
+configuration active and write an error to `~/Library/Logs/Defi.log` when using
+the installed service. Reloading preserves workspace contents, focus, column
+widths, and scroll positions. Geometry is recalculated only when a changed
+setting affects the current layout.
 
 Invalid TOML, invalid values, unknown workspaces in rules or commands, and
 invalid command strings stop config loading. An invalid accelerator or modifier
@@ -468,8 +467,8 @@ windows keep observed size and position, park with their workspace, and remain
 isolated per monitor. Use `force_tiling = true` only for windows known to behave
 correctly when resized.
 
-Rules apply when a window is first discovered. Config hot reload is unsupported;
-restart Defi after changing rules.
+Rules apply when a window is first discovered. Reloaded rules affect windows
+discovered afterward without moving windows already managed by Defi.
 
 ## Built-in defaults
 
@@ -563,8 +562,8 @@ names = []
 
 ## Unsupported configuration
 
-Startup commands, dimming, per-edge gaps, removing generated keybindings, and
-config hot reload are not implemented. No compatibility aliases exist before
+Startup commands, dimming, per-edge gaps, and removing generated keybindings are
+not implemented. No compatibility aliases exist before
 the first stable release; use setting names exactly as documented.
 
 ## Full example

--- a/Sources/DefiDaemon/DaemonConfiguration.swift
+++ b/Sources/DefiDaemon/DaemonConfiguration.swift
@@ -1,0 +1,227 @@
+import Darwin
+import DefiConfig
+import DefiMacOS
+import DefiModel
+import DefiRuntime
+import Foundation
+
+@MainActor
+final class ConfigFileWatcher {
+  private let configURL: URL
+  private let changeHandler: @MainActor @Sendable () -> Void
+  private var directorySource: DispatchSourceFileSystemObject?
+  private var fileSource: DispatchSourceFileSystemObject?
+  private var reloadGeneration: UInt64 = 0
+
+  init(configURL: URL, changeHandler: @escaping @MainActor @Sendable () -> Void) {
+    self.configURL = configURL
+    self.changeHandler = changeHandler
+  }
+
+  func start() throws {
+    guard directorySource == nil else { return }
+    let directoryURL = configURL.deletingLastPathComponent()
+    let descriptor = open(directoryURL.path, O_EVTONLY)
+    guard descriptor >= 0 else {
+      throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+    }
+    let source = DispatchSource.makeFileSystemObjectSource(
+      fileDescriptor: descriptor,
+      eventMask: [.write, .rename, .delete],
+      queue: .main
+    )
+    source.setEventHandler { [weak self] in
+      MainActor.assumeIsolated {
+        self?.scheduleReload()
+      }
+    }
+    source.setCancelHandler {
+      close(descriptor)
+    }
+    directorySource = source
+    source.resume()
+    replaceFileSource()
+  }
+
+  func stop() {
+    reloadGeneration &+= 1
+    fileSource?.cancel()
+    fileSource = nil
+    directorySource?.cancel()
+    directorySource = nil
+  }
+
+  private func scheduleReload() {
+    reloadGeneration &+= 1
+    let generation = reloadGeneration
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
+      MainActor.assumeIsolated {
+        guard let self, generation == self.reloadGeneration else { return }
+        self.replaceFileSource()
+        self.changeHandler()
+      }
+    }
+  }
+
+  private func replaceFileSource() {
+    fileSource?.cancel()
+    fileSource = nil
+    let descriptor = open(configURL.path, O_EVTONLY)
+    guard descriptor >= 0 else { return }
+    let source = DispatchSource.makeFileSystemObjectSource(
+      fileDescriptor: descriptor,
+      eventMask: [.write, .rename, .delete],
+      queue: .main
+    )
+    source.setEventHandler { [weak self] in
+      MainActor.assumeIsolated {
+        self?.scheduleReload()
+      }
+    }
+    source.setCancelHandler {
+      close(descriptor)
+    }
+    fileSource = source
+    source.resume()
+  }
+}
+
+@MainActor
+extension Daemon {
+  func startConfigWatcher() {
+    let watcher = ConfigFileWatcher(configURL: configURL) { [weak self] in
+      self?.reloadConfiguration()
+    }
+    do {
+      try watcher.start()
+      configWatcher = watcher
+    } catch {
+      log("config watcher unavailable for \(configURL.path): \(error)")
+    }
+  }
+
+  func reloadConfiguration() {
+    do {
+      let nextConfig = try Config.load(from: configURL)
+      guard nextConfig != config else { return }
+      applyConfiguration(nextConfig)
+      log("config reloaded")
+    } catch {
+      log("config reload failed; keeping previous configuration: \(error)")
+    }
+  }
+
+  private func applyConfiguration(_ nextConfig: Config) {
+    let previousConfig = config
+    let previousViewports = viewportsByMonitor
+    let previousFloatingMonitorIDs = Dictionary(
+      uniqueKeysWithValues: floatingWindowFrames.keys.compactMap { windowID in
+        state.monitorID(containing: windowID).map { (windowID, $0) }
+      }
+    )
+    let requiresLayout = state.applyConfiguration(nextConfig)
+    config = nextConfig
+    configGeneration &+= 1
+
+    if hotKeyConfigurationChanged(from: previousConfig, to: nextConfig) {
+      hotKeys?.stop()
+      hotKeys = nil
+      pendingHotKeyCommands.removeAll(keepingCapacity: true)
+      installHotKeys()
+      hotKeys?.setOverviewModeEnabled(overviewController?.isOpen == true)
+    }
+    if previousConfig.menuBar != nextConfig.menuBar {
+      updateMenuBarAvailability()
+    }
+
+    let nextViewports = viewportsByMonitor
+    let viewportsChanged = previousViewports != nextViewports
+    let bordersChanged =
+      previousConfig.decorations.borders
+      != nextConfig.decorations.borders
+    if requiresLayout || viewportsChanged || bordersChanged {
+      rebaseFloatingWindowFrames(
+        previousViewports: previousViewports,
+        nextViewports: nextViewports,
+        previousMonitorIDs: previousFloatingMonitorIDs
+      )
+      synchronizeScrollOffsets(state: &state, viewports: nextViewports)
+      snapScrollOffsetsToTargets()
+      applyCurrentLayout(
+        asynchronousPositions: true,
+        updateVisibility: true,
+        positionTimeoutSeconds: 0.05,
+        forceFloatingFrameWrites: viewportsChanged,
+        source: "config-reload"
+      )
+    }
+
+    updateOverviewIfOpen()
+    updateMenuBar()
+    persistTopology()
+    if previousConfig.rules != nextConfig.rules {
+      synchronizeDesktop(
+        forceFullWindowRefresh: true,
+        forceWindowListRefresh: true,
+        forceApplicationInventoryRefresh: true
+      )
+    }
+  }
+
+  private func hotKeyConfigurationChanged(from previous: Config, to next: Config) -> Bool {
+    previous.keys != next.keys
+      || previous.modifierCombinations != next.modifierCombinations
+      || previous.input.focusFollowsMouse != next.input.focusFollowsMouse
+      || previous.input.mouseFollowsFocus != next.input.mouseFollowsFocus
+  }
+
+  func installHotKeys() {
+    let manager = HotKeyManager(
+      config: config,
+      userInputTracker: platform.userInputTracker,
+      pointerMotionTracker: platform.pointerMotionTracker,
+      pointerMotionHandler: { [weak self] invocation in
+        guard self?.desktopSessionActive == true else { return }
+        self?.handlePointerMotion(invocation)
+      },
+      tapReenabledHandler: { [weak self] timestamp in
+        self?.handleEventTapReenabled(at: timestamp)
+      },
+      overviewHandler: { [weak self] action in
+        guard self?.desktopSessionActive == true else { return }
+        self?.overviewController?.handleKey(action)
+      }
+    ) { [weak self] invocation in
+      self?.enqueueHotKey(invocation)
+    }
+    do {
+      try manager.start()
+      hotKeys = manager
+      if let bindingError = manager.bindingError {
+        if manager.tracksPointerMotion {
+          log("hotkeys unavailable: \(bindingError); pointer tracking remains enabled")
+        } else {
+          log("hotkeys unavailable: \(bindingError)")
+        }
+      }
+    } catch {
+      log("input event tap unavailable: \(error)")
+    }
+  }
+
+  func updateMenuBarAvailability() {
+    guard config.menuBar.enabled else {
+      menuBar?.remove()
+      menuBar = nil
+      return
+    }
+    guard menuBar == nil else { return }
+    menuBar = MenuBarController { [weak self] command in
+      if command == "quit" {
+        self?.requestShutdown()
+      } else {
+        _ = self?.handle(command)
+      }
+    }
+  }
+}

--- a/Sources/DefiDaemon/DaemonDesktopSynchronization.swift
+++ b/Sources/DefiDaemon/DaemonDesktopSynchronization.swift
@@ -41,6 +41,7 @@ extension Daemon {
   ) {
     guard desktopSessionActive else { return }
     let sessionGeneration = desktopSessionGeneration
+    let requestedConfigGeneration = configGeneration
     let nativeFocusWasPending = platform.hasPendingNativeFocusEvent
     if desktopSnapshotInFlight {
       supersededDesktopSnapshotRequest = (
@@ -60,7 +61,8 @@ extension Daemon {
     ) { [weak self] snapshot in
       guard let self else { return }
       guard desktopSessionActive,
-        desktopSessionGeneration == sessionGeneration
+        desktopSessionGeneration == sessionGeneration,
+        configGeneration == requestedConfigGeneration
       else {
         desktopSnapshotInFlight = false
         supersededDesktopSnapshotRequest = nil

--- a/Sources/DefiDaemon/DaemonStatusLifecycle.swift
+++ b/Sources/DefiDaemon/DaemonStatusLifecycle.swift
@@ -308,6 +308,7 @@ extension Daemon {
   }
 
   func shutdown() -> Never {
+    configWatcher?.stop()
     timer?.cancel()
     ipcSource?.cancel()
     flushPendingPlacementWrite()

--- a/Sources/DefiDaemon/DefiDaemon.swift
+++ b/Sources/DefiDaemon/DefiDaemon.swift
@@ -164,7 +164,8 @@ enum DisplacedPointerFocusRecovery: Equatable {
 
 @MainActor
 final class Daemon: NSObject {
-  let config: Config
+  let configURL: URL
+  var config: Config
   let platform = MacOSPlatform()
   let server: UnixSocketServer
   let placementStore: PlacementStore
@@ -202,6 +203,8 @@ final class Daemon: NSObject {
   var layoutPlansByMonitor: [MonitorID: MonitorLayoutPlan] = [:]
   var shouldShutdown = false
   var signalSources: [DispatchSourceSignal] = []
+  var configWatcher: ConfigFileWatcher?
+  var configGeneration: UInt64 = 0
   var pendingHotKeyCommands: [HotKeyInvocation] = []
   var processingHotKeyCommands = false
   var processedHotKeyCount = 0
@@ -283,7 +286,8 @@ final class Daemon: NSObject {
   var followUpBackoffSteps = 0
 
   fileprivate init(options: DaemonOptions) throws {
-    config = try Config.load(from: options.configURL)
+    configURL = options.configURL ?? Config.defaultURL
+    config = try Config.load(from: configURL)
     server = try UnixSocketServer(url: options.socketURL)
     placementStore = PlacementStore()
     topologyStore = WorkspaceTopologyStore()
@@ -333,46 +337,9 @@ final class Daemon: NSObject {
       }
     )
 
-    let manager = HotKeyManager(
-      config: config,
-      userInputTracker: platform.userInputTracker,
-      pointerMotionTracker: platform.pointerMotionTracker,
-      pointerMotionHandler: { [weak self] invocation in
-        guard self?.desktopSessionActive == true else { return }
-        self?.handlePointerMotion(invocation)
-      },
-      tapReenabledHandler: { [weak self] timestamp in
-        self?.handleEventTapReenabled(at: timestamp)
-      },
-      overviewHandler: { [weak self] action in
-        guard self?.desktopSessionActive == true else { return }
-        self?.overviewController?.handleKey(action)
-      }
-    ) { [weak self] invocation in
-      self?.enqueueHotKey(invocation)
-    }
-    do {
-      try manager.start()
-      hotKeys = manager
-      if let bindingError = manager.bindingError {
-        if manager.tracksPointerMotion {
-          log("hotkeys unavailable: \(bindingError); pointer tracking remains enabled")
-        } else {
-          log("hotkeys unavailable: \(bindingError)")
-        }
-      }
-    } catch {
-      log("input event tap unavailable: \(error)")
-    }
-    if config.menuBar.enabled {
-      menuBar = MenuBarController { [weak self] command in
-        if command == "quit" {
-          self?.requestShutdown()
-        } else {
-          _ = self?.handle(command)
-        }
-      }
-    }
+    installHotKeys()
+    updateMenuBarAvailability()
+    startConfigWatcher()
     installIPCSource()
 
     synchronizeDesktop(

--- a/Sources/DefiMacOS/HotKeys.swift
+++ b/Sources/DefiMacOS/HotKeys.swift
@@ -147,6 +147,7 @@ public final class HotKeyManager {
         }
       }
     }
+    let callbackContext = Unmanaged.passRetained(context)
     guard
       let tap = CGEvent.tapCreate(
         tap: .cgSessionEventTap,
@@ -154,18 +155,24 @@ public final class HotKeyManager {
         options: .defaultTap,
         eventsOfInterest: mask,
         callback: callback,
-        userInfo: Unmanaged.passUnretained(context).toOpaque()
+        userInfo: callbackContext.toOpaque()
       )
     else {
+      callbackContext.release()
       throw HotKeyError.eventTapUnavailable
     }
     guard let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
     else {
       CGEvent.tapEnable(tap: tap, enable: false)
       CFMachPortInvalidate(tap)
+      callbackContext.release()
       throw HotKeyError.eventTapUnavailable
     }
-    context.install(tap: tap, source: source)
+    context.install(
+      tap: tap,
+      source: source,
+      callbackContext: callbackContext
+    )
     let thread = Thread { context.run() }
     thread.name = "com.quentin.defi.hotkeys"
     thread.qualityOfService = .userInteractive
@@ -216,6 +223,7 @@ final class HotKeyTapContext: @unchecked Sendable {
   private var tap: CFMachPort?
   private var source: CFRunLoopSource?
   private var runLoop: CFRunLoop?
+  private var callbackContext: Unmanaged<HotKeyTapContext>?
   private var captured = 0
   private var reenables = 0
   private var pointerTransitions = 0
@@ -247,10 +255,15 @@ final class HotKeyTapContext: @unchecked Sendable {
     self.tapReenabled = tapReenabled
   }
 
-  func install(tap: CFMachPort, source: CFRunLoopSource) {
+  func install(
+    tap: CFMachPort,
+    source: CFRunLoopSource,
+    callbackContext: Unmanaged<HotKeyTapContext>
+  ) {
     lock.lock()
     self.tap = tap
     self.source = source
+    self.callbackContext = callbackContext
     lock.unlock()
   }
 
@@ -500,7 +513,10 @@ final class HotKeyTapContext: @unchecked Sendable {
     let tap = tap
     let source = source
     let runLoop = runLoop
+    let callbackContext = callbackContext
+    self.callbackContext = nil
     lock.unlock()
+    guard let callbackContext else { return }
     if let tap {
       CGEvent.tapEnable(tap: tap, enable: false)
     }
@@ -508,6 +524,7 @@ final class HotKeyTapContext: @unchecked Sendable {
       if let tap {
         CFMachPortInvalidate(tap)
       }
+      callbackContext.release()
       return
     }
     CFRunLoopPerformBlock(runLoop, CFRunLoopMode.commonModes.rawValue) {
@@ -518,6 +535,7 @@ final class HotKeyTapContext: @unchecked Sendable {
         CGEvent.tapEnable(tap: tap, enable: false)
         CFMachPortInvalidate(tap)
       }
+      callbackContext.release()
       CFRunLoopStop(runLoop)
     }
     CFRunLoopWakeUp(runLoop)

--- a/Sources/DefiMacOS/HotKeys.swift
+++ b/Sources/DefiMacOS/HotKeys.swift
@@ -188,6 +188,12 @@ public final class HotKeyManager {
     context?.setOverviewModeEnabled(enabled)
   }
 
+  public func stop() {
+    context?.stop()
+    context = nil
+    thread = nil
+  }
+
   isolated deinit {
     context?.stop()
   }
@@ -495,9 +501,11 @@ final class HotKeyTapContext: @unchecked Sendable {
     let source = source
     let runLoop = runLoop
     lock.unlock()
+    if let tap {
+      CGEvent.tapEnable(tap: tap, enable: false)
+    }
     guard let runLoop else {
       if let tap {
-        CGEvent.tapEnable(tap: tap, enable: false)
         CFMachPortInvalidate(tap)
       }
       return

--- a/Sources/DefiMacOS/HotKeys.swift
+++ b/Sources/DefiMacOS/HotKeys.swift
@@ -514,6 +514,8 @@ final class HotKeyTapContext: @unchecked Sendable {
     let source = source
     let runLoop = runLoop
     let callbackContext = callbackContext
+    self.tap = nil
+    self.source = nil
     self.callbackContext = nil
     lock.unlock()
     guard let callbackContext else { return }

--- a/Sources/DefiMacOS/MenuBar.swift
+++ b/Sources/DefiMacOS/MenuBar.swift
@@ -46,6 +46,10 @@ public final class MenuBarController: NSObject {
     rebuildMenu()
   }
 
+  public func remove() {
+    NSStatusBar.system.removeStatusItem(statusItem)
+  }
+
   private func updateButton() {
     guard let button = statusItem.button else { return }
     button.image = nil

--- a/Sources/DefiRuntime/RuntimeState.swift
+++ b/Sources/DefiRuntime/RuntimeState.swift
@@ -95,6 +95,30 @@ public struct RuntimeState: Equatable, Sendable {
     WorkspaceTopology(state: self)
   }
 
+  @discardableResult
+  public mutating func applyConfiguration(_ config: Config) -> Bool {
+    let previousLayout = layout
+    let nextWorkspaceNames = config.workspaces.names.map(WorkspaceID.init(rawValue:))
+    let nextWorkspaceMonitorPositions = Dictionary(
+      uniqueKeysWithValues: config.workspaces.monitors.map {
+        (WorkspaceID(rawValue: $0.key), $0.value)
+      }
+    )
+    let workspacesChanged =
+      workspaceNames != nextWorkspaceNames
+      || workspaceMonitorPositions != nextWorkspaceMonitorPositions
+
+    layout = LayoutSettings(config: config)
+    workspaceNames = nextWorkspaceNames
+    defaultWorkspace = config.workspaces.defaultName.map(WorkspaceID.init(rawValue:))
+    workspaceMonitorPositions = nextWorkspaceMonitorPositions
+    if workspacesChanged {
+      reconcileConfiguredWorkspaces()
+    }
+
+    return workspacesChanged || previousLayout.requiresImmediateReflow(comparedTo: layout)
+  }
+
   public mutating func attachMonitor(_ monitorID: MonitorID) {
     attachMonitor(monitorID, previousViewports: [:], nextViewports: [:])
   }
@@ -725,5 +749,16 @@ extension LayoutSettings {
       outerLeftGap: max(config.layout.outerLeftGap ?? config.layout.gaps, borderPadding),
       horizontalViewportPadding: borderPadding
     )
+  }
+
+  fileprivate func requiresImmediateReflow(comparedTo other: LayoutSettings) -> Bool {
+    centerFocusedColumn != other.centerFocusedColumn
+      || innerHorizontalGap != other.innerHorizontalGap
+      || innerVerticalGap != other.innerVerticalGap
+      || outerTopGap != other.outerTopGap
+      || outerRightGap != other.outerRightGap
+      || outerBottomGap != other.outerBottomGap
+      || outerLeftGap != other.outerLeftGap
+      || horizontalViewportPadding != other.horizontalViewportPadding
   }
 }

--- a/Tests/DefiDaemonTests/ConfigFileWatcherTests.swift
+++ b/Tests/DefiDaemonTests/ConfigFileWatcherTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Testing
+
+@testable import DefiDaemon
+
+@MainActor
+private final class ReloadCounter {
+  var value = 0
+}
+
+struct ConfigFileWatcherTests {
+  @Test @MainActor
+  func observesInPlaceAndAtomicConfigSavesAfterDebouncing() async throws {
+    let directory = FileManager.default.temporaryDirectory
+      .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+    let configURL = directory.appending(path: "config.toml")
+    try FileManager.default.createDirectory(
+      at: directory,
+      withIntermediateDirectories: true
+    )
+    defer { try? FileManager.default.removeItem(at: directory) }
+    try Data("[layout]\ngaps = 8\n".utf8).write(to: configURL)
+
+    let counter = ReloadCounter()
+    let watcher = ConfigFileWatcher(configURL: configURL) {
+      counter.value += 1
+    }
+    try watcher.start()
+    try Data("[layout]\ngaps = 10\n".utf8).write(to: configURL)
+    try await waitForReloadCount(1, counter: counter)
+    #expect(counter.value == 1)
+
+    try Data("[layout]\ngaps = 12\n".utf8).write(to: configURL, options: .atomic)
+    try await waitForReloadCount(2, counter: counter)
+    watcher.stop()
+
+    #expect(counter.value == 2)
+  }
+
+  @MainActor
+  private func waitForReloadCount(_ expected: Int, counter: ReloadCounter) async throws {
+    for _ in 0..<100 {
+      if counter.value >= expected { return }
+      try await Task.sleep(for: .milliseconds(50))
+    }
+  }
+}

--- a/Tests/DefiRuntimeTests/LayoutGapRuntimeTests.swift
+++ b/Tests/DefiRuntimeTests/LayoutGapRuntimeTests.swift
@@ -92,4 +92,51 @@ struct LayoutGapRuntimeTests {
 
     #expect(leftAlignedFrame.x == 4)
   }
+
+  @Test
+  func configReloadPreservesLayoutStateAndOnlyRequestsNecessaryReflows() {
+    let monitorID = MonitorID(rawValue: 1)
+    let windowID = WindowID(rawValue: 1)
+    var state = RuntimeState(
+      config: Config(workspaces: WorkspacesConfig(names: ["dev"]))
+    )
+    state.attachMonitor(monitorID)
+    state.monitors[0].workspaces[0].columns = [
+      Column(window: windowID, width: .pixels(640))
+    ]
+    state.monitors[0].workspaces[0].scrollOffset = 0.25
+    state.windows[windowID] = Window(
+      id: windowID,
+      appID: "test",
+      title: "Test",
+      frame: Rect(x: 0, y: 0, width: 640, height: 800)
+    )
+
+    let defaultsOnly = state.applyConfiguration(
+      Config(
+        layout: LayoutConfig(
+          defaultColumnWidth: 0.5,
+          presetColumnWidths: [0.5, 1]
+        ),
+        workspaces: WorkspacesConfig(names: ["dev"])
+      )
+    )
+
+    #expect(defaultsOnly == false)
+    #expect(state.monitors[0].workspaces[0].columns[0].width == .pixels(640))
+    #expect(state.monitors[0].workspaces[0].scrollOffset == 0.25)
+
+    let geometryChanged = state.applyConfiguration(
+      Config(
+        layout: LayoutConfig(gaps: 20),
+        workspaces: WorkspacesConfig(names: ["dev", "web"])
+      )
+    )
+
+    #expect(geometryChanged)
+    #expect(state.monitors[0].workspaces[0].columns[0].width == .pixels(640))
+    #expect(state.monitors[0].workspaces[0].columns[0].windows == [windowID])
+    #expect(state.monitors[0].workspaces[0].scrollOffset == 0.25)
+    #expect(state.monitors[0].workspaces.contains { $0.id == WorkspaceID(rawValue: "web") })
+  }
 }


### PR DESCRIPTION
## Summary

- Add debounced config file watching for in-place and atomic saves.
- Preserve the last valid configuration when reloads fail.
- Apply changed hotkeys, menu bar settings, layout, workspaces, and rules without restarting.
- Document live reload behavior and add coverage for watcher and runtime state preservation.

## Testing

- Not run: `swift build`
- Not run: `swift test`
- Not run: `./script/build_and_run.sh --verify`