### PR TITLE
fix: keep floating windows above tiled windows

### DIFF
--- a/Sources/DefiMacOS/AXFocusModels.swift
+++ b/Sources/DefiMacOS/AXFocusModels.swift
@@ -107,6 +107,46 @@ struct NativeFocusCompletion: Equatable, Sendable {
   let recoveryRequest: NativeFocusRecoveryRequest?
 }
 
+struct ForegroundRaiseOutcome: Equatable {
+  let succeeded: Bool
+  let retried: Bool
+  let cancelled: Bool
+}
+
+func performForegroundRaise(
+  isCurrent: () -> Bool,
+  attempt: (Float) -> AXError
+) -> ForegroundRaiseOutcome {
+  guard isCurrent() else {
+    return ForegroundRaiseOutcome(
+      succeeded: false,
+      retried: false,
+      cancelled: true
+    )
+  }
+  let initialResult = attempt(0.016)
+  guard isCurrent() else {
+    return ForegroundRaiseOutcome(
+      succeeded: false,
+      retried: false,
+      cancelled: true
+    )
+  }
+  guard initialResult != .success else {
+    return ForegroundRaiseOutcome(
+      succeeded: true,
+      retried: false,
+      cancelled: false
+    )
+  }
+  let retryResult = attempt(0.05)
+  return ForegroundRaiseOutcome(
+    succeeded: retryResult == .success,
+    retried: true,
+    cancelled: !isCurrent()
+  )
+}
+
 struct NativeFocusRecoveryTransfer: Equatable, Sendable {
   let carried: NativeFocusRecoveryRequest?
   let recovery: NativeFocusRecoveryRequest?

--- a/Sources/DefiMacOS/AXFocusModels.swift
+++ b/Sources/DefiMacOS/AXFocusModels.swift
@@ -18,6 +18,7 @@ struct AsyncFocusRequest: @unchecked Sendable {
   let selectsSpecificWindow: Bool
   let validatesSpecificWindowFocus: Bool
   let activatesApplication: Bool
+  let foregroundWindowElements: [AXUIElement]
   let inputGuard: FocusInputGuard?
   let recoveryRequest: NativeFocusRecoveryRequest?
 }

--- a/Sources/DefiMacOS/AXFocusWriterExecution.swift
+++ b/Sources/DefiMacOS/AXFocusWriterExecution.swift
@@ -180,17 +180,29 @@ extension AXFocusWriter {
             cancelled = true
             break
           }
-          AXMessagingTimeoutAccess.shared.withTimeout(
-            0.016,
-            elements: [element]
-          ) {
-            let raiseStartedAt = ProcessInfo.processInfo.systemUptime
-            _ = AXUIElementPerformAction(
-              element,
-              kAXRaiseAction as CFString
-            )
-            raiseDurationMS +=
-              (ProcessInfo.processInfo.systemUptime - raiseStartedAt) * 1_000
+          let raiseStartedAt = ProcessInfo.processInfo.systemUptime
+          let outcome = performForegroundRaise(
+            isCurrent: {
+              isCurrent(queued) && inputGuardIsCurrent(request)
+            },
+            attempt: { timeout in
+              AXMessagingTimeoutAccess.shared.withTimeout(
+                timeout,
+                elements: [element]
+              ) {
+                AXUIElementPerformAction(
+                  element,
+                  kAXRaiseAction as CFString
+                )
+              }
+            }
+          )
+          raiseDurationMS +=
+            (ProcessInfo.processInfo.systemUptime - raiseStartedAt) * 1_000
+          retried = retried || outcome.retried
+          if outcome.cancelled {
+            cancelled = true
+            break
           }
         }
       }

--- a/Sources/DefiMacOS/AXFocusWriterExecution.swift
+++ b/Sources/DefiMacOS/AXFocusWriterExecution.swift
@@ -169,6 +169,31 @@ extension AXFocusWriter {
       } else if activationRequired == nil {
         cancelled = true
       }
