### PR TITLE
fix: constrain cycling for fixed-width windows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,11 @@ competing event taps, socket ownership, AX writes, and visible layout glitches.
 
 - check for an existing daemon or loaded `com.quentin.defi` LaunchAgent before launch
 - when the LaunchAgent is loaded, use `defi service restart`; never also use `open -n`
+- before replacing an installed bundle, preserve its code-signing identity; set
+  `DEFI_CODESIGN_IDENTITY` in the ignored `.env.local` when needed and verify
+  the replacement has the same designated requirement, because macOS treats a
+  changed requirement as different code and prompts for Accessibility and
+  Screen Recording again
 - stop the current instance before replacing the installed app bundle
 - after build/run verification, confirm exactly one `defi-daemon` process remains
 

--- a/Sources/DefiCore/Layout.swift
+++ b/Sources/DefiCore/Layout.swift
@@ -156,6 +156,9 @@ func columnLayoutWidth(
   let minimumTiledWidth = column.windows
     .compactMap { windowsByID[$0]?.minimumTiledWidth }
     .max() ?? 0
+  let maximumTiledWidth = column.windows
+    .compactMap { windowsByID[$0]?.maximumTiledWidth }
+    .min()
   let requestedWidth: Double
   switch column.width {
   case .fraction(let fraction):
@@ -163,7 +166,7 @@ func columnLayoutWidth(
   case .pixels(let width):
     requestedWidth = width
   }
-  return max(requestedWidth, minimumTiledWidth)
+  return max(min(requestedWidth, maximumTiledWidth ?? requestedWidth), minimumTiledWidth)
 }
 
 private func applyGaps(

--- a/Sources/DefiCore/Layout.swift
+++ b/Sources/DefiCore/Layout.swift
@@ -37,6 +37,17 @@ public func computeLayout(
           width: intrinsicWidth,
           height: intrinsicHeight
         )
+      } else if let window = windowsByID[windowID] {
+        let constrainedWidth = max(
+          min(width, window.maximumTiledWidth ?? width),
+          window.minimumTiledWidth ?? 0
+        )
+        frame = Rect(
+          x: x + (width - constrainedWidth) / 2,
+          y: slot.y,
+          width: constrainedWidth,
+          height: height
+        )
       } else {
         frame = slot
       }
@@ -156,9 +167,11 @@ func columnLayoutWidth(
   let minimumTiledWidth = column.windows
     .compactMap { windowsByID[$0]?.minimumTiledWidth }
     .max() ?? 0
-  let maximumTiledWidth = column.windows
+  let maximumTiledWidths = column.windows
     .compactMap { windowsByID[$0]?.maximumTiledWidth }
-    .min()
+  let maximumTiledWidth = maximumTiledWidths.count == column.windows.count
+    ? maximumTiledWidths.max()
+    : nil
   let requestedWidth: Double
   switch column.width {
   case .fraction(let fraction):

--- a/Sources/DefiCore/Workspace.swift
+++ b/Sources/DefiCore/Workspace.swift
@@ -179,11 +179,12 @@ public func cycleWidth(
   of column: inout Column,
   direction: Direction,
   presets: [Double],
-  minimumFraction: Double? = nil
+  minimumFraction: Double? = nil,
+  maximumFraction: Double? = nil
 ) {
   guard !presets.isEmpty else { return }
   func effectiveWidth(_ preset: Double) -> Double {
-    max(preset, minimumFraction ?? 0)
+    max(min(preset, maximumFraction ?? preset), minimumFraction ?? 0)
   }
   if column.preMaximizedWidth != nil {
     let boundaryIndex: Int?

--- a/Sources/DefiDaemon/DaemonDesktop.swift
+++ b/Sources/DefiDaemon/DaemonDesktop.swift
@@ -282,7 +282,7 @@ extension Daemon {
           }
           if !state.pendingNativeFullscreenWidthResetWindowIDs.contains(windowID),
             !platform.isInitialFrameSettlementActive(for: windowID),
-            learnTiledWindowMinimumWidth(
+            learnTiledWindowWidthConstraint(
               windowID,
               actualFrame: frame,
               state: &state,

--- a/Sources/DefiDaemon/DaemonDesktopReconciliation.swift
+++ b/Sources/DefiDaemon/DaemonDesktopReconciliation.swift
@@ -243,7 +243,7 @@ extension Daemon {
       let count = persistentWidthDriftCounts[mismatch.windowID, default: 0] + 1
       persistentWidthDriftCounts[mismatch.windowID] = count
       if count >= 3,
-        learnTiledWindowMinimumWidth(
+        learnTiledWindowWidthConstraint(
           mismatch.windowID,
           actualFrame: mismatch.actual,
           state: &state,

--- a/Sources/DefiModel/Window.swift
+++ b/Sources/DefiModel/Window.swift
@@ -16,6 +16,7 @@ public struct Window: Equatable, Codable, Sendable {
   public var forceTiling: Bool
   public var intrinsicSize: Bool
   public var minimumTiledWidth: Double?
+  public var maximumTiledWidth: Double?
 
   public init(
     id: WindowID,
@@ -32,7 +33,8 @@ public struct Window: Equatable, Codable, Sendable {
     floatingOrigin: FloatingOrigin? = nil,
     forceTiling: Bool = false,
     intrinsicSize: Bool = false,
-    minimumTiledWidth: Double? = nil
+    minimumTiledWidth: Double? = nil,
+    maximumTiledWidth: Double? = nil
   ) {
     self.id = id
     self.appID = appID
@@ -49,6 +51,7 @@ public struct Window: Equatable, Codable, Sendable {
     self.forceTiling = forceTiling
     self.intrinsicSize = intrinsicSize
     self.minimumTiledWidth = minimumTiledWidth
+    self.maximumTiledWidth = maximumTiledWidth
   }
 }
 

--- a/Sources/DefiRuntime/CommandReducer.swift
+++ b/Sources/DefiRuntime/CommandReducer.swift
@@ -153,10 +153,11 @@ public func reduce(
         let maximumFraction: Double? = viewports[state.monitors[monitorIndex].id].flatMap {
           viewport in
           guard viewport.width > 0 else { return nil }
-          let maximumWidth = column.windows.compactMap {
+          let maximumWidths = column.windows.compactMap {
             state.windows[$0]?.maximumTiledWidth
-          }.min()
-          return maximumWidth.map { $0 / viewport.width }
+          }
+          guard maximumWidths.count == column.windows.count else { return nil }
+          return maximumWidths.max().map { $0 / viewport.width }
         }
         cycleWidth(
           of: &state.monitors[monitorIndex].workspaces[index].columns[columnIndex],

--- a/Sources/DefiRuntime/CommandReducer.swift
+++ b/Sources/DefiRuntime/CommandReducer.swift
@@ -140,6 +140,7 @@ public func reduce(
         for windowID in column.windows
         where state.pendingNativeFullscreenWidthResetWindowIDs.remove(windowID) != nil {
           state.windows[windowID]?.minimumTiledWidth = nil
+          state.windows[windowID]?.maximumTiledWidth = nil
         }
         let minimumFraction: Double? = viewports[state.monitors[monitorIndex].id].flatMap {
           viewport in
@@ -149,11 +150,20 @@ public func reduce(
           }.max()
           return minimumWidth.map { $0 / viewport.width }
         }
+        let maximumFraction: Double? = viewports[state.monitors[monitorIndex].id].flatMap {
+          viewport in
+          guard viewport.width > 0 else { return nil }
+          let maximumWidth = column.windows.compactMap {
+            state.windows[$0]?.maximumTiledWidth
+          }.min()
+          return maximumWidth.map { $0 / viewport.width }
+        }
         cycleWidth(
           of: &state.monitors[monitorIndex].workspaces[index].columns[columnIndex],
           direction: direction,
           presets: layout.presetColumnWidths,
-          minimumFraction: minimumFraction
+          minimumFraction: minimumFraction,
+          maximumFraction: maximumFraction
         )
         state.monitors[monitorIndex].workspaces[index].targetScrollOffset =
           focusedColumnLeftScrollOffset(

--- a/Sources/DefiRuntime/ScrollReconciliation.swift
+++ b/Sources/DefiRuntime/ScrollReconciliation.swift
@@ -168,9 +168,13 @@ private func tiledWindowWidthLearning(
       let minimumTiledWidth = workspace.columns[columnIndex].windows.compactMap {
         state.windows[$0]?.minimumTiledWidth
       }.max() ?? 0
-      let maximumTiledWidth = workspace.columns[columnIndex].windows.compactMap {
+      let maximumTiledWidths = workspace.columns[columnIndex].windows.compactMap {
         state.windows[$0]?.maximumTiledWidth
-      }.min()
+      }
+      let maximumTiledWidth =
+        maximumTiledWidths.count == workspace.columns[columnIndex].windows.count
+        ? maximumTiledWidths.max()
+        : nil
       let currentSlotWidth = max(
         min(configuredSlotWidth, maximumTiledWidth ?? configuredSlotWidth),
         minimumTiledWidth

--- a/Sources/DefiRuntime/ScrollReconciliation.swift
+++ b/Sources/DefiRuntime/ScrollReconciliation.swift
@@ -58,7 +58,9 @@ public func learnTiledWindowWidth(
   viewports: [MonitorID: Rect]
 ) -> Bool {
   let previousMinimum = state.windows[windowID]?.minimumTiledWidth
+  let previousMaximum = state.windows[windowID]?.maximumTiledWidth
   state.windows[windowID]?.minimumTiledWidth = nil
+  state.windows[windowID]?.maximumTiledWidth = nil
   guard let learned = tiledWindowWidthLearning(
     windowID,
     actualFrame: actualFrame,
@@ -66,6 +68,7 @@ public func learnTiledWindowWidth(
     viewports: viewports
   ) else {
     state.windows[windowID]?.minimumTiledWidth = previousMinimum
+    state.windows[windowID]?.maximumTiledWidth = previousMaximum
     return false
   }
   state.monitors[learned.monitorIndex].workspaces[learned.workspaceIndex]
@@ -75,7 +78,7 @@ public func learnTiledWindowWidth(
 }
 
 @discardableResult
-public func learnTiledWindowMinimumWidth(
+public func learnTiledWindowWidthConstraint(
   _ windowID: WindowID,
   actualFrame: Rect,
   state: inout RuntimeState,
@@ -86,12 +89,28 @@ public func learnTiledWindowMinimumWidth(
     actualFrame: actualFrame,
     state: state,
     viewports: viewports
-  ), learned.width > learned.requestedWidth + 0.5,
+  ) else { return false }
+  if learned.width > learned.requestedWidth + 0.5,
     learned.width > (state.windows[windowID]?.minimumTiledWidth ?? 0) + 0.5
-  else {
+  {
+    state.windows[windowID]?.minimumTiledWidth = learned.width
+    if let maximum = state.windows[windowID]?.maximumTiledWidth,
+      maximum < learned.width
+    {
+      state.windows[windowID]?.maximumTiledWidth = nil
+    }
+  } else if learned.width < learned.requestedWidth - 0.5,
+    learned.width < (state.windows[windowID]?.maximumTiledWidth ?? .infinity) - 0.5
+  {
+    state.windows[windowID]?.maximumTiledWidth = learned.width
+    if let minimum = state.windows[windowID]?.minimumTiledWidth,
+      minimum > learned.width
+    {
+      state.windows[windowID]?.minimumTiledWidth = nil
+    }
+  } else {
     return false
   }
-  state.windows[windowID]?.minimumTiledWidth = learned.width
   synchronizeScrollOffsets(state: &state, viewports: viewports)
   return true
 }
@@ -146,11 +165,15 @@ private func tiledWindowWidthLearning(
       case .pixels(let width):
         configuredSlotWidth = width
       }
+      let minimumTiledWidth = workspace.columns[columnIndex].windows.compactMap {
+        state.windows[$0]?.minimumTiledWidth
+      }.max() ?? 0
+      let maximumTiledWidth = workspace.columns[columnIndex].windows.compactMap {
+        state.windows[$0]?.maximumTiledWidth
+      }.min()
       let currentSlotWidth = max(
-        configuredSlotWidth,
-        workspace.columns[columnIndex].windows.compactMap {
-          state.windows[$0]?.minimumTiledWidth
-        }.max() ?? 0
+        min(configuredSlotWidth, maximumTiledWidth ?? configuredSlotWidth),
+        minimumTiledWidth
       )
       let learnedWidth = max(currentSlotWidth + actualFrame.width - target.width, 80)
       guard abs(learnedWidth - currentSlotWidth) >= 1 else { return nil }

--- a/Sources/DefiRuntime/WindowReconciliation.swift
+++ b/Sources/DefiRuntime/WindowReconciliation.swift
@@ -241,6 +241,9 @@ public func reconcileWindows(
         updated.minimumTiledWidth = nativeFullscreenWindowIDs.contains(window.id)
           ? nil
           : existing.minimumTiledWidth
+        updated.maximumTiledWidth = nativeFullscreenWindowIDs.contains(window.id)
+          ? nil
+          : existing.maximumTiledWidth
         if existing.intrinsicSize,
           !externallyChangedWindowIDs.contains(window.id)
         {
@@ -290,6 +293,7 @@ private func applyWindowIDReplacements(
     replacement.forceTiling = previous.forceTiling
     replacement.intrinsicSize = previous.intrinsicSize
     replacement.minimumTiledWidth = previous.minimumTiledWidth
+    replacement.maximumTiledWidth = previous.maximumTiledWidth
     if previous.intrinsicSize {
       replacement.frame.width = previous.frame.width
       replacement.frame.height = previous.frame.height

--- a/Tests/DefiRuntimeTests/RuntimeWidthLearningTests.swift
+++ b/Tests/DefiRuntimeTests/RuntimeWidthLearningTests.swift
@@ -185,6 +185,69 @@ struct RuntimeWidthConstraintTests {
     )
     #expect(state.monitors[0].workspaces[0].columns[0].width == .fraction(0.5))
   }
+
+  @Test
+  func stackedWindowsKeepIndependentWidthConstraints() throws {
+    let monitorID = MonitorID(rawValue: 1)
+    let fixedID = WindowID(rawValue: 1)
+    let wideID = WindowID(rawValue: 2)
+    let followingID = WindowID(rawValue: 3)
+    var state = RuntimeState(config: Config())
+    state.attachMonitor(monitorID)
+    state.layout = LayoutSettings(
+      innerHorizontalGap: 0,
+      innerVerticalGap: 0,
+      outerTopGap: 0,
+      outerRightGap: 0,
+      outerBottomGap: 0,
+      outerLeftGap: 0
+    )
+    state.windows = [
+      fixedID: Window(
+        id: fixedID,
+        appID: "fixed",
+        title: "Fixed",
+        frame: Rect(x: 0, y: 0, width: 500, height: 350),
+        maximumTiledWidth: 500
+      ),
+      wideID: Window(
+        id: wideID,
+        appID: "wide",
+        title: "Wide",
+        frame: Rect(x: 0, y: 350, width: 600, height: 350),
+        minimumTiledWidth: 600
+      ),
+      followingID: Window(
+        id: followingID,
+        appID: "following",
+        title: "Following",
+        frame: Rect(x: 800, y: 0, width: 500, height: 700)
+      ),
+    ]
+    state.monitors[0].workspaces[0].columns = [
+      Column(windows: [fixedID, wideID], focusedWindow: 0, width: .fraction(0.8)),
+      Column(window: followingID, width: .fraction(0.5)),
+    ]
+    let viewport = Rect(x: 0, y: 0, width: 1_000, height: 700)
+
+    try reduce(
+      .cycleWidth(.previous),
+      on: monitorID,
+      state: &state,
+      viewports: [monitorID: viewport]
+    )
+
+    #expect(state.monitors[0].workspaces[0].columns[0].width == .fraction(0.66))
+    let frames = computeLayout(
+      workspace: state.monitors[0].workspaces[0],
+      viewport: viewport,
+      windows: Array(state.windows.values),
+      settings: state.layout
+    ).frames
+    #expect(frames.first { $0.windowID == fixedID }?.frame.width == 500)
+    #expect(frames.first { $0.windowID == wideID }?.frame.width == 660)
+    #expect(frames.first { $0.windowID == followingID }?.frame.x == 660)
+  }
 }
 
 struct RuntimeWidthLearningTests {

--- a/Tests/DefiRuntimeTests/RuntimeWidthLearningTests.swift
+++ b/Tests/DefiRuntimeTests/RuntimeWidthLearningTests.swift
@@ -4,7 +4,7 @@ import DefiModel
 import DefiRuntime
 import Testing
 
-struct RuntimeMinimumWidthTests {
+struct RuntimeWidthConstraintTests {
   @Test
   func cycleSkipsPresetWithTheSameEffectiveMinimumWidth() throws {
     let monitorID = MonitorID(rawValue: 1)
@@ -72,7 +72,7 @@ struct RuntimeMinimumWidthTests {
     ]
 
     #expect(
-      learnTiledWindowMinimumWidth(
+      learnTiledWindowWidthConstraint(
         constrainedID,
         actualFrame: Rect(x: 0, y: 0, width: 560, height: 700),
         state: &state,
@@ -100,6 +100,90 @@ struct RuntimeMinimumWidthTests {
     )
     #expect(constrained.frame.width == 560)
     #expect(following.frame.x == 560)
+  }
+
+  @Test
+  func acceptedMaximumWidthReflowsAndSkipsEquivalentPresets() throws {
+    let monitorID = MonitorID(rawValue: 1)
+    let constrainedID = WindowID(rawValue: 1)
+    let followingID = WindowID(rawValue: 2)
+    var state = RuntimeState(config: Config())
+    state.attachMonitor(monitorID)
+    state.layout = LayoutSettings(
+      innerHorizontalGap: 0,
+      innerVerticalGap: 0,
+      outerTopGap: 0,
+      outerRightGap: 0,
+      outerBottomGap: 0,
+      outerLeftGap: 0
+    )
+    state.windows = [
+      constrainedID: Window(
+        id: constrainedID,
+        appID: "settings",
+        title: "Settings",
+        frame: Rect(x: 0, y: 0, width: 800, height: 700)
+      ),
+      followingID: Window(
+        id: followingID,
+        appID: "editor",
+        title: "Editor",
+        frame: Rect(x: 800, y: 0, width: 500, height: 700)
+      ),
+    ]
+    state.monitors[0].workspaces[0].columns = [
+      Column(window: constrainedID, width: .fraction(0.8)),
+      Column(window: followingID, width: .fraction(0.5)),
+    ]
+    let viewport = Rect(x: 0, y: 0, width: 1_000, height: 700)
+
+    #expect(
+      learnTiledWindowWidthConstraint(
+        constrainedID,
+        actualFrame: Rect(x: 0, y: 0, width: 560, height: 700),
+        state: &state,
+        viewports: [monitorID: viewport]
+      )
+    )
+
+    let layout = computeLayout(
+      workspace: state.monitors[0].workspaces[0],
+      viewport: viewport,
+      windows: Array(state.windows.values),
+      settings: state.layout
+    )
+    let constrained = try #require(
+      layout.frames.first { $0.windowID == constrainedID }
+    )
+    let following = try #require(
+      layout.frames.first { $0.windowID == followingID }
+    )
+    #expect(constrained.frame.width == 560)
+    #expect(following.frame.x == 560)
+
+    try reduce(
+      .cycleWidth(.previous),
+      on: monitorID,
+      state: &state,
+      viewports: [monitorID: viewport]
+    )
+    #expect(state.monitors[0].workspaces[0].columns[0].width == .fraction(0.5))
+
+    #expect(
+      learnTiledWindowWidthConstraint(
+        constrainedID,
+        actualFrame: Rect(x: 0, y: 0, width: 560, height: 700),
+        state: &state,
+        viewports: [monitorID: viewport]
+      )
+    )
+    try reduce(
+      .cycleWidth(.next),
+      on: monitorID,
+      state: &state,
+      viewports: [monitorID: viewport]
+    )
+    #expect(state.monitors[0].workspaces[0].columns[0].width == .fraction(0.5))
   }
 }
 


### PR DESCRIPTION
## Summary

- Learn maximum tiled widths for windows that cannot expand beyond their native size.
- Clamp column layout and width cycling to learned minimum and maximum constraints.
- Preserve width constraints across reconciliation and add regression coverage.

## Testing

- Not run: `swift build`
- Not run: `swift test`
- Not run: `./script/build_and_run.sh --verify`