### PR TITLE
Reduce snapshot and overview resource usage

### DIFF
--- a/Sources/DefiMacOS/MacOSPlatform+Snapshot.swift
+++ b/Sources/DefiMacOS/MacOSPlatform+Snapshot.swift
@@ -209,10 +209,27 @@ extension SnapshotEngine {
     pendingFrameRequiresFullSnapshot = false
     let monitors = onMain { $0.discoverMonitors() }
     lastMonitorFrames = monitors.map(\.frame)
-    var hasCopiedCGWindows = false
+    var hasResolvedCGWindows = false
     var cachedCGWindows: [CGWindowRecord]?
+    let refreshesOnlyKnownFrames = !frameWindowIDs.isEmpty
+      && frameWindowIDs.isSubset(of: Set(elements.keys))
+      && effectiveIncrementalProcessIDs?.isSubset(of: frameProcessIDs) == true
+      && !forceWindowListRefreshEffective
+      && !forceApplicationInventoryRefresh
+      && !tracesWindowTopology
+      && !eventRequiresFullSnapshot
     func publicCGWindows() -> [CGWindowRecord]? {
-      if hasCopiedCGWindows { return cachedCGWindows }
+      if hasResolvedCGWindows { return cachedCGWindows }
+      let reusableCGWindows = lastCGWindowInventory
+      if cgWindowInventoryCanBeReused(
+        snapshotUsesCachedWindows: effectiveIncrementalProcessIDs?.isEmpty == true,
+        snapshotRefreshesOnlyKnownFrames: refreshesOnlyKnownFrames,
+        cachedInventoryAvailable: reusableCGWindows != nil
+      ) {
+        hasResolvedCGWindows = true
+        cachedCGWindows = reusableCGWindows
+        return cachedCGWindows
+      }
       let copied: [CGWindowRecord]?
       let copyDurationMS: Double
       if preparedCGWindowInventoryAvailable {
@@ -232,8 +249,9 @@ extension SnapshotEngine {
         maximumSnapshotCGWindowCopyDurationMS,
         copyDurationMS
       )
-      hasCopiedCGWindows = true
+      hasResolvedCGWindows = true
       cachedCGWindows = copied
+      lastCGWindowInventory = copied
       cgWindowInventoryRetryAttempts =
         updatedWindowListReadRetryAttempts(
           previousAttempts: cgWindowInventoryRetryAttempts,

--- a/Sources/DefiMacOS/OverviewController.swift
+++ b/Sources/DefiMacOS/OverviewController.swift
@@ -152,7 +152,6 @@ public final class OverviewController: NSObject {
   private var previewRevealStartedAt: [WindowID: TimeInterval] = [:]
   private var previewFadeTimer: Timer?
   private var attemptedPreviewWindowIDs = Set<WindowID>()
-  private var hasAttemptedDesktopCapture = false
   private var hasRequestedPreviewPermission = false
   private var previewPendingCount = 0
   private var alignSelectionOnNextUpdate = false
@@ -166,7 +165,7 @@ public final class OverviewController: NSObject {
 
   public private(set) var isOpen = false
   public private(set) var usesWorkspaceParking = false
-  public var panelCount: Int { panels.count }
+  public var panelCount: Int { isOpen ? panels.count : 0 }
   public private(set) var previewPermissionState: OverviewPreviewPermissionState = .disabled
   public private(set) var previewFailureCount = 0
   public var previewCacheCount: Int { previewCache.count }
@@ -250,7 +249,6 @@ public final class OverviewController: NSObject {
     windowCornerRadius: Double = 12,
     windowPreviewsEnabled: Bool = false
   ) {
-    closePanelsImmediately()
     sessionGeneration &+= 1
     self.snapshot = snapshot
     self.layout = layout
@@ -263,13 +261,19 @@ public final class OverviewController: NSObject {
       windowPreviewsEnabled: windowPreviewsEnabled,
       screenCaptureAccessGranted: CGPreflightScreenCaptureAccess()
     )
+    let monitorIDs = Set(snapshot.monitors.map(\.id))
+    let canReusePanels = Set(panels.keys) == monitorIDs
+      && panels.allSatisfy { monitorID, panel in
+        screen(for: monitorID)?.frame == panel.window.frame
+          && panel.usesCapturedDesktop == !usesWorkspaceParking
+      }
+    if !canReusePanels { closePanelsImmediately() }
     previewTask?.cancel()
     previewTask = nil
     previewCache.removeAll(keepingCapacity: true)
     restoreRememberedPreviews(for: snapshot)
     resetPreviewFadeAnimation()
     attemptedPreviewWindowIDs.removeAll(keepingCapacity: true)
-    hasAttemptedDesktopCapture = false
     previewPendingCount = 0
     previewPermissionState = windowPreviewsEnabled ? .notDetermined : .disabled
     selection = initialSelection(in: snapshot)
@@ -289,7 +293,9 @@ public final class OverviewController: NSObject {
       )
     })
     for monitor in snapshot.monitors {
-      guard let screen = screen(for: monitor.id) else { continue }
+      guard panels[monitor.id] == nil,
+        let screen = screen(for: monitor.id)
+      else { continue }
       panels[monitor.id] = OverviewPanel(
         monitorID: monitor.id,
         screen: screen,
@@ -333,7 +339,6 @@ public final class OverviewController: NSObject {
       }
       resetPreviewFadeAnimation()
       attemptedPreviewWindowIDs.removeAll(keepingCapacity: true)
-      hasAttemptedDesktopCapture = false
       previewPendingCount = 0
       previewPermissionState = windowPreviewsEnabled ? .notDetermined : .disabled
     }
@@ -471,16 +476,12 @@ public final class OverviewController: NSObject {
     previewCache.removeAll(keepingCapacity: true)
     resetPreviewFadeAnimation()
     attemptedPreviewWindowIDs.removeAll(keepingCapacity: true)
-    hasAttemptedDesktopCapture = false
     previewPendingCount = 0
     stopOverviewAnimations()
     openStateHandler(false)
     let closingPanels = Array(panels.values)
-    panels.removeAll(keepingCapacity: true)
-    let animated = animationsEnabled
-      && !NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
     for panel in closingPanels {
-      panel.hide(animated: animated)
+      panel.hide()
     }
   }
 
@@ -845,9 +846,7 @@ public final class OverviewController: NSObject {
     let requests = visiblePreviewRequests().filter {
       !attemptedPreviewWindowIDs.contains($0.windowID)
     }
-    let captureDesktop = !hasAttemptedDesktopCapture
-    guard captureDesktop || !requests.isEmpty else { return }
-    hasAttemptedDesktopCapture = true
+    guard !requests.isEmpty else { return }
     attemptedPreviewWindowIDs.formUnion(requests.map(\.windowID))
     previewPendingCount = requests.count
     let generation = sessionGeneration
@@ -855,7 +854,6 @@ public final class OverviewController: NSObject {
       await Task.yield()
       await self?.capturePreviewBatch(
         requests,
-        captureDesktop: captureDesktop,
         generation: generation
       )
     }
@@ -863,7 +861,6 @@ public final class OverviewController: NSObject {
 
   private func capturePreviewBatch(
     _ requests: [OverviewPreviewRequest],
-    captureDesktop: Bool,
     generation: UInt64
   ) async {
     guard windowPreviewsEnabled, isOpen, generation == sessionGeneration,
@@ -895,22 +892,9 @@ public final class OverviewController: NSObject {
       return
     }
 
-    let desktopRequests: [OverviewDesktopCaptureRequest] = captureDesktop
-      ? panels.compactMap { monitorID, panel in
-      guard let displayID = CGDirectDisplayID(exactly: monitorID.rawValue) else {
-        return nil
-      }
-      let scale = panel.window.backingScaleFactor
-      return OverviewDesktopCaptureRequest(
-        monitorID: monitorID,
-        displayID: displayID,
-        width: max(Int((panel.view.bounds.width * scale).rounded(.up)), 1),
-        height: max(Int((panel.view.bounds.height * scale).rounded(.up)), 1)
-      )
-      } : []
     let results = await captureOverviewImages(
       previews: requests,
-      desktops: desktopRequests
+      desktops: []
     )
     guard windowPreviewsEnabled, isOpen, generation == sessionGeneration,
       !Task.isCancelled
@@ -1072,7 +1056,7 @@ public final class OverviewController: NSObject {
     guard let snapshot else { return [] }
     var requests: [OverviewPreviewRequest] = []
     for (monitorID, projection) in projections {
-      let scale = panels[monitorID]?.window.backingScaleFactor ?? 1
+      let scale = min(panels[monitorID]?.window.backingScaleFactor ?? 1, 1)
       for card in projection.workspaces.flatMap(\.windows) {
         guard let window = snapshot.windows[card.windowID] else { continue }
         let width = min(max(Int((card.frame.width * scale).rounded(.up)), 32), 1_600)
@@ -1674,6 +1658,7 @@ private protocol OverviewViewDelegate: AnyObject {
 @MainActor
 private final class OverviewPanel {
   let monitorID: MonitorID
+  let usesCapturedDesktop: Bool
   let window: NSPanel
   let view: OverviewView
   private let desktopView: NSView
@@ -1685,6 +1670,7 @@ private final class OverviewPanel {
     delegate: OverviewViewDelegate
   ) {
     self.monitorID = monitorID
+    self.usesCapturedDesktop = usesCapturedDesktop
     view = OverviewView(monitorID: monitorID, delegate: delegate)
     desktopView = NSView(frame: NSRect(origin: .zero, size: screen.frame.size))
     window = NSPanel(
@@ -1769,21 +1755,8 @@ private final class OverviewPanel {
     }
   }
 
-  func hide(animated: Bool) {
-    guard animated else {
-      close()
-      return
-    }
-    NSAnimationContext.runAnimationGroup { context in
-      context.duration = 0.12
-      context.timingFunction = CAMediaTimingFunction(name: .easeIn)
-      window.animator().alphaValue = 0
-      view.layer?.setAffineTransform(CGAffineTransform(scaleX: 0.98, y: 0.98))
-    } completionHandler: { [weak self] in
-      MainActor.assumeIsolated {
-        self?.close()
-      }
-    }
+  func hide() {
+    orderOut()
   }
 
   func localPoint(fromScreen point: NSPoint) -> NSPoint {
@@ -1792,8 +1765,14 @@ private final class OverviewPanel {
   }
 
   func close() {
-    window.orderOut(nil)
+    orderOut()
+    desktopView.layer?.contents = nil
     window.close()
+  }
+
+  private func orderOut() {
+    view.discardPreviewImages()
+    window.orderOut(nil)
   }
 }
 
@@ -1825,6 +1804,10 @@ private final class OverviewView: NSView {
     setAccessibilityElement(true)
     setAccessibilityRole(.group)
     setAccessibilityLabel("Defi Overview")
+  }
+
+  func discardPreviewImages() {
+    previews.removeAll(keepingCapacity: false)
   }
 
   @available(*, unavailable)

--- a/Sources/DefiMacOS/OverviewPreviewCapture.swift
+++ b/Sources/DefiMacOS/OverviewPreviewCapture.swift
@@ -4,8 +4,6 @@ import DefiModel
 import Foundation
 import ScreenCaptureKit
 
-private let overviewPreviewCIContext = CIContext(options: [.cacheIntermediates: false])
-
 func overviewPreviewBlurFadeHeight(
   titleBandHeight: CGFloat,
   imageScale: CGFloat,
@@ -16,7 +14,8 @@ func overviewPreviewBlurFadeHeight(
 
 func progressivelyBlurredOverviewPreview(
   _ image: CGImage,
-  fadeHeight requestedFadeHeight: CGFloat
+  fadeHeight requestedFadeHeight: CGFloat,
+  context: CIContext = CIContext(options: [.cacheIntermediates: false])
 ) -> CGImage? {
   let source = CIImage(cgImage: image)
   let extent = source.extent
@@ -42,7 +41,7 @@ func progressivelyBlurredOverviewPreview(
   blur.setValue(mask, forKey: "inputMask")
   blur.setValue(min(max(extent.height * 0.04, 10), 24), forKey: kCIInputRadiusKey)
   guard let output = blur.outputImage?.cropped(to: extent) else { return nil }
-  return overviewPreviewCIContext.createCGImage(output, from: extent)
+  return context.createCGImage(output, from: extent)
 }
 
 func overviewPreviewOpacity(
@@ -144,6 +143,8 @@ func captureOverviewImages(
   previews requests: [OverviewPreviewRequest],
   desktops desktopRequests: [OverviewDesktopCaptureRequest]
 ) async -> OverviewCaptureResults {
+  let renderingContext = CIContext(options: [.cacheIntermediates: false])
+  defer { renderingContext.clearCaches() }
   do {
     let content = try await SCShareableContent.excludingDesktopWindows(
       true,
@@ -174,7 +175,10 @@ func captureOverviewImages(
     let windows = Dictionary(
       uniqueKeysWithValues: content.windows.map { ($0.windowID, $0) }
     )
-    let batch = OverviewScreenCaptureBatch(windows: windows)
+    let batch = OverviewScreenCaptureBatch(
+      windows: windows,
+      renderingContext: renderingContext
+    )
     let previews = await runOverviewPreviewCaptures(requests) { request in
       await batch.capture(request)
     }
@@ -192,9 +196,11 @@ func captureOverviewImages(
 @MainActor
 private final class OverviewScreenCaptureBatch {
   private let windows: [CGWindowID: SCWindow]
+  private let renderingContext: CIContext
 
-  init(windows: [CGWindowID: SCWindow]) {
+  init(windows: [CGWindowID: SCWindow], renderingContext: CIContext) {
     self.windows = windows
+    self.renderingContext = renderingContext
   }
 
   func capture(
@@ -220,10 +226,12 @@ private final class OverviewScreenCaptureBatch {
         contentFilter: SCContentFilter(desktopIndependentWindow: window),
         configuration: configuration
       )
+      let renderingContext = renderingContext
       let styledImage = await Task.detached(priority: .userInitiated) {
         progressivelyBlurredOverviewPreview(
           image,
-          fadeHeight: CGFloat(request.blurFadeHeight)
+          fadeHeight: CGFloat(request.blurFadeHeight),
+          context: renderingContext
         ) ?? image
       }.value
       return OverviewPreviewCaptureResult(request: request, image: styledImage)

--- a/Sources/DefiMacOS/SnapshotEngine.swift
+++ b/Sources/DefiMacOS/SnapshotEngine.swift
@@ -413,6 +413,11 @@ final class SnapshotEngine: @unchecked Sendable {
     set { read { $0.preparedCGWindowInventory = newValue } }
   }
 
+  var lastCGWindowInventory: [CGWindowRecord]? {
+    get { read { $0.lastCGWindowInventory } }
+    set { read { $0.lastCGWindowInventory = newValue } }
+  }
+
   var preparedCGWindowInventoryDurationMS: Double {
     get { read { $0.preparedCGWindowInventoryDurationMS } }
     set { read { $0.preparedCGWindowInventoryDurationMS = newValue } }
@@ -1204,6 +1209,7 @@ private struct Storage {
   var lastSnapshotCGWindowCopyDurationMS = 0.0
   var maximumSnapshotCGWindowCopyDurationMS = 0.0
   var preparedCGWindowInventory: [CGWindowRecord]?
+  var lastCGWindowInventory: [CGWindowRecord]?
   var preparedCGWindowInventoryDurationMS = 0.0
   var preparedCGWindowInventoryAvailable = false
   var cgWindowInventoryPreparationPending = false

--- a/Sources/DefiMacOS/WindowRefreshPolicy.swift
+++ b/Sources/DefiMacOS/WindowRefreshPolicy.swift
@@ -72,6 +72,15 @@ func cgWindowInventoryRetryIsRequired(
   return unmatchedWindowRetryIsPending(attempts: attempts)
 }
 
+func cgWindowInventoryCanBeReused(
+  snapshotUsesCachedWindows: Bool,
+  snapshotRefreshesOnlyKnownFrames: Bool,
+  cachedInventoryAvailable: Bool
+) -> Bool {
+  cachedInventoryAvailable
+    && (snapshotUsesCachedWindows || snapshotRefreshesOnlyKnownFrames)
+}
+
 func applicationWindowsAfterPreparingTopologyObservation(
   prepareObservation: () -> Void,
   copyWindows: () -> [AXUIElement]?

--- a/Tests/DefiMacOSTests/WindowSnapshotStabilityTests.swift
+++ b/Tests/DefiMacOSTests/WindowSnapshotStabilityTests.swift
@@ -216,6 +216,35 @@ struct WindowSnapshotStabilityTests {
       ) == false)
   }
 
+  @Test func cachedAndKnownFrameSnapshotsReuseTheCGWindowInventory() {
+    #expect(
+      cgWindowInventoryCanBeReused(
+        snapshotUsesCachedWindows: true,
+        snapshotRefreshesOnlyKnownFrames: false,
+        cachedInventoryAvailable: true
+      )
+    )
+    #expect(
+      cgWindowInventoryCanBeReused(
+        snapshotUsesCachedWindows: false,
+        snapshotRefreshesOnlyKnownFrames: true,
+        cachedInventoryAvailable: true
+      )
+    )
+    #expect(
+      cgWindowInventoryCanBeReused(
+        snapshotUsesCachedWindows: false,
+        snapshotRefreshesOnlyKnownFrames: false,
+        cachedInventoryAvailable: true
+      ) == false)
+    #expect(
+      cgWindowInventoryCanBeReused(
+        snapshotUsesCachedWindows: true,
+        snapshotRefreshesOnlyKnownFrames: true,
+        cachedInventoryAvailable: false
+      ) == false)
+  }
+
   @Test func snapshotDurationPercentilesAreBoundedAndDeterministic() {
     let samples = [1.0, 5.0, 2.0, 4.0, 3.0]
 


### PR DESCRIPTION
## Summary

- Reuse cached CGWindow inventories for eligible snapshots.
- Reuse overview panels and release preview resources when hidden.
- Remove unnecessary desktop captures and cap preview scale.
- Add coverage for CGWindow inventory reuse decisions.

## Testing

- `swift build`
- `swift test`
- `./script/build_and_run.sh --verify`