### PR TITLE
fix: reduce window open and close synchronization lag

### DIFF
--- a/Sources/DefiDaemon/DaemonConfiguration.swift
+++ b/Sources/DefiDaemon/DaemonConfiguration.swift
@@ -1,4 +1,3 @@
-import AppKit
 import Darwin
 import DefiConfig
 import DefiMacOS
@@ -7,6 +6,13 @@ import DefiRuntime
 import Foundation
 
 let windowCloseRefreshDelays = [50, 150, 350, 700, 1_200, 2_000]
+
+func windowCloseTargetProcessID(
+  eventTargetProcessID: pid_t?,
+  selectedProcessID: pid_t?
+) -> pid_t? {
+  eventTargetProcessID ?? selectedProcessID
+}
 
 func windowCloseRetryIsCurrent(
   intentTimestamp: TimeInterval,
@@ -205,9 +211,10 @@ extension Daemon {
           .flatMap { state.selectedWindowID(on: $0) }
         let selectedProcessID = selectedWindowID
           .flatMap { state.windows[$0]?.processID }
-        guard let processID = targetProcessID
-          ?? NSWorkspace.shared.frontmostApplication?.processIdentifier
-          ?? selectedProcessID
+        guard let processID = windowCloseTargetProcessID(
+          eventTargetProcessID: targetProcessID,
+          selectedProcessID: selectedProcessID
+        )
         else { return }
         let previousWindowCount = state.windows.values.lazy.filter {
           $0.processID == processID

--- a/Sources/DefiDaemon/DaemonConfiguration.swift
+++ b/Sources/DefiDaemon/DaemonConfiguration.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Darwin
 import DefiConfig
 import DefiMacOS
@@ -186,6 +187,24 @@ extension Daemon {
       },
       tapReenabledHandler: { [weak self] timestamp in
         self?.handleEventTapReenabled(at: timestamp)
+      },
+      closeIntentHandler: { [weak self] timestamp in
+        guard let self, desktopSessionActive else { return }
+        let selectedProcessID = activeMonitorID
+          .flatMap { state.selectedWindowID(on: $0) }
+          .flatMap { state.windows[$0]?.processID }
+        guard let processID = NSWorkspace.shared.frontmostApplication?
+          .processIdentifier ?? selectedProcessID
+        else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(50)) {
+          guard self.desktopSessionActive else { return }
+          self.platform.requestWindowTopologyRefresh(
+            processID: processID,
+            inputTimestamp: timestamp
+          )
+          self.needsDesktopSync = true
+          self.scheduleTick()
+        }
       },
       overviewHandler: { [weak self] action in
         guard self?.desktopSessionActive == true else { return }

--- a/Sources/DefiDaemon/DaemonConfiguration.swift
+++ b/Sources/DefiDaemon/DaemonConfiguration.swift
@@ -6,6 +6,17 @@ import DefiModel
 import DefiRuntime
 import Foundation
 
+let windowCloseRefreshDelays = [50, 150, 350, 700, 1_200, 2_000]
+
+func windowCloseRetryIsCurrent(
+  intentTimestamp: TimeInterval,
+  latestInputTimestamp: TimeInterval,
+  latestCloseIntentTimestamp: TimeInterval
+) -> Bool {
+  latestCloseIntentTimestamp == intentTimestamp
+    && latestInputTimestamp <= intentTimestamp
+}
+
 @MainActor
 final class ConfigFileWatcher {
   private let configURL: URL
@@ -188,22 +199,48 @@ extension Daemon {
       tapReenabledHandler: { [weak self] timestamp in
         self?.handleEventTapReenabled(at: timestamp)
       },
-      closeIntentHandler: { [weak self] timestamp in
+      closeIntentHandler: { [weak self] timestamp, targetProcessID in
         guard let self, desktopSessionActive else { return }
-        let selectedProcessID = activeMonitorID
+        let selectedWindowID = activeMonitorID
           .flatMap { state.selectedWindowID(on: $0) }
+        let selectedProcessID = selectedWindowID
           .flatMap { state.windows[$0]?.processID }
-        guard let processID = NSWorkspace.shared.frontmostApplication?
-          .processIdentifier ?? selectedProcessID
+        guard let processID = targetProcessID
+          ?? NSWorkspace.shared.frontmostApplication?.processIdentifier
+          ?? selectedProcessID
         else { return }
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(50)) {
-          guard self.desktopSessionActive else { return }
-          self.platform.requestWindowTopologyRefresh(
-            processID: processID,
-            inputTimestamp: timestamp
-          )
-          self.needsDesktopSync = true
-          self.scheduleTick()
+        let previousWindowCount = state.windows.values.lazy.filter {
+          $0.processID == processID
+        }.count
+        let trackedWindowID = selectedProcessID == processID
+          ? selectedWindowID
+          : nil
+        for delay in windowCloseRefreshDelays {
+          DispatchQueue.main.asyncAfter(
+            deadline: .now() + .milliseconds(delay)
+          ) {
+            let input = self.platform.userInputTracker.snapshot
+            guard self.desktopSessionActive,
+              windowCloseRetryIsCurrent(
+                intentTimestamp: timestamp,
+                latestInputTimestamp: input.latestEventTimestamp,
+                latestCloseIntentTimestamp: input.latestCloseIntent
+              ),
+              trackedWindowID.map({ self.state.windows[$0] != nil }) ?? true,
+              self.state.windows.values.lazy.filter({
+                $0.processID == processID
+              }).count >= previousWindowCount
+            else { return }
+            self.platform.recordPerformanceTrace(
+              "window-close-retry pid=\(processID) delay=\(delay)"
+            )
+            self.platform.requestWindowTopologyRefresh(
+              processID: processID,
+              inputTimestamp: timestamp
+            )
+            self.needsDesktopSync = true
+            self.scheduleTick()
+          }
         }
       },
       overviewHandler: { [weak self] action in

--- a/Sources/DefiMacOS/HotKeys.swift
+++ b/Sources/DefiMacOS/HotKeys.swift
@@ -12,6 +12,8 @@ public final class HotKeyManager {
     @MainActor @Sendable (PointerMotionInvocation) -> Void
   public typealias TapReenabledHandler =
     @MainActor @Sendable (TimeInterval) -> Void
+  public typealias CloseIntentHandler =
+    @MainActor @Sendable (TimeInterval) -> Void
   public typealias OverviewHandler =
     @MainActor @Sendable (OverviewKeyAction) -> Void
 
@@ -21,6 +23,7 @@ public final class HotKeyManager {
   public let bindingError: HotKeyError?
   private let pointerMotionHandler: PointerMotionHandler?
   private let tapReenabledHandler: TapReenabledHandler
+  private let closeIntentHandler: CloseIntentHandler
   private let overviewHandler: OverviewHandler
   private let userInputTracker: UserInputTracker
   private let pointerMotionTracker: PointerMotionTracker
@@ -55,6 +58,7 @@ public final class HotKeyManager {
     pointerMotionTracker: PointerMotionTracker = PointerMotionTracker(),
     pointerMotionHandler: PointerMotionHandler? = nil,
     tapReenabledHandler: @escaping TapReenabledHandler = { _ in },
+    closeIntentHandler: @escaping CloseIntentHandler = { _ in },
     overviewHandler: @escaping OverviewHandler = { _ in },
     handler: @escaping Handler
   ) {
@@ -65,6 +69,7 @@ public final class HotKeyManager {
       ? pointerMotionHandler
       : nil
     self.tapReenabledHandler = tapReenabledHandler
+    self.closeIntentHandler = closeIntentHandler
     self.overviewHandler = overviewHandler
     self.userInputTracker = userInputTracker
     self.pointerMotionTracker = pointerMotionTracker
@@ -118,6 +123,7 @@ public final class HotKeyManager {
     let handler = self.handler
     let pointerMotionHandler = self.pointerMotionHandler
     let tapReenabledHandler = self.tapReenabledHandler
+    let closeIntentHandler = self.closeIntentHandler
     let overviewHandler = self.overviewHandler
     let context = HotKeyTapContext(
       bindings: bindings,
@@ -144,6 +150,12 @@ public final class HotKeyManager {
       DispatchQueue.main.async {
         MainActor.assumeIsolated {
           tapReenabledHandler(timestamp)
+        }
+      }
+    } closeIntent: { timestamp in
+      DispatchQueue.main.async {
+        MainActor.assumeIsolated {
+          closeIntentHandler(timestamp)
         }
       }
     }
@@ -218,6 +230,7 @@ final class HotKeyTapContext: @unchecked Sendable {
   private let deliverOverview: @Sendable (OverviewKeyAction) -> Void
   private let deliverPointerMotion: @Sendable (PointerMotionInvocation) -> Void
   private let tapReenabled: @Sendable (TimeInterval) -> Void
+  private let closeIntent: @Sendable (TimeInterval) -> Void
   private let lock = NSLock()
   private let ready = DispatchSemaphore(value: 0)
   private var tap: CFMachPort?
@@ -243,7 +256,8 @@ final class HotKeyTapContext: @unchecked Sendable {
     deliver: @escaping @Sendable (HotKeyInvocation) -> Void,
     deliverOverview: @escaping @Sendable (OverviewKeyAction) -> Void,
     deliverPointerMotion: @escaping @Sendable (PointerMotionInvocation) -> Void,
-    tapReenabled: @escaping @Sendable (TimeInterval) -> Void
+    tapReenabled: @escaping @Sendable (TimeInterval) -> Void,
+    closeIntent: @escaping @Sendable (TimeInterval) -> Void = { _ in }
   ) {
     self.bindings = bindings
     self.userInputTracker = userInputTracker
@@ -253,6 +267,7 @@ final class HotKeyTapContext: @unchecked Sendable {
     self.deliverOverview = deliverOverview
     self.deliverPointerMotion = deliverPointerMotion
     self.tapReenabled = tapReenabled
+    self.closeIntent = closeIntent
   }
 
   func install(
@@ -375,6 +390,7 @@ final class HotKeyTapContext: @unchecked Sendable {
         capturedModifierReleaseState.capture(
           modifierBits: hotKeyModifierBits(event.flags)
         )
+        self.closeIntent(timestamp)
       }
     }
     guard isKeyDown else {

--- a/Sources/DefiMacOS/HotKeys.swift
+++ b/Sources/DefiMacOS/HotKeys.swift
@@ -13,7 +13,7 @@ public final class HotKeyManager {
   public typealias TapReenabledHandler =
     @MainActor @Sendable (TimeInterval) -> Void
   public typealias CloseIntentHandler =
-    @MainActor @Sendable (TimeInterval) -> Void
+    @MainActor @Sendable (TimeInterval, pid_t?) -> Void
   public typealias OverviewHandler =
     @MainActor @Sendable (OverviewKeyAction) -> Void
 
@@ -58,7 +58,7 @@ public final class HotKeyManager {
     pointerMotionTracker: PointerMotionTracker = PointerMotionTracker(),
     pointerMotionHandler: PointerMotionHandler? = nil,
     tapReenabledHandler: @escaping TapReenabledHandler = { _ in },
-    closeIntentHandler: @escaping CloseIntentHandler = { _ in },
+    closeIntentHandler: @escaping CloseIntentHandler = { _, _ in },
     overviewHandler: @escaping OverviewHandler = { _ in },
     handler: @escaping Handler
   ) {
@@ -152,10 +152,10 @@ public final class HotKeyManager {
           tapReenabledHandler(timestamp)
         }
       }
-    } closeIntent: { timestamp in
+    } closeIntent: { timestamp, processID in
       DispatchQueue.main.async {
         MainActor.assumeIsolated {
-          closeIntentHandler(timestamp)
+          closeIntentHandler(timestamp, processID)
         }
       }
     }
@@ -230,7 +230,7 @@ final class HotKeyTapContext: @unchecked Sendable {
   private let deliverOverview: @Sendable (OverviewKeyAction) -> Void
   private let deliverPointerMotion: @Sendable (PointerMotionInvocation) -> Void
   private let tapReenabled: @Sendable (TimeInterval) -> Void
-  private let closeIntent: @Sendable (TimeInterval) -> Void
+  private let closeIntent: @Sendable (TimeInterval, pid_t?) -> Void
   private let lock = NSLock()
   private let ready = DispatchSemaphore(value: 0)
   private var tap: CFMachPort?
@@ -257,7 +257,7 @@ final class HotKeyTapContext: @unchecked Sendable {
     deliverOverview: @escaping @Sendable (OverviewKeyAction) -> Void,
     deliverPointerMotion: @escaping @Sendable (PointerMotionInvocation) -> Void,
     tapReenabled: @escaping @Sendable (TimeInterval) -> Void,
-    closeIntent: @escaping @Sendable (TimeInterval) -> Void = { _ in }
+    closeIntent: @escaping @Sendable (TimeInterval, pid_t?) -> Void = { _, _ in }
   ) {
     self.bindings = bindings
     self.userInputTracker = userInputTracker
@@ -390,7 +390,12 @@ final class HotKeyTapContext: @unchecked Sendable {
         capturedModifierReleaseState.capture(
           modifierBits: hotKeyModifierBits(event.flags)
         )
-        self.closeIntent(timestamp)
+        let rawProcessID = event.getIntegerValueField(
+          .eventTargetUnixProcessID
+        )
+        let processID = pid_t(exactly: rawProcessID)
+          .flatMap { $0 > 0 ? $0 : nil }
+        self.closeIntent(timestamp, processID)
       }
     }
     guard isKeyDown else {

--- a/Sources/DefiMacOS/MacOSPlatform+FramePerformance.swift
+++ b/Sources/DefiMacOS/MacOSPlatform+FramePerformance.swift
@@ -345,9 +345,17 @@ extension MacOSPlatform {
   public var notificationObservationFailureSummary: String {
     let counts = eventMonitor?.notificationObservationFailureCountsValue ?? [:]
     guard !counts.isEmpty else { return "[]" }
+    var failuresByProcess: [pid_t: [String]] = [:]
+    for kind in NotificationObservationKind.allCases {
+      for (processID, count) in counts[kind] ?? [:] {
+        failuresByProcess[processID, default: []]
+          .append("\(kind.rawValue)x\(count)")
+      }
+    }
     return "["
-      + counts.sorted { $0.key < $1.key }
-        .map { "\($0.key)x\($0.value)" }.joined(separator: ",")
+      + failuresByProcess.sorted { $0.key < $1.key }
+        .map { "\($0.key):\($0.value.joined(separator: "/"))" }
+        .joined(separator: ",")
       + "]"
   }
 

--- a/Sources/DefiMacOS/MacOSPlatform+WindowBorderObservation.swift
+++ b/Sources/DefiMacOS/MacOSPlatform+WindowBorderObservation.swift
@@ -9,6 +9,21 @@ import OSLog
 @MainActor
 extension MacOSPlatform {
 
+  public func requestWindowTopologyRefresh(
+    processID: pid_t,
+    inputTimestamp: TimeInterval? = nil
+  ) {
+    invalidatePreparedAXWindowAttributes()
+    windowTopologyEventPending = true
+    pendingWindowTopologyProcessIDs.insert(processID)
+    if let inputTimestamp {
+      pendingWindowTopologyInputTimestamp = max(
+        pendingWindowTopologyInputTimestamp ?? inputTimestamp,
+        inputTimestamp
+      )
+    }
+  }
+
   public func invalidateInputAfterEventTapReenabled(
     at timestamp: TimeInterval
   ) {
@@ -30,6 +45,10 @@ extension MacOSPlatform {
     guard eventMonitor == nil else { return }
     let monitor = PlatformEventMonitor(
       handler: { [weak self] kind, processID in
+        let eventInputTimestamp = self?.userInputTracker.latestEventTimestamp
+        let previousWindowCount = processID.flatMap {
+          self?.applicationWindowCounts[$0]
+        }
         self?.invalidatePreparedAXWindowAttributes()
         if let self {
           pendingWindowTopologyInputTimestamp =
@@ -127,6 +146,22 @@ extension MacOSPlatform {
               self.invalidatePreparedAXWindowAttributes()
               self.windowTopologyEventPending = true
               self.windowTopologyRequiresFullSnapshot = true
+              handler()
+            }
+          }
+        }
+        if let processID, let previousWindowCount {
+          for delay in windowTopologyRefreshDelays(for: kind) {
+            DispatchQueue.main.asyncAfter(
+              deadline: .now() + .milliseconds(delay)
+            ) { [weak self] in
+              guard let self,
+                self.applicationWindowCounts[processID] == previousWindowCount
+              else { return }
+              self.requestWindowTopologyRefresh(
+                processID: processID,
+                inputTimestamp: eventInputTimestamp
+              )
               handler()
             }
           }

--- a/Sources/DefiMacOS/MacOSPlatform+WindowBorderObservation.swift
+++ b/Sources/DefiMacOS/MacOSPlatform+WindowBorderObservation.swift
@@ -45,7 +45,8 @@ extension MacOSPlatform {
     guard eventMonitor == nil else { return }
     let monitor = PlatformEventMonitor(
       handler: { [weak self] kind, processID in
-        let eventInputTimestamp = self?.userInputTracker.latestEventTimestamp
+        let eventInput = self?.userInputTracker.snapshot
+        let eventInputTimestamp = eventInput?.latestEventTimestamp
         let previousWindowCount = processID.flatMap {
           self?.applicationWindowCounts[$0]
         }
@@ -66,7 +67,7 @@ extension MacOSPlatform {
             "window-event kind=\(String(describing: kind)) pid=\(processID)"
           )
         case .full:
-          if kind == .windows || kind == .application
+          if kind == .windowCreated || kind == .windows || kind == .application
             || kind == .applicationTerminated
           {
             self?.windowTopologyEventPending = true
@@ -151,7 +152,12 @@ extension MacOSPlatform {
           }
         }
         if let processID, let previousWindowCount {
-          for delay in windowTopologyRefreshDelays(for: kind) {
+          for delay in windowTopologyRefreshDelays(
+            for: kind,
+            latestInputTimestamp: eventInputTimestamp,
+            latestCloseIntentTimestamp: eventInput?.latestCloseIntent ?? 0,
+            now: ProcessInfo.processInfo.systemUptime
+          ) {
             DispatchQueue.main.asyncAfter(
               deadline: .now() + .milliseconds(delay)
             ) { [weak self] in

--- a/Sources/DefiMacOS/PlatformEventCallbacks.swift
+++ b/Sources/DefiMacOS/PlatformEventCallbacks.swift
@@ -24,23 +24,40 @@ func registerNotificationBatch(
 
 let notificationObservationMaxAttempts = 3
 
+enum NotificationObservationKind: String, CaseIterable {
+  case applicationTopology = "app"
+  case windowTopology = "window"
+  case frame
+}
+
+typealias NotificationObservationFailureCounts = [
+  NotificationObservationKind: [pid_t: Int]
+]
+
 func updatedNotificationObservationFailureCounts(
-  _ counts: [pid_t: Int],
+  _ counts: NotificationObservationFailureCounts,
   activeProcessIDs: Set<pid_t>,
-  failedProcessID: pid_t? = nil
-) -> [pid_t: Int] {
-  var updated = counts.filter { activeProcessIDs.contains($0.key) }
-  if let failedProcessID, activeProcessIDs.contains(failedProcessID) {
-    updated[failedProcessID, default: 0] += 1
+  failedProcessID: pid_t? = nil,
+  kind: NotificationObservationKind? = nil
+) -> NotificationObservationFailureCounts {
+  var updated = counts.mapValues { failures in
+    failures.filter { activeProcessIDs.contains($0.key) }
+  }.filter { !$0.value.isEmpty }
+  if let failedProcessID, let kind,
+    activeProcessIDs.contains(failedProcessID)
+  {
+    updated[kind, default: [:]][failedProcessID, default: 0] += 1
   }
   return updated
 }
 
 func processIDsIncompatibleWithNotificationObservation(
-  _ counts: [pid_t: Int]
+  _ counts: NotificationObservationFailureCounts,
+  kind: NotificationObservationKind
 ) -> Set<pid_t> {
   Set(
-    counts.filter { $0.value >= notificationObservationMaxAttempts }
+    (counts[kind] ?? [:])
+      .filter { $0.value >= notificationObservationMaxAttempts }
       .keys
   )
 }

--- a/Sources/DefiMacOS/PlatformEventMonitor.swift
+++ b/Sources/DefiMacOS/PlatformEventMonitor.swift
@@ -21,7 +21,8 @@ final class PlatformEventMonitor {
   private var mouseGestureNormalizer = MouseGestureEventNormalizer()
   private var observers: [pid_t: AXObserver] = [:]
   private var topologyObservedProcessIDs = Set<pid_t>()
-  private var notificationObservationFailureCounts: [pid_t: Int] = [:]
+  private var notificationObservationFailureCounts:
+    NotificationObservationFailureCounts = [:]
   private var observedWindows: [pid_t: [AXUIElement]] = [:]
   private var topologyRequiredWindows: [pid_t: [AXUIElement]] = [:]
   private var frameRequiredWindows: [pid_t: [AXUIElement]] = [:]
@@ -245,7 +246,6 @@ final class PlatformEventMonitor {
     }
 
     for (processID, windows) in applications {
-      guard !isIncompatibleWithNotificationObservation(processID) else { continue }
       guard let observer = observer(for: processID) else { continue }
       prepareForWindowDiscovery(
         processID: processID,
@@ -268,11 +268,15 @@ final class PlatformEventMonitor {
         applicationWindows: windows
       )
       for window in requiredTopology
-      where !isIncompatibleWithNotificationObservation(processID) {
+      where !isIncompatibleWithNotificationObservation(
+        .windowTopology,
+        processID: processID
+      ) {
         if !topologyObserved.contains(where: { CFEqual($0, window) }),
           subscribe(
             observer,
             processID: processID,
+            kind: .windowTopology,
             element: window,
             notifications: [
               kAXUIElementDestroyedNotification,
@@ -285,13 +289,17 @@ final class PlatformEventMonitor {
         }
       }
       for window in windows {
-        if !isIncompatibleWithNotificationObservation(processID),
+        if !isIncompatibleWithNotificationObservation(
+          .frame,
+          processID: processID
+        ),
           frameNotificationsEnabled,
           requiredFrames.contains(where: { CFEqual($0, window) }),
           !frameObserved.contains(where: { CFEqual($0, window) }),
           subscribe(
             observer,
             processID: processID,
+            kind: .frame,
             element: window,
             notifications: [kAXMovedNotification, kAXResizedNotification]
           )
@@ -332,7 +340,10 @@ final class PlatformEventMonitor {
     processID: pid_t,
     application: AXUIElement
   ) {
-    guard !isIncompatibleWithNotificationObservation(processID) else { return }
+    guard !isIncompatibleWithNotificationObservation(
+      .applicationTopology,
+      processID: processID
+    ) else { return }
     guard let observer = observer(for: processID) else { return }
     prepareForWindowDiscovery(
       processID: processID,
@@ -345,12 +356,19 @@ final class PlatformEventMonitor {
     for processIDs: Set<pid_t>
   ) -> Bool {
     let requiredProcessIDs =
-      processIDs.subtracting(incompatibleNotificationProcessIDs)
+      processIDs.subtracting(
+        incompatibleNotificationProcessIDs(for: .applicationTopology)
+      )
     guard requiredProcessIDs.isSubset(of: topologyObservedProcessIDs) else {
       return false
     }
+    let incompatibleWindowProcessIDs = incompatibleNotificationProcessIDs(
+      for: .windowTopology
+    )
     return topologyRequiredWindows.allSatisfy { processID, windows in
-      guard requiredProcessIDs.contains(processID) else { return true }
+      guard requiredProcessIDs.contains(processID),
+        !incompatibleWindowProcessIDs.contains(processID)
+      else { return true }
       let topologyObserved = topologyObservedWindows[processID] ?? []
       return windows.allSatisfy { window in
         topologyObserved.contains(where: { CFEqual($0, window) })
@@ -374,19 +392,31 @@ final class PlatformEventMonitor {
   }
 
   var incompatibleNotificationProcessIDs: Set<pid_t> {
-    processIDsIncompatibleWithNotificationObservation(
-      notificationObservationFailureCounts
-    )
+    NotificationObservationKind.allCases.reduce(into: Set<pid_t>()) {
+      $0.formUnion(incompatibleNotificationProcessIDs(for: $1))
+    }
   }
 
-  var notificationObservationFailureCountsValue: [pid_t: Int] {
+  var notificationObservationFailureCountsValue:
+    NotificationObservationFailureCounts
+  {
     notificationObservationFailureCounts
   }
 
   private func isIncompatibleWithNotificationObservation(
-    _ processID: pid_t
+    _ kind: NotificationObservationKind,
+    processID: pid_t
   ) -> Bool {
-    incompatibleNotificationProcessIDs.contains(processID)
+    incompatibleNotificationProcessIDs(for: kind).contains(processID)
+  }
+
+  private func incompatibleNotificationProcessIDs(
+    for kind: NotificationObservationKind
+  ) -> Set<pid_t> {
+    processIDsIncompatibleWithNotificationObservation(
+      notificationObservationFailureCounts,
+      kind: kind
+    )
   }
 
   func hasReliableFrameCoverage() -> Bool {
@@ -547,6 +577,7 @@ final class PlatformEventMonitor {
     if subscribe(
       observer,
       processID: processID,
+      kind: .applicationTopology,
       element: application,
       notifications: [
         kAXFocusedWindowChangedNotification,
@@ -561,6 +592,7 @@ final class PlatformEventMonitor {
   private func subscribe(
     _ observer: AXObserver,
     processID: pid_t,
+    kind: NotificationObservationKind,
     element: AXUIElement,
     notifications: [String]
   ) -> Bool {
@@ -587,7 +619,8 @@ final class PlatformEventMonitor {
       notificationObservationFailureCounts = updatedNotificationObservationFailureCounts(
         notificationObservationFailureCounts,
         activeProcessIDs: Set(observers.keys),
-        failedProcessID: processID
+        failedProcessID: processID,
+        kind: kind
       )
     }
     return registered

--- a/Sources/DefiMacOS/PlatformEventMonitor.swift
+++ b/Sources/DefiMacOS/PlatformEventMonitor.swift
@@ -551,6 +551,8 @@ final class PlatformEventMonitor {
           case kAXUIElementDestroyedNotification:
             monitor.windowDestroyedHandler(element)
             monitor.handler(.windows, normalizedProcessID)
+          case kAXWindowCreatedNotification:
+            monitor.handler(.windowCreated, normalizedProcessID)
           default:
             monitor.handler(.windows, normalizedProcessID)
           }

--- a/Sources/DefiMacOS/PlatformEventNormalization.swift
+++ b/Sources/DefiMacOS/PlatformEventNormalization.swift
@@ -8,6 +8,7 @@ enum PlatformEventKind: Equatable {
   case applicationTerminated
   case focus
   case frame
+  case windowCreated
   case windows
   case mouse
   case mouseRelease
@@ -111,13 +112,25 @@ func applicationLifecycleRefreshDelays(for kind: PlatformEventKind) -> [Int] {
   switch kind {
   case .application, .applicationTerminated:
     return [50, 150, 350, 700, 1_200, 2_000, 3_500, 5_500, 8_000, 12_000]
-  case .focus, .frame, .windows, .mouse, .mouseRelease, .screens, .space:
+  case .focus, .frame, .windowCreated, .windows, .mouse, .mouseRelease, .screens,
+    .space:
     return []
   }
 }
 
-func windowTopologyRefreshDelays(for kind: PlatformEventKind) -> [Int] {
-  kind == .windows ? [50, 150, 350] : []
+func windowTopologyRefreshDelays(
+  for kind: PlatformEventKind,
+  latestInputTimestamp: TimeInterval?,
+  latestCloseIntentTimestamp: TimeInterval,
+  now: TimeInterval
+) -> [Int] {
+  guard let latestInputTimestamp,
+    kind == .windowCreated,
+    latestCloseIntentTimestamp < latestInputTimestamp,
+    latestInputTimestamp <= now,
+    now - latestInputTimestamp <= 1
+  else { return [] }
+  return [50, 150, 350]
 }
 
 func nativeFocusedWindowIDAfterEvent(
@@ -169,7 +182,7 @@ func updatedWindowTopologyInputTimestamp(
   previousTimestamp: TimeInterval?
 ) -> TimeInterval? {
   switch kind {
-  case .windows, .applicationTerminated:
+  case .windowCreated, .windows, .applicationTerminated:
     return latestInputTimestamp
   case .application, .focus, .frame, .mouse, .mouseRelease, .screens, .space:
     return previousTimestamp
@@ -240,7 +253,7 @@ func windowSnapshotInvalidation(
   processID: pid_t?
 ) -> WindowSnapshotInvalidation {
   switch kind {
-  case .windows:
+  case .windowCreated, .windows:
     return processID.map(WindowSnapshotInvalidation.process) ?? .full
   case .application, .applicationTerminated, .screens, .space:
     return .full

--- a/Sources/DefiMacOS/PlatformEventNormalization.swift
+++ b/Sources/DefiMacOS/PlatformEventNormalization.swift
@@ -116,6 +116,10 @@ func applicationLifecycleRefreshDelays(for kind: PlatformEventKind) -> [Int] {
   }
 }
 
+func windowTopologyRefreshDelays(for kind: PlatformEventKind) -> [Int] {
+  kind == .windows ? [50, 150, 350] : []
+}
+
 func nativeFocusedWindowIDAfterEvent(
   _ kind: PlatformEventKind,
   cachedWindowID: WindowID?

--- a/Tests/DefiDaemonTests/DaemonCommandPolicyTests.swift
+++ b/Tests/DefiDaemonTests/DaemonCommandPolicyTests.swift
@@ -7,6 +7,19 @@ import Testing
 @testable import DefiDaemon
 
 struct DaemonCommandPolicyTests {
+  @Test(
+    "Close fallback keeps the selected process",
+    .bug("https://github.com/qeude/Defi/pull/49#discussion_r3925069182")
+  )
+  func closeFallbackKeepsSelectedProcess() {
+    #expect(
+      windowCloseTargetProcessID(
+        eventTargetProcessID: nil,
+        selectedProcessID: 42
+      ) == 42
+    )
+  }
+
   @Test
   func closeTopologyRetriesAreBoundedAndLatestWins() {
     #expect(windowCloseRefreshDelays == [50, 150, 350, 700, 1_200, 2_000])

--- a/Tests/DefiDaemonTests/DaemonCommandPolicyTests.swift
+++ b/Tests/DefiDaemonTests/DaemonCommandPolicyTests.swift
@@ -8,6 +8,32 @@ import Testing
 
 struct DaemonCommandPolicyTests {
   @Test
+  func closeTopologyRetriesAreBoundedAndLatestWins() {
+    #expect(windowCloseRefreshDelays == [50, 150, 350, 700, 1_200, 2_000])
+    #expect(
+      windowCloseRetryIsCurrent(
+        intentTimestamp: 10,
+        latestInputTimestamp: 10,
+        latestCloseIntentTimestamp: 10
+      )
+    )
+    #expect(
+      windowCloseRetryIsCurrent(
+        intentTimestamp: 10,
+        latestInputTimestamp: 11,
+        latestCloseIntentTimestamp: 10
+      ) == false
+    )
+    #expect(
+      windowCloseRetryIsCurrent(
+        intentTimestamp: 10,
+        latestInputTimestamp: 11,
+        latestCloseIntentTimestamp: 11
+      ) == false
+    )
+  }
+
+  @Test
   func backgroundSnapshotWaitsForTheCurrentCommandAnimation() {
     #expect(
       desktopSnapshotWaitsForCommandAnimation(

--- a/Tests/DefiMacOSTests/HotKeyTests.swift
+++ b/Tests/DefiMacOSTests/HotKeyTests.swift
@@ -75,7 +75,8 @@ struct HotKeyTests {
   ]
 
   private func makeContext(
-    bindings: [Key: String]
+    bindings: [Key: String],
+    closeIntent: @escaping @Sendable (TimeInterval) -> Void = { _ in }
   ) -> (HotKeyTapContext, HotKeyInvocationRecorder) {
     let invocations = HotKeyInvocationRecorder()
     return (
@@ -87,7 +88,8 @@ struct HotKeyTests {
         deliver: { invocations.append($0) },
         deliverOverview: { _ in },
         deliverPointerMotion: { _ in },
-        tapReenabled: { _ in }
+        tapReenabled: { _ in },
+        closeIntent: closeIntent
       ),
       invocations
     )
@@ -191,6 +193,25 @@ struct HotKeyTests {
     #expect(forwardedEvent?.takeUnretainedValue() === event)
     #expect(event.flags == [.maskCommand])
     #expect(invocations.commands.isEmpty)
+  }
+
+  @Test
+  func `Command W forwards the event and reports close intent`() throws {
+    let timestamps = Mutex<[TimeInterval]>([])
+    let (context, invocations) = makeContext(
+      bindings: [:],
+      closeIntent: { timestamp in timestamps.withLock { $0.append(timestamp) } }
+    )
+    let event = try #require(
+      CGEvent(keyboardEventSource: nil, virtualKey: 13, keyDown: true)
+    )
+    event.flags = [.maskCommand]
+
+    let forwardedEvent = context.handle(type: .keyDown, event: event)
+
+    #expect(forwardedEvent?.takeUnretainedValue() === event)
+    #expect(invocations.commands.isEmpty)
+    #expect(timestamps.withLock { $0.count } == 1)
   }
 
   @Test

--- a/Tests/DefiMacOSTests/HotKeyTests.swift
+++ b/Tests/DefiMacOSTests/HotKeyTests.swift
@@ -76,7 +76,7 @@ struct HotKeyTests {
 
   private func makeContext(
     bindings: [Key: String],
-    closeIntent: @escaping @Sendable (TimeInterval) -> Void = { _ in }
+    closeIntent: @escaping @Sendable (TimeInterval, pid_t?) -> Void = { _, _ in }
   ) -> (HotKeyTapContext, HotKeyInvocationRecorder) {
     let invocations = HotKeyInvocationRecorder()
     return (
@@ -195,23 +195,34 @@ struct HotKeyTests {
     #expect(invocations.commands.isEmpty)
   }
 
-  @Test
-  func `Command W forwards the event and reports close intent`() throws {
-    let timestamps = Mutex<[TimeInterval]>([])
+  @Test(arguments: [pid_t(0), 4242])
+  func `Command W forwards the event and reports close intent`(
+    rawProcessID: pid_t
+  ) throws {
+    let intents = Mutex<[(timestamp: TimeInterval, processID: pid_t?)]>([])
     let (context, invocations) = makeContext(
       bindings: [:],
-      closeIntent: { timestamp in timestamps.withLock { $0.append(timestamp) } }
+      closeIntent: { timestamp, processID in
+        intents.withLock { $0.append((timestamp, processID)) }
+      }
     )
     let event = try #require(
       CGEvent(keyboardEventSource: nil, virtualKey: 13, keyDown: true)
     )
     event.flags = [.maskCommand]
+    event.setIntegerValueField(
+      .eventTargetUnixProcessID,
+      value: Int64(rawProcessID)
+    )
+    let expectedTimestamp = Double(event.timestamp) / 1_000_000_000
 
     let forwardedEvent = context.handle(type: .keyDown, event: event)
 
     #expect(forwardedEvent?.takeUnretainedValue() === event)
     #expect(invocations.commands.isEmpty)
-    #expect(timestamps.withLock { $0.count } == 1)
+    #expect(intents.withLock { $0.map(\.timestamp) } == [expectedTimestamp])
+    let expectedProcessID = rawProcessID > 0 ? rawProcessID : nil
+    #expect(intents.withLock { $0.map(\.processID) } == [expectedProcessID])
   }
 
   @Test

--- a/Tests/DefiMacOSTests/PlatformEventTests.swift
+++ b/Tests/DefiMacOSTests/PlatformEventTests.swift
@@ -254,8 +254,38 @@ struct PlatformEventTests {
         == [50, 150, 350, 700, 1_200, 2_000, 3_500, 5_500, 8_000, 12_000]
     )
     #expect(applicationLifecycleRefreshDelays(for: .focus).isEmpty)
-    #expect(windowTopologyRefreshDelays(for: .windows) == [50, 150, 350])
-    #expect(windowTopologyRefreshDelays(for: .frame).isEmpty)
+    #expect(
+      windowTopologyRefreshDelays(
+        for: .windowCreated,
+        latestInputTimestamp: 9.5,
+        latestCloseIntentTimestamp: 0,
+        now: 10
+      ) == [50, 150, 350]
+    )
+    #expect(
+      windowTopologyRefreshDelays(
+        for: .windowCreated,
+        latestInputTimestamp: 8.5,
+        latestCloseIntentTimestamp: 0,
+        now: 10
+      ).isEmpty
+    )
+    #expect(
+      windowTopologyRefreshDelays(
+        for: .windows,
+        latestInputTimestamp: 9.5,
+        latestCloseIntentTimestamp: 0,
+        now: 10
+      ).isEmpty
+    )
+    #expect(
+      windowTopologyRefreshDelays(
+        for: .windowCreated,
+        latestInputTimestamp: 9.5,
+        latestCloseIntentTimestamp: 9.5,
+        now: 10
+      ).isEmpty
+    )
   }
 
   @Test @MainActor

--- a/Tests/DefiMacOSTests/PlatformEventTests.swift
+++ b/Tests/DefiMacOSTests/PlatformEventTests.swift
@@ -254,6 +254,20 @@ struct PlatformEventTests {
         == [50, 150, 350, 700, 1_200, 2_000, 3_500, 5_500, 8_000, 12_000]
     )
     #expect(applicationLifecycleRefreshDelays(for: .focus).isEmpty)
+    #expect(windowTopologyRefreshDelays(for: .windows) == [50, 150, 350])
+    #expect(windowTopologyRefreshDelays(for: .frame).isEmpty)
+  }
+
+  @Test @MainActor
+  func targetedTopologyRefreshPreservesItsInputTimestamp() {
+    let platform = MacOSPlatform()
+
+    platform.requestWindowTopologyRefresh(processID: 101, inputTimestamp: 12)
+    platform.requestWindowTopologyRefresh(processID: 101, inputTimestamp: 10)
+
+    #expect(platform.hasPendingWindowTopologyEvent)
+    #expect(platform.pendingWindowTopologyProcessIDs == [101])
+    #expect(platform.pendingWindowTopologyInputTimestamp == 12)
   }
 
   @Test
@@ -1595,36 +1609,60 @@ struct PlatformEventTests {
   }
 
   @Test
-  func failedNotificationObservationRetriesThenQuarantines() {
+  func failedFrameObservationDoesNotQuarantineWindowTopology() {
     let failedProcessID: pid_t = 101
     var counts = updatedNotificationObservationFailureCounts(
       [:],
       activeProcessIDs: [failedProcessID],
-      failedProcessID: failedProcessID
+      failedProcessID: failedProcessID,
+      kind: .frame
     )
 
-    #expect(counts == [failedProcessID: 1])
+    #expect(counts == [.frame: [failedProcessID: 1]])
     #expect(
-      processIDsIncompatibleWithNotificationObservation(counts).isEmpty
+      processIDsIncompatibleWithNotificationObservation(
+        counts,
+        kind: .frame
+      ).isEmpty
     )
     for _ in 1..<(notificationObservationMaxAttempts - 1) {
       counts = updatedNotificationObservationFailureCounts(
         counts,
         activeProcessIDs: [failedProcessID],
-        failedProcessID: failedProcessID
+        failedProcessID: failedProcessID,
+        kind: .frame
       )
     }
     #expect(
-      processIDsIncompatibleWithNotificationObservation(counts).isEmpty
+      processIDsIncompatibleWithNotificationObservation(
+        counts,
+        kind: .frame
+      ).isEmpty
     )
     counts = updatedNotificationObservationFailureCounts(
       counts,
       activeProcessIDs: [failedProcessID],
-      failedProcessID: failedProcessID
+      failedProcessID: failedProcessID,
+      kind: .frame
     )
     #expect(
-      processIDsIncompatibleWithNotificationObservation(counts)
+      processIDsIncompatibleWithNotificationObservation(
+        counts,
+        kind: .frame
+      )
         == [failedProcessID]
+    )
+    #expect(
+      processIDsIncompatibleWithNotificationObservation(
+        counts,
+        kind: .applicationTopology
+      ).isEmpty
+    )
+    #expect(
+      processIDsIncompatibleWithNotificationObservation(
+        counts,
+        kind: .windowTopology
+      ).isEmpty
     )
     #expect(
       updatedNotificationObservationFailureCounts(


### PR DESCRIPTION
## Summary

- Refresh window topology promptly after close intents and window lifecycle events.
- Add delayed topology refreshes to handle asynchronous macOS window updates.
- Track Accessibility observation failures independently by notification type.
- Add coverage for close intent forwarding and targeted topology refresh behavior.

## Testing

- Added Swift Testing coverage for hotkey close intents and topology refresh state.
- Updated notification observation failure tests for per-kind quarantine.
- Not run: `swift build`, `swift test`, and desktop verification.