+      if !cancelled,
+        windowSelectionSucceeded,
+        activationSucceeded,
+        isCurrent(queued),
+        inputGuardIsCurrent(request)
+      {
+        for element in request.foregroundWindowElements {
+          guard isCurrent(queued), inputGuardIsCurrent(request) else {
+            cancelled = true
+            break
+          }
+          AXMessagingTimeoutAccess.shared.withTimeout(
+            0.016,
+            elements: [element]
+          ) {
+            let raiseStartedAt = ProcessInfo.processInfo.systemUptime
+            _ = AXUIElementPerformAction(
+              element,
+              kAXRaiseAction as CFString
+            )
+            raiseDurationMS +=
+              (ProcessInfo.processInfo.systemUptime - raiseStartedAt) * 1_000
+          }
+        }
+      }
       if activationAttempted, !isCurrent(queued) {
         markRecoveryActivationNeeded()
         cancelled = true

--- a/Sources/DefiMacOS/MacOSPlatform+Focus.swift
+++ b/Sources/DefiMacOS/MacOSPlatform+Focus.swift
@@ -206,6 +206,9 @@ extension MacOSPlatform {
         selectsSpecificWindow: selectsSpecificWindow,
         validatesSpecificWindowFocus: !selectsSpecificWindow,
         activatesApplication: activatesApplication,
+        foregroundWindowElements: foregroundFloatingWindowElements(
+          above: windowID
+        ),
         inputGuard: maximumUserInputTimestamp.map {
           FocusInputGuard(
             tracker: userInputTracker,
@@ -407,6 +410,7 @@ extension MacOSPlatform {
         activatesApplication:
           NSWorkspace.shared.frontmostApplication?.processIdentifier
           != processID,
+        foregroundWindowElements: [],
         inputGuard: FocusInputGuard(
           tracker: userInputTracker,
           maximumTimestamp: timestamp
@@ -437,6 +441,33 @@ extension MacOSPlatform {
     submittedFocusRecoveryRequestID = requestID
     submittedFocusRecoveryTimestamp = timestamp
     submittedFocusRecoveryGeneration = recoveryGeneration
+  }
+
+  private func foregroundFloatingWindowElements(
+    above targetWindowID: WindowID
+  ) -> [AXUIElement] {
+    guard !floatingWindowIDs.contains(targetWindowID),
+      let targetFrame = lastSnapshotWindows.first(where: {
+        $0.id == targetWindowID
+      })?.frame,
+      let targetMonitor = lastMonitorFrames.first(where: {
+        targetIntersects(targetFrame, monitor: $0)
+      })
+    else { return [] }
+
+    var remaining = floatingWindowIDs.subtracting(lastHiddenWindowIDs).filter {
+      windowID in
+      lastSnapshotWindows.first(where: { $0.id == windowID }).map {
+        targetIntersects($0.frame, monitor: targetMonitor)
+      } == true
+    }
+    var ordered = (snapshotEngine.lastCGWindowInventory ?? []).reversed()
+      .compactMap { record -> WindowID? in
+        let windowID = WindowID(rawValue: UInt64(record.id))
+        return remaining.remove(windowID) == nil ? nil : windowID
+      }
+    ordered.append(contentsOf: remaining.sorted { $0.rawValue < $1.rawValue })
+    return ordered.compactMap { elements[$0] }
   }
 
   private func submitFocusRecoveryFallback(

--- a/Tests/DefiMacOSTests/DesktopE2ETests.swift
+++ b/Tests/DefiMacOSTests/DesktopE2ETests.swift
@@ -1,3 +1,4 @@
+import ApplicationServices
 import CoreGraphics
 import DefiConfig
 import DefiCore
@@ -77,6 +78,108 @@ final class DesktopE2ETests: XCTestCase {
     pumpRunLoop(for: 0.5)
 
     XCTAssertEqual(platform.snapshot(config: Config()).focusedWindowID, window.id)
+  }
+
+  func testTiledFocusKeepsFloatingWindowAboveIt() throws {
+    let platform = try makePlatform()
+    let snapshot = platform.snapshot(config: Config())
+    let onscreenWindowIDs = Set(
+      copyCGWindows(options: [.optionOnScreenOnly, .excludeDesktopElements])
+        .map { WindowID(rawValue: UInt64($0.id)) }
+    )
+    guard let floating = snapshot.windows.first(where: {
+      $0.floating && onscreenWindowIDs.contains($0.id)
+    }),
+      let monitor = snapshot.monitors.first(where: {
+        $0.frame.x < floating.frame.x + floating.frame.width
+          && floating.frame.x < $0.frame.x + $0.frame.width
+          && $0.frame.y < floating.frame.y + floating.frame.height
+          && floating.frame.y < $0.frame.y + $0.frame.height
+      }),
+      let tiled = snapshot.windows.first(where: {
+        !$0.floating
+          && $0.processID != floating.processID
+          && onscreenWindowIDs.contains($0.id)
+          && monitor.frame.x < $0.frame.x + $0.frame.width
+          && $0.frame.x < monitor.frame.x + monitor.frame.width
+          && monitor.frame.y < $0.frame.y + $0.frame.height
+          && $0.frame.y < monitor.frame.y + monitor.frame.height
+      })
+    else {
+      throw XCTSkip("On-screen floating and tiled windows from different apps required")
+    }
+    let originalFocusedWindowID = snapshot.focusedWindowID
+    defer {
+      if let originalFocusedWindowID {
+        platform.focus(originalFocusedWindowID)
+        pumpRunLoop(for: 0.3)
+      }
+    }
+
+    var focusResult: NativeFocusResult?
+    platform.focus(floating.id, completion: { focusResult = $0 })
+    XCTAssertTrue(
+      pumpRunLoop(
+        until: { focusResult != nil },
+        timeout: 1
+      )
+    )
+    XCTAssertTrue(focusResult == .completed || focusResult == .completedWithoutMutation)
+    guard let tiledElement = platform.elements[tiled.id],
+      let processID = tiled.processID,
+      let tiledApplication = platform.applications[processID]
+    else {
+      XCTFail("Tiled test window lost its Accessibility elements")
+      return
+    }
+    focusResult = nil
+    platform.focus(tiled.id, completion: { focusResult = $0 })
+    XCTAssertTrue(
+      pumpRunLoop(
+        until: { focusResult != nil },
+        timeout: 1
+      )
+    )
+    XCTAssertEqual(
+      AXUIElementPerformAction(
+        tiledElement,
+        kAXRaiseAction as CFString
+      ),
+      .success
+    )
+    pumpRunLoop(for: 0.1)
+    _ = platform.snapshot(config: Config())
+
+    focusResult = nil
+    platform.focus(tiled.id, completion: { focusResult = $0 })
+    XCTAssertTrue(
+      pumpRunLoop(
+        until: { focusResult != nil },
+        timeout: 1
+      )
+    )
+    XCTAssertTrue(focusResult == .completed || focusResult == .completedWithoutMutation)
+
+    let windowOrder = copyCGWindows(
+      options: [.optionOnScreenOnly, .excludeDesktopElements]
+    ).map { WindowID(rawValue: UInt64($0.id)) }
+    guard let floatingIndex = windowOrder.firstIndex(of: floating.id),
+      let tiledIndex = windowOrder.firstIndex(of: tiled.id)
+    else {
+      XCTFail("Focused test windows disappeared from WindowServer order")
+      return
+    }
+    XCTAssertLessThan(floatingIndex, tiledIndex)
+    var focusedWindow: CFTypeRef?
+    XCTAssertEqual(
+      AXUIElementCopyAttributeValue(
+        tiledApplication,
+        kAXFocusedWindowAttribute as CFString,
+        &focusedWindow
+      ),
+      .success
+    )
+    XCTAssertTrue(focusedWindow.map { CFEqual($0, tiledElement) } == true)
   }
 
   func testAppliedTargetConvergesWithRealWindowFrame() throws {

--- a/Tests/DefiMacOSTests/PlatformEventTests.swift
+++ b/Tests/DefiMacOSTests/PlatformEventTests.swift
@@ -429,6 +429,36 @@ struct PlatformEventTests {
   }
 
   @Test
+  func foregroundRaiseRetriesOnceAndStopsWhenStale() {
+    var current = true
+    var timeouts: [Float] = []
+    let recovered = performForegroundRaise(
+      isCurrent: { current },
+      attempt: { timeout in
+        timeouts.append(timeout)
+        return timeouts.count == 1 ? .cannotComplete : .success
+      }
+    )
+    #expect(recovered.succeeded)
+    #expect(recovered.retried)
+    #expect(recovered.cancelled == false)
+    #expect(timeouts == [0.016, 0.05])
+
+    timeouts = []
+    let stale = performForegroundRaise(
+      isCurrent: { current },
+      attempt: { timeout in
+        timeouts.append(timeout)
+        current = false
+        return .cannotComplete
+      }
+    )
+    #expect(stale.cancelled)
+    #expect(stale.retried == false)
+    #expect(timeouts == [0.016])
+  }
+
+  @Test
   func focusedExplicitTargetSkipsNoOpNativeWrite() {
     #expect(
       specificWindowFocusWriteIsRequired(


### PR DESCRIPTION
## Summary

- Raise same-monitor floating windows after focusing a tiled window.
- Preserve latest-wins focus cancellation and Accessibility timeouts.
- Add a desktop E2E check for floating-window z-order and tiled focus.

## Testing

- Not run