### PR TITLE
feat(overview): show desktop backgrounds

### DIFF
--- a/Sources/DefiCore/Overview.swift
+++ b/Sources/DefiCore/Overview.swift
@@ -132,6 +132,11 @@ public func interpolateOverviewProjection(
           to: targetWorkspace.frame,
           progress: progress
         ),
+        visibleFrame: interpolateOverviewRect(
+          from: sourceWorkspace.visibleFrame,
+          to: targetWorkspace.visibleFrame,
+          progress: progress
+        ),
         windows: windows,
         hiddenTiledWindowCountBefore: targetWorkspace.hiddenTiledWindowCountBefore,
         hiddenTiledWindowCountAfter: targetWorkspace.hiddenTiledWindowCountAfter
@@ -205,6 +210,7 @@ public struct OverviewWorkspaceProjection: Equatable, Sendable {
   public let workspaceID: WorkspaceID
   public let label: String
   public let frame: Rect
+  public let visibleFrame: Rect
   public let windows: [OverviewWindowProjection]
   public let hiddenTiledWindowCountBefore: Int
   public let hiddenTiledWindowCountAfter: Int
@@ -213,6 +219,7 @@ public struct OverviewWorkspaceProjection: Equatable, Sendable {
     workspaceID: WorkspaceID,
     label: String? = nil,
     frame: Rect,
+    visibleFrame: Rect? = nil,
     windows: [OverviewWindowProjection],
     hiddenTiledWindowCountBefore: Int = 0,
     hiddenTiledWindowCountAfter: Int = 0
@@ -220,6 +227,7 @@ public struct OverviewWorkspaceProjection: Equatable, Sendable {
     self.workspaceID = workspaceID
     self.label = label ?? workspaceID.rawValue
     self.frame = frame
+    self.visibleFrame = visibleFrame ?? frame
     self.windows = windows
     self.hiddenTiledWindowCountBefore = hiddenTiledWindowCountBefore
     self.hiddenTiledWindowCountAfter = hiddenTiledWindowCountAfter
@@ -342,9 +350,16 @@ public func projectOverview(
         settings: layout
       ).frames.map { ($0.windowID, $0.frame) }
     )
-    let tiledTarget = Rect(
-      x: workspaceFrame.x + workspaceGap,
+    let visibleFrame = Rect(
+      x: workspaceFrame.x
+        + (workspaceFrame.width - monitorFrame.width * contentScale) / 2,
       y: workspaceFrame.y,
+      width: monitorFrame.width * contentScale,
+      height: workspaceFrame.height
+    )
+    let tiledTarget = Rect(
+      x: visibleFrame.x,
+      y: visibleFrame.y,
       width: workspaceFrame.width,
       height: workspaceFrame.height
     )
@@ -392,14 +407,10 @@ public func projectOverview(
         width: frame.width,
         height: frame.height
       )
-      let projectedWidth = localFrame.width * contentScale
-      let sourceRange = max(sourceViewport.width - localFrame.width, 1)
-      let targetRange = max(workspaceFrame.width - projectedWidth, 0)
       let projectedFrame = Rect(
-        x: workspaceFrame.x
-          + min(max(localFrame.x / sourceRange, 0), 1) * targetRange,
-        y: workspaceFrame.y + localFrame.y * contentScale,
-        width: projectedWidth,
+        x: visibleFrame.x + localFrame.x * contentScale,
+        y: visibleFrame.y + localFrame.y * contentScale,
+        width: localFrame.width * contentScale,
         height: localFrame.height * contentScale
       )
       guard projectedFrame.intersects(workspaceFrame) else { continue }
@@ -421,6 +432,7 @@ public func projectOverview(
         label: originalWorkspace.name
           ?? (originalWorkspace.kind == .trailing ? "+" : String(workspaceIndex + 1)),
         frame: workspaceFrame,
+        visibleFrame: visibleFrame,
         windows: projectedWindows,
         hiddenTiledWindowCountBefore: hiddenTiledWindowCountBefore,
         hiddenTiledWindowCountAfter: hiddenTiledWindowCountAfter
@@ -461,8 +473,8 @@ public func overviewDropTarget(
     let scale = workspaceProjection.frame.height / monitorFrame.height
     let width = max(sourceFrame.width * scale, 1)
     let height = max(sourceFrame.height * scale, 1)
-    let horizontalRange = max(workspaceProjection.frame.width - width, 1)
-    let verticalRange = max(workspaceProjection.frame.height - height, 1)
+    let horizontalRange = max(workspaceProjection.visibleFrame.width - width, 1)
+    let verticalRange = max(workspaceProjection.visibleFrame.height - height, 1)
     let relativeWidth = min(sourceFrame.width / monitorFrame.width, 1)
     let relativeHeight = min(sourceFrame.height / monitorFrame.height, 1)
     return .floating(
@@ -470,11 +482,11 @@ public func overviewDropTarget(
       workspaceID: workspace.id,
       relativeFrame: Rect(
         x: min(max(
-          (point.x - workspaceProjection.frame.x - width / 2) / horizontalRange,
+          (point.x - workspaceProjection.visibleFrame.x - width / 2) / horizontalRange,
           0
         ), 1) * (1 - relativeWidth),
         y: min(max(
-          (point.y - workspaceProjection.frame.y - height / 2) / verticalRange,
+          (point.y - workspaceProjection.visibleFrame.y - height / 2) / verticalRange,
           0
         ), 1) * (1 - relativeHeight),
         width: relativeWidth,

--- a/Sources/DefiDaemon/DaemonDesktop.swift
+++ b/Sources/DefiDaemon/DaemonDesktop.swift
@@ -38,6 +38,10 @@ func layoutWindowIDsOutsideSubmissionScope(
     : []
 }
 
+func acceptedFrameChangedWidth(_ accepted: Rect, from previous: Rect?) -> Bool {
+  previous.map { abs($0.width - accepted.width) >= 1 } ?? false
+}
+
 @MainActor
 extension Daemon {
   func applyCurrentLayout(
@@ -277,10 +281,12 @@ extension Daemon {
         for (windowID, frame) in acceptedFrames.sorted(by: {
           $0.key.rawValue < $1.key.rawValue
         }) {
+          let previousFrame = state.windows[windowID]?.frame
           if let monitorID = state.monitorID(containing: windowID) {
             affectedMonitorIDs.insert(monitorID)
           }
-          if !state.pendingNativeFullscreenWidthResetWindowIDs.contains(windowID),
+          if acceptedFrameChangedWidth(frame, from: previousFrame),
+            !state.pendingNativeFullscreenWidthResetWindowIDs.contains(windowID),
             !platform.isInitialFrameSettlementActive(for: windowID),
             learnTiledWindowWidthConstraint(
               windowID,

--- a/Sources/DefiDaemon/DaemonDesktop.swift
+++ b/Sources/DefiDaemon/DaemonDesktop.swift
@@ -38,10 +38,6 @@ func layoutWindowIDsOutsideSubmissionScope(
     : []
 }
 
-func acceptedFrameChangedWidth(_ accepted: Rect, from previous: Rect?) -> Bool {
-  previous.map { abs($0.width - accepted.width) >= 1 } ?? false
-}
-
 @MainActor
 extension Daemon {
   func applyCurrentLayout(
@@ -276,37 +272,9 @@ extension Daemon {
       focusRequestIDAfterCommit: focusRequestIDAfterCommit,
       acceptedFrameHandler: { [weak self] acceptedFrames in
         guard let self else { return }
-        var learnedMinimum = false
-        var affectedMonitorIDs = Set<MonitorID>()
-        for (windowID, frame) in acceptedFrames.sorted(by: {
-          $0.key.rawValue < $1.key.rawValue
-        }) {
-          let previousFrame = state.windows[windowID]?.frame
-          if let monitorID = state.monitorID(containing: windowID) {
-            affectedMonitorIDs.insert(monitorID)
-          }
-          if acceptedFrameChangedWidth(frame, from: previousFrame),
-            !state.pendingNativeFullscreenWidthResetWindowIDs.contains(windowID),
-            !platform.isInitialFrameSettlementActive(for: windowID),
-            learnTiledWindowWidthConstraint(
-              windowID,
-              actualFrame: frame,
-              state: &state,
-              viewports: viewportsByMonitor
-            )
-          {
-            learnedMinimum = true
-          }
+        for (windowID, frame) in acceptedFrames {
           state.updateWindowFrame(frame, for: windowID)
         }
-        guard learnedMinimum else { return }
-        applyCurrentLayout(
-          monitorIDs: affectedMonitorIDs,
-          asynchronousPositions: true,
-          updateVisibility: false,
-          positionTimeoutSeconds: 0.05,
-          source: "accepted-size-reflow"
-        )
       },
       commandPerformance: commandPerformance,
       source: source

--- a/Sources/DefiDaemon/DaemonDesktopReconciliation.swift
+++ b/Sources/DefiDaemon/DaemonDesktopReconciliation.swift
@@ -228,31 +228,22 @@ extension Daemon {
   }
 
   func learnPersistentWidthConstraints(_ mismatches: [FrameMismatch]) {
-    let mismatchedIDs = Set(mismatches.map(\.windowID))
-    persistentWidthDriftCounts = persistentWidthDriftCounts.filter {
-      mismatchedIDs.contains($0.key)
-    }
     for mismatch in mismatches {
       guard abs(mismatch.actual.width - mismatch.target.width) >= 2,
         state.windows[mismatch.windowID]?.intrinsicSize != true,
+        state.windows[mismatch.windowID]?.minimumTiledWidth == nil,
+        state.windows[mismatch.windowID]?.maximumTiledWidth == nil,
         !state.pendingNativeFullscreenWidthResetWindowIDs.contains(mismatch.windowID),
         !platform.isInitialFrameSettlementActive(for: mismatch.windowID)
       else {
         continue
       }
-      let count = persistentWidthDriftCounts[mismatch.windowID, default: 0] + 1
-      persistentWidthDriftCounts[mismatch.windowID] = count
-      if count >= 3,
-        learnTiledWindowWidthConstraint(
-          mismatch.windowID,
-          actualFrame: mismatch.actual,
-          state: &state,
-          viewports: viewportsByMonitor
-        )
-      {
-        persistentWidthDriftCounts[mismatch.windowID] = 0
-      }
+      _ = learnTiledWindowWidthConstraint(
+        mismatch.windowID,
+        actualFrame: mismatch.actual,
+        state: &state,
+        viewports: viewportsByMonitor
+      )
     }
   }
-
 }

--- a/Sources/DefiDaemon/DaemonDesktopSynchronization.swift
+++ b/Sources/DefiDaemon/DaemonDesktopSynchronization.swift
@@ -203,7 +203,6 @@ extension Daemon {
       submittedWorkspaceFocusGeneration = nil
       pendingWindowRemovalFocusGuard = nil
       consumeDeferredMouseFocusIntent()
-      persistentWidthDriftCounts.removeAll(keepingCapacity: true)
       finishMouseGestureTracking()
     }
     latestMonitors = snapshot.monitors

--- a/Sources/DefiDaemon/DaemonOverview.swift
+++ b/Sources/DefiDaemon/DaemonOverview.swift
@@ -86,6 +86,20 @@ extension Daemon {
             source: isOpen ? "overview-park" : "overview-restore"
           )
         }
+      },
+      commitScrollOffsets: { [weak self] offsets in
+        guard let self else { return }
+        let changedMonitorIDs = applyOverviewScrollOffsets(offsets, state: &state)
+        guard !changedMonitorIDs.isEmpty else { return }
+        persistPlacements()
+        guard overviewController?.usesWorkspaceParking != true else { return }
+        applyCurrentLayout(
+          monitorIDs: changedMonitorIDs,
+          asynchronousPositions: true,
+          updateVisibility: false,
+          positionTimeoutSeconds: 0.05,
+          source: "overview-scroll-commit"
+        )
       }
     )
   }

--- a/Sources/DefiDaemon/DaemonStatusLifecycle.swift
+++ b/Sources/DefiDaemon/DaemonStatusLifecycle.swift
@@ -177,6 +177,7 @@ extension Daemon {
       + " windowMetadata=\(attributeReads.metadata)/\(attributeReads.metadataReuses)"
       + " windowIDs=private:\(platform.successfulPrivateWindowIDLookupCount)/fallback:\(platform.publicWindowIDLookupFallbackCount)/available:\(platform.privateWindowIDLookupStatus)"
       + " windowBounds=private:\(platform.successfulPrivateWindowBoundsLookupCount)/fallback:\(platform.privateWindowBoundsLookupFallbackCount)/available:\(platform.isPrivateWindowBoundsLookupAvailable)"
+      + " windowConstraints=private:\(platform.successfulPrivateWindowConstraintLookupCount)/fallback:\(platform.privateWindowConstraintLookupFallbackCount)/available:\(platform.isPrivateWindowConstraintLookupAvailable)"
       + " snapshotP50/P95=\(snapshotP50MS)/\(snapshotP95MS)"
       + " snapshotComponents=\(applicationInventoryP50MS)/\(applicationInventoryP95MS):\(applicationWindowListP50MS)/\(applicationWindowListP95MS)"
       + " focusFollowsMouse=\(config.input.focusFollowsMouse) mouseFollowsFocus=\(config.input.mouseFollowsFocus) pointerTransitions=\(pointerTransitionCount) pointerFocus=\(pointerFocusAppliedCount)/\(pointerFocusObservedCount) pointerIgnored=\(pointerFocusIgnoredCount) cursorWarps=\(cursorWarps.applied)/\(cursorWarps.skipped)/\(cursorWarps.failed)"

--- a/Sources/DefiDaemon/DefiDaemon.swift
+++ b/Sources/DefiDaemon/DefiDaemon.swift
@@ -232,7 +232,6 @@ final class Daemon: NSObject {
   var mouseGestureSettlement: MouseGestureSettlement?
   var mouseGesturePreempted = false
   var mouseReorderAnimationActive = false
-  var persistentWidthDriftCounts: [WindowID: Int] = [:]
   var floatingWindowFrames: [WindowID: Rect] = [:]
   var scrollAnimations: [ScrollAnimationKey: ScrollAnimation] = [:]
   var animationFrameCount = 0

--- a/Sources/DefiMacOS/MacOSPlatform+Snapshot.swift
+++ b/Sources/DefiMacOS/MacOSPlatform+Snapshot.swift
@@ -416,6 +416,7 @@ extension SnapshotEngine {
     applicationWindowCounts = applicationWindows.mapValues(\.count)
     lastSnapshotWindows = windows
     lastSnapshotWindowIDs = Set(windows.lazy.map(\.id))
+    onMain { $0.borderBoundsProvider.retainConstraints(for: nextWindowIDs) }
     lastSnapshotProcessIDs = Set(windows.lazy.compactMap(\.processID))
     lastApplicationWindowElements = applicationWindows
     minimizedWindowElementsByProcess =

--- a/Sources/DefiMacOS/MacOSPlatform.swift
+++ b/Sources/DefiMacOS/MacOSPlatform.swift
@@ -551,6 +551,18 @@ public final class MacOSPlatform {
     borderBoundsProvider.failureCount
   }
 
+  public var isPrivateWindowConstraintLookupAvailable: Bool {
+    borderBoundsProvider.constraintsAreAvailable
+  }
+
+  public var successfulPrivateWindowConstraintLookupCount: Int {
+    borderBoundsProvider.successfulConstraintLookupCount
+  }
+
+  public var privateWindowConstraintLookupFallbackCount: Int {
+    borderBoundsProvider.constraintFallbackCount
+  }
+
   var cursorWarpAppliedCount = 0
   var cursorWarpSkippedCount = 0
   var cursorWarpFailedCount = 0

--- a/Sources/DefiMacOS/OverviewController.swift
+++ b/Sources/DefiMacOS/OverviewController.swift
@@ -4,6 +4,8 @@ import DefiCore
 import DefiModel
 import QuartzCore
 
+private let overviewTransitionDuration: TimeInterval = 0.16
+
 private struct OverviewViewportAnimation {
   let from: OverviewViewport
   let to: OverviewViewport
@@ -124,12 +126,16 @@ public final class OverviewController: NSObject {
   ) -> Void
   public typealias MonitorHandler = @MainActor @Sendable (MonitorID) -> Void
   public typealias OpenStateHandler = @MainActor @Sendable (Bool) -> Void
+  public typealias ScrollCommitHandler = @MainActor @Sendable (
+    [MonitorID: [WorkspaceID: Double]]
+  ) -> Void
 
   private let focusWindowHandler: WindowHandler
   private let focusWorkspaceHandler: WorkspaceHandler
   private let dropHandler: DropHandler
   private let activateMonitorHandler: MonitorHandler
   private let openStateHandler: OpenStateHandler
+  private let scrollCommitHandler: ScrollCommitHandler
   private var panels: [MonitorID: OverviewPanel] = [:]
   private var snapshot: OverviewSnapshot?
   private var layout = LayoutSettings()
@@ -182,13 +188,15 @@ public final class OverviewController: NSObject {
     focusWorkspace: @escaping WorkspaceHandler,
     drop: @escaping DropHandler,
     activateMonitor: @escaping MonitorHandler,
-    openStateChanged: @escaping OpenStateHandler
+    openStateChanged: @escaping OpenStateHandler,
+    commitScrollOffsets: @escaping ScrollCommitHandler
   ) {
     focusWindowHandler = focusWindow
     focusWorkspaceHandler = focusWorkspace
     dropHandler = drop
     activateMonitorHandler = activateMonitor
     openStateHandler = openStateChanged
+    scrollCommitHandler = commitScrollOffsets
     super.init()
     let center = NSWorkspace.shared.notificationCenter
     center.addObserver(
@@ -407,6 +415,21 @@ public final class OverviewController: NSObject {
         viewportTargets[monitor.id] = viewport
       }
       activeWorkspaceByMonitor[monitor.id] = monitor.activeWorkspace
+      guard let previousMonitor = previousSnapshot?.monitors.first(where: {
+        $0.id == monitor.id
+      }) else { continue }
+      for workspace in monitor.workspaces {
+        guard let previousWorkspace = previousMonitor.workspaces.first(where: {
+          $0.id == workspace.id
+        }),
+          previousWorkspace.targetScrollOffset != workspace.targetScrollOffset
+        else { continue }
+        var target = viewportTargets[monitor.id]
+          ?? viewports[monitor.id]
+          ?? OverviewViewport()
+        target.horizontalOffsets[workspace.id] = workspace.targetScrollOffset
+        viewportTargets[monitor.id] = target
+      }
     }
     if alignSelectionOnNextUpdate,
       let location = selection?.location,
@@ -426,7 +449,7 @@ public final class OverviewController: NSObject {
         pendingTarget: viewportTargets[location.monitorID],
         animationTarget: viewportAnimations[location.monitorID]?.to,
         workspaceID: location.workspaceID,
-        scrollOffset: workspace.scrollOffset,
+        scrollOffset: workspace.targetScrollOffset,
         sourceWorkspaceID: sourceWorkspaceID,
         sourceMaximumHorizontalOffset: sourceWorkspaceID.flatMap {
           maximumHorizontalOffset(for: $0, on: monitor)
@@ -464,6 +487,10 @@ public final class OverviewController: NSObject {
   }
 
   public func close() {
+    close(commitScrollOffsets: true)
+  }
+
+  private func close(commitScrollOffsets: Bool) {
     guard isOpen else { return }
     isOpen = false
     sessionGeneration &+= 1
@@ -481,6 +508,9 @@ public final class OverviewController: NSObject {
     capturedDesktopMonitorIDs.removeAll(keepingCapacity: true)
     previewPendingCount = 0
     stopOverviewAnimations()
+    if commitScrollOffsets {
+      scrollCommitHandler(viewports.mapValues(\.horizontalOffsets))
+    }
     openStateHandler(false)
     let closingPanels = Array(panels.values)
     for panel in closingPanels {
@@ -526,14 +556,30 @@ public final class OverviewController: NSObject {
 
   private func chooseSelection() {
     guard let snapshot, let selection else { return }
+    alignSelectionOnNextUpdate = true
     switch selection {
     case .window(let windowID, let monitorID, let workspaceID):
       guard let window = snapshot.windows[windowID] else { return }
-      close()
+      expectActivation(of: window.processID)
       focusWindowHandler(windowID, window.appID, monitorID, workspaceID)
     case .workspace(let monitorID, let workspaceID):
-      close()
       focusWorkspaceHandler(monitorID, workspaceID)
+    }
+    closeAfterSelectionAlignment()
+  }
+
+  private func closeAfterSelectionAlignment() {
+    guard animationsEnabled,
+      !NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+    else {
+      close(commitScrollOffsets: false)
+      return
+    }
+    let generation = sessionGeneration
+    DispatchQueue.main.asyncAfter(deadline: .now() + overviewTransitionDuration) {
+      [weak self] in
+      guard let self, isOpen, sessionGeneration == generation else { return }
+      close(commitScrollOffsets: false)
     }
   }
 
@@ -1145,7 +1191,7 @@ public final class OverviewController: NSObject {
       from: current,
       to: target,
       startedAt: CACurrentMediaTime(),
-      duration: 0.16
+      duration: overviewTransitionDuration
     )
     projectionAnimations[monitorID] = nil
     link.isPaused = false
@@ -1169,7 +1215,7 @@ public final class OverviewController: NSObject {
       from: source,
       to: target,
       startedAt: CACurrentMediaTime(),
-      duration: 0.16
+      duration: overviewTransitionDuration
     )
     link.isPaused = false
   }
@@ -1779,7 +1825,7 @@ private final class OverviewPanel {
     DispatchQueue.main.asyncAfter(deadline: .now() + displayInterval) { [weak self] in
       guard let self else { return }
       NSAnimationContext.runAnimationGroup { context in
-        context.duration = 0.16
+        context.duration = overviewTransitionDuration
         context.timingFunction = CAMediaTimingFunction(name: .easeOut)
         self.window.animator().alphaValue = 1
         self.view.layer?.setAffineTransform(.identity)

--- a/Sources/DefiMacOS/OverviewController.swift
+++ b/Sources/DefiMacOS/OverviewController.swift
@@ -152,6 +152,7 @@ public final class OverviewController: NSObject {
   private var previewRevealStartedAt: [WindowID: TimeInterval] = [:]
   private var previewFadeTimer: Timer?
   private var attemptedPreviewWindowIDs = Set<WindowID>()
+  private var attemptedDesktopMonitorIDs = Set<MonitorID>()
   private var hasRequestedPreviewPermission = false
   private var previewPendingCount = 0
   private var alignSelectionOnNextUpdate = false
@@ -274,6 +275,7 @@ public final class OverviewController: NSObject {
     restoreRememberedPreviews(for: snapshot)
     resetPreviewFadeAnimation()
     attemptedPreviewWindowIDs.removeAll(keepingCapacity: true)
+    attemptedDesktopMonitorIDs.removeAll(keepingCapacity: true)
     previewPendingCount = 0
     previewPermissionState = windowPreviewsEnabled ? .notDetermined : .disabled
     selection = initialSelection(in: snapshot)
@@ -476,6 +478,7 @@ public final class OverviewController: NSObject {
     previewCache.removeAll(keepingCapacity: true)
     resetPreviewFadeAnimation()
     attemptedPreviewWindowIDs.removeAll(keepingCapacity: true)
+    attemptedDesktopMonitorIDs.removeAll(keepingCapacity: true)
     previewPendingCount = 0
     stopOverviewAnimations()
     openStateHandler(false)
@@ -894,7 +897,7 @@ public final class OverviewController: NSObject {
 
     let results = await captureOverviewImages(
       previews: requests,
-      desktops: []
+      desktops: desktopCaptureRequests()
     )
     guard windowPreviewsEnabled, isOpen, generation == sessionGeneration,
       !Task.isCancelled
@@ -1088,6 +1091,20 @@ public final class OverviewController: NSObject {
     }
     var seen = Set<WindowID>()
     return requests.filter { seen.insert($0.windowID).inserted }
+  }
+
+  private func desktopCaptureRequests() -> [OverviewDesktopCaptureRequest] {
+    panels.compactMap { monitorID, panel in
+      guard attemptedDesktopMonitorIDs.insert(monitorID).inserted,
+        let displayID = CGDirectDisplayID(exactly: monitorID.rawValue)
+      else { return nil }
+      return OverviewDesktopCaptureRequest(
+        monitorID: monitorID,
+        displayID: displayID,
+        width: max(Int(panel.window.frame.width.rounded(.up)), 1),
+        height: max(Int(panel.window.frame.height.rounded(.up)), 1)
+      )
+    }
   }
 
   private func screen(for monitorID: MonitorID) -> NSScreen? {
@@ -1712,11 +1729,13 @@ private final class OverviewPanel {
     desktopView.layer?.contentsScale = screen.backingScaleFactor
     desktopView.layer?.masksToBounds = true
     desktopView.autoresizingMask = [.width, .height]
-    if usesCapturedDesktop,
-      let url = NSWorkspace.shared.desktopImageURL(for: screen),
+    if let url = NSWorkspace.shared.desktopImageURL(for: screen),
       let image = NSImage(contentsOf: url)
     {
-      desktopView.layer?.contents = image
+      if usesCapturedDesktop {
+        desktopView.layer?.contents = image
+      }
+      view.setDesktopImage(image)
     }
     let glassView = NSGlassEffectView(
       frame: NSRect(origin: .zero, size: screen.frame.size)
@@ -1734,6 +1753,7 @@ private final class OverviewPanel {
 
   func setDesktopImage(_ image: NSImage) {
     desktopView.layer?.contents = image
+    view.setDesktopImage(image)
   }
 
   func show(animated: Bool) {
@@ -1786,6 +1806,7 @@ private final class OverviewView: NSView {
   private var drag: OverviewDragPresentation?
   private var borderStyle = WindowBorderStyle(config: BordersConfig())
   private var windowCornerRadius = 12.0
+  private var desktopImage: NSImage?
   private var previews: [WindowID: NSImage] = [:]
   private var previewOpacities: [WindowID: Double] = [:]
   private var mouseDownPoint: NSPoint?
@@ -1808,6 +1829,11 @@ private final class OverviewView: NSView {
 
   func discardPreviewImages() {
     previews.removeAll(keepingCapacity: false)
+  }
+
+  func setDesktopImage(_ image: NSImage) {
+    desktopImage = image
+    needsDisplay = true
   }
 
   @available(*, unavailable)
@@ -1897,10 +1923,23 @@ private final class OverviewView: NSView {
   ) {
     let frame = nsRect(workspace.frame)
     let scale = contentScale(for: workspace, snapshot: snapshot)
+    drawVisibleDesktop(for: workspace)
     NSGraphicsContext.saveGraphicsState()
     frame.clip()
     for window in workspace.windows
-    where drag?.windowID != window.windowID
+    where window.layer != .floating
+      && drag?.windowID != window.windowID
+      && projection?.overlayWindowID != window.windowID
+    {
+      drawWindow(window, snapshot: snapshot)
+    }
+    NSGraphicsContext.restoreGraphicsState()
+
+    NSGraphicsContext.saveGraphicsState()
+    nsRect(workspace.visibleFrame).clip()
+    for window in workspace.windows
+    where window.layer == .floating
+      && drag?.windowID != window.windowID
       && projection?.overlayWindowID != window.windowID
     {
       drawWindow(window, snapshot: snapshot)
@@ -1911,13 +1950,78 @@ private final class OverviewView: NSView {
     let borderWidth = borderStyle.width * scale
     frame.insetBy(dx: -borderWidth, dy: -borderWidth).clip()
     for window in workspace.windows
-    where drag?.windowID != window.windowID
+    where window.layer != .floating
+      && drag?.windowID != window.windowID
+      && projection?.overlayWindowID != window.windowID
+    {
+      drawWindowBorder(window, scale: scale)
+    }
+    NSGraphicsContext.restoreGraphicsState()
+
+    NSGraphicsContext.saveGraphicsState()
+    nsRect(workspace.visibleFrame).insetBy(
+      dx: -borderWidth,
+      dy: -borderWidth
+    ).clip()
+    for window in workspace.windows
+    where window.layer == .floating
+      && drag?.windowID != window.windowID
       && projection?.overlayWindowID != window.windowID
     {
       drawWindowBorder(window, scale: scale)
     }
     NSGraphicsContext.restoreGraphicsState()
     drawHorizontalOverflowIndicators(for: workspace)
+  }
+
+  private func drawVisibleDesktop(for workspace: OverviewWorkspaceProjection) {
+    let frame = nsRect(workspace.visibleFrame)
+    let path = NSBezierPath(
+      roundedRect: frame,
+      xRadius: windowCornerRadius,
+      yRadius: windowCornerRadius
+    )
+    NSGraphicsContext.saveGraphicsState()
+    path.addClip()
+    if let desktopImage {
+      desktopImage.draw(
+        in: frame,
+        from: aspectFillSourceRect(for: desktopImage, in: frame),
+        operation: .sourceOver,
+        fraction: 1,
+        respectFlipped: true,
+        hints: [.interpolation: NSImageInterpolation.high]
+      )
+    } else {
+      NSColor.windowBackgroundColor.setFill()
+      path.fill()
+    }
+    NSColor.black.withAlphaComponent(0.12).setFill()
+    path.fill()
+    NSGraphicsContext.restoreGraphicsState()
+  }
+
+  private func aspectFillSourceRect(for image: NSImage, in frame: NSRect) -> NSRect {
+    guard image.size.width > 0, image.size.height > 0, frame.width > 0, frame.height > 0
+    else { return .zero }
+    let imageRatio = image.size.width / image.size.height
+    let frameRatio = frame.width / frame.height
+    if imageRatio > frameRatio {
+      let width = image.size.height * frameRatio
+      return NSRect(
+        x: (image.size.width - width) / 2,
+        y: 0,
+        width: width,
+        height: image.size.height
+      )
+    }
+    let height = image.size.width / frameRatio
+    return NSRect(
+      x: 0,
+      y: (image.size.height - height) / 2,
+      width: image.size.width,
+      height: height
+    )
   }
 
   private func drawWindow(

--- a/Sources/DefiMacOS/OverviewController.swift
+++ b/Sources/DefiMacOS/OverviewController.swift
@@ -152,7 +152,7 @@ public final class OverviewController: NSObject {
   private var previewRevealStartedAt: [WindowID: TimeInterval] = [:]
   private var previewFadeTimer: Timer?
   private var attemptedPreviewWindowIDs = Set<WindowID>()
-  private var attemptedDesktopMonitorIDs = Set<MonitorID>()
+  private var capturedDesktopMonitorIDs = Set<MonitorID>()
   private var hasRequestedPreviewPermission = false
   private var previewPendingCount = 0
   private var alignSelectionOnNextUpdate = false
@@ -275,7 +275,7 @@ public final class OverviewController: NSObject {
     restoreRememberedPreviews(for: snapshot)
     resetPreviewFadeAnimation()
     attemptedPreviewWindowIDs.removeAll(keepingCapacity: true)
-    attemptedDesktopMonitorIDs.removeAll(keepingCapacity: true)
+    capturedDesktopMonitorIDs.removeAll(keepingCapacity: true)
     previewPendingCount = 0
     previewPermissionState = windowPreviewsEnabled ? .notDetermined : .disabled
     selection = initialSelection(in: snapshot)
@@ -478,7 +478,7 @@ public final class OverviewController: NSObject {
     previewCache.removeAll(keepingCapacity: true)
     resetPreviewFadeAnimation()
     attemptedPreviewWindowIDs.removeAll(keepingCapacity: true)
-    attemptedDesktopMonitorIDs.removeAll(keepingCapacity: true)
+    capturedDesktopMonitorIDs.removeAll(keepingCapacity: true)
     previewPendingCount = 0
     stopOverviewAnimations()
     openStateHandler(false)
@@ -752,7 +752,7 @@ public final class OverviewController: NSObject {
       ?? .workspace(monitorID: monitor.id, workspaceID: workspace.id)
   }
 
-  private func updatePanels() {
+  private func updatePanels(scheduleCaptures: Bool = true) {
     guard let snapshot else { return }
     var projections: [MonitorID: OverviewProjection] = [:]
     let now = CACurrentMediaTime()
@@ -790,7 +790,7 @@ public final class OverviewController: NSObject {
       )
     }
     self.projections = projections
-    schedulePreviewsIfNeeded()
+    if scheduleCaptures { schedulePreviewsIfNeeded() }
   }
 
   private func projection(
@@ -850,7 +850,7 @@ public final class OverviewController: NSObject {
       !attemptedPreviewWindowIDs.contains($0.windowID)
     }
     let hasPendingDesktopCapture = panels.keys.contains {
-      !attemptedDesktopMonitorIDs.contains($0)
+      !capturedDesktopMonitorIDs.contains($0)
     }
     guard overviewCaptureBatchNeeded(
       previewRequestCount: requests.count,
@@ -901,9 +901,10 @@ public final class OverviewController: NSObject {
       return
     }
 
+    let desktopRequests = desktopCaptureRequests()
     let results = await captureOverviewImages(
       previews: requests,
-      desktops: desktopCaptureRequests()
+      desktops: desktopRequests
     )
     guard windowPreviewsEnabled, isOpen, generation == sessionGeneration,
       !Task.isCancelled
@@ -911,6 +912,11 @@ public final class OverviewController: NSObject {
       finishPreviewBatch(generation: generation)
       return
     }
+    capturedDesktopMonitorIDs = overviewRecordedDesktopCaptureMonitorIDs(
+      existing: capturedDesktopMonitorIDs,
+      requested: Set(desktopRequests.map(\.monitorID)),
+      captured: Set(results.desktops.keys)
+    )
     let currentRequests = Dictionary(
       uniqueKeysWithValues: visiblePreviewRequests().map { ($0.windowID, $0) }
     )
@@ -959,7 +965,7 @@ public final class OverviewController: NSObject {
     }
     finishPreviewBatch(generation: generation)
     if didAddPreview { startPreviewFadeAnimation() }
-    updatePanels()
+    updatePanels(scheduleCaptures: false)
   }
 
   private func finishPreviewBatch(generation: UInt64) {
@@ -1101,7 +1107,7 @@ public final class OverviewController: NSObject {
 
   private func desktopCaptureRequests() -> [OverviewDesktopCaptureRequest] {
     panels.compactMap { monitorID, panel in
-      guard attemptedDesktopMonitorIDs.insert(monitorID).inserted,
+      guard !capturedDesktopMonitorIDs.contains(monitorID),
         let displayID = CGDirectDisplayID(exactly: monitorID.rawValue)
       else { return nil }
       return OverviewDesktopCaptureRequest(

--- a/Sources/DefiMacOS/OverviewController.swift
+++ b/Sources/DefiMacOS/OverviewController.swift
@@ -152,6 +152,7 @@ public final class OverviewController: NSObject {
   private var expectedActivationGeneration: UInt64 = 0
   private var windowPreviewsEnabled = false
   private var previewTask: Task<Void, Never>?
+  private var desktopCaptureRetryTask: Task<Void, Never>?
   private var previewCache: [WindowID: NSImage] = [:]
   private var rememberedPreviews: [WindowID: RememberedOverviewPreview] = [:]
   private var rememberedPreviewByteCosts: [WindowID: Int] = [:]
@@ -220,6 +221,7 @@ public final class OverviewController: NSObject {
   }
 
   isolated deinit {
+    desktopCaptureRetryTask?.cancel()
     previewFadeTimer?.invalidate()
     for link in viewportDisplayLinks.values { link.invalidate() }
     NSWorkspace.shared.notificationCenter.removeObserver(self)
@@ -279,6 +281,7 @@ public final class OverviewController: NSObject {
     if !canReusePanels { closePanelsImmediately() }
     previewTask?.cancel()
     previewTask = nil
+    cancelDesktopCaptureRetry()
     previewCache.removeAll(keepingCapacity: true)
     restoreRememberedPreviews(for: snapshot)
     resetPreviewFadeAnimation()
@@ -341,6 +344,7 @@ public final class OverviewController: NSObject {
       self.windowPreviewsEnabled = windowPreviewsEnabled
       previewTask?.cancel()
       previewTask = nil
+      cancelDesktopCaptureRetry()
       previewCache.removeAll(keepingCapacity: true)
       if windowPreviewsEnabled {
         restoreRememberedPreviews(for: snapshot)
@@ -502,6 +506,7 @@ public final class OverviewController: NSObject {
     expectedActivationProcessID = nil
     previewTask?.cancel()
     previewTask = nil
+    cancelDesktopCaptureRetry()
     previewCache.removeAll(keepingCapacity: true)
     resetPreviewFadeAnimation()
     attemptedPreviewWindowIDs.removeAll(keepingCapacity: true)
@@ -904,6 +909,7 @@ public final class OverviewController: NSObject {
     ) else { return }
     attemptedPreviewWindowIDs.formUnion(requests.map(\.windowID))
     previewPendingCount = requests.count
+    cancelDesktopCaptureRetry()
     let generation = sessionGeneration
     previewTask = Task { @MainActor [weak self] in
       await Task.yield()
@@ -963,6 +969,10 @@ public final class OverviewController: NSObject {
       requested: Set(desktopRequests.map(\.monitorID)),
       captured: Set(results.desktops.keys)
     )
+    let shouldRetryDesktopCapture = overviewDesktopCaptureRetryNeeded(
+      requested: Set(desktopRequests.map(\.monitorID)),
+      captured: Set(results.desktops.keys)
+    )
     let currentRequests = Dictionary(
       uniqueKeysWithValues: visiblePreviewRequests().map { ($0.windowID, $0) }
     )
@@ -1011,6 +1021,9 @@ public final class OverviewController: NSObject {
     }
     finishPreviewBatch(generation: generation)
     if didAddPreview { startPreviewFadeAnimation() }
+    if shouldRetryDesktopCapture {
+      scheduleDesktopCaptureRetry(generation: generation)
+    }
     updatePanels(scheduleCaptures: false)
   }
 
@@ -1018,6 +1031,28 @@ public final class OverviewController: NSObject {
     guard generation == sessionGeneration else { return }
     previewTask = nil
     previewPendingCount = 0
+  }
+
+  private func scheduleDesktopCaptureRetry(generation: UInt64) {
+    cancelDesktopCaptureRetry()
+    desktopCaptureRetryTask = Task { @MainActor [weak self] in
+      do {
+        try await Task.sleep(for: .seconds(1))
+      } catch {
+        return
+      }
+      guard let self else { return }
+      self.desktopCaptureRetryTask = nil
+      guard self.windowPreviewsEnabled, self.isOpen,
+        generation == self.sessionGeneration
+      else { return }
+      self.schedulePreviewsIfNeeded()
+    }
+  }
+
+  private func cancelDesktopCaptureRetry() {
+    desktopCaptureRetryTask?.cancel()
+    desktopCaptureRetryTask = nil
   }
 
   private func startPreviewFadeAnimation() {

--- a/Sources/DefiMacOS/OverviewController.swift
+++ b/Sources/DefiMacOS/OverviewController.swift
@@ -1071,7 +1071,7 @@ public final class OverviewController: NSObject {
     guard let snapshot else { return [] }
     var requests: [OverviewPreviewRequest] = []
     for (monitorID, projection) in projections {
-      let scale = min(panels[monitorID]?.window.backingScaleFactor ?? 1, 1)
+      let scale = max(panels[monitorID]?.window.backingScaleFactor ?? 1, 1)
       for card in projection.workspaces.flatMap(\.windows) {
         guard let window = snapshot.windows[card.windowID] else { continue }
         let width = min(max(Int((card.frame.width * scale).rounded(.up)), 32), 1_600)
@@ -2062,7 +2062,7 @@ private final class OverviewView: NSView {
       path.addClip()
       preview.draw(
         in: frame,
-        from: .zero,
+        from: aspectFillSourceRect(for: preview, in: frame),
         operation: .sourceOver,
         fraction: opacity,
         respectFlipped: true,

--- a/Sources/DefiMacOS/OverviewController.swift
+++ b/Sources/DefiMacOS/OverviewController.swift
@@ -2013,7 +2013,11 @@ private final class OverviewView: NSView {
     NSGraphicsContext.restoreGraphicsState()
   }
 
-  private func aspectFillSourceRect(for image: NSImage, in frame: NSRect) -> NSRect {
+  private func aspectFillSourceRect(
+    for image: NSImage,
+    in frame: NSRect,
+    horizontalAlignment: CGFloat = 0.5
+  ) -> NSRect {
     guard image.size.width > 0, image.size.height > 0, frame.width > 0, frame.height > 0
     else { return .zero }
     let imageRatio = image.size.width / image.size.height
@@ -2021,7 +2025,7 @@ private final class OverviewView: NSView {
     if imageRatio > frameRatio {
       let width = image.size.height * frameRatio
       return NSRect(
-        x: (image.size.width - width) / 2,
+        x: (image.size.width - width) * horizontalAlignment,
         y: 0,
         width: width,
         height: image.size.height
@@ -2062,7 +2066,7 @@ private final class OverviewView: NSView {
       path.addClip()
       preview.draw(
         in: frame,
-        from: aspectFillSourceRect(for: preview, in: frame),
+        from: aspectFillSourceRect(for: preview, in: frame, horizontalAlignment: 0),
         operation: .sourceOver,
         fraction: opacity,
         respectFlipped: true,

--- a/Sources/DefiMacOS/OverviewController.swift
+++ b/Sources/DefiMacOS/OverviewController.swift
@@ -849,7 +849,13 @@ public final class OverviewController: NSObject {
     let requests = visiblePreviewRequests().filter {
       !attemptedPreviewWindowIDs.contains($0.windowID)
     }
-    guard !requests.isEmpty else { return }
+    let hasPendingDesktopCapture = panels.keys.contains {
+      !attemptedDesktopMonitorIDs.contains($0)
+    }
+    guard overviewCaptureBatchNeeded(
+      previewRequestCount: requests.count,
+      hasPendingDesktopCapture: hasPendingDesktopCapture
+    ) else { return }
     attemptedPreviewWindowIDs.formUnion(requests.map(\.windowID))
     previewPendingCount = requests.count
     let generation = sessionGeneration

--- a/Sources/DefiMacOS/OverviewPreviewCapture.swift
+++ b/Sources/DefiMacOS/OverviewPreviewCapture.swift
@@ -77,6 +77,13 @@ func overviewRecordedDesktopCaptureMonitorIDs(
   existing.union(captured.intersection(requested))
 }
 
+func overviewDesktopCaptureRetryNeeded(
+  requested: Set<MonitorID>,
+  captured: Set<MonitorID>
+) -> Bool {
+  !requested.isSubset(of: captured)
+}
+
 struct OverviewPreviewRequest: Equatable, Sendable {
   let windowID: WindowID
   let expectedAppID: String

--- a/Sources/DefiMacOS/OverviewPreviewCapture.swift
+++ b/Sources/DefiMacOS/OverviewPreviewCapture.swift
@@ -281,6 +281,6 @@ func overviewPreviewRequestIsCurrent(
   currentAppID: String?
 ) -> Bool {
   generation == currentGeneration
-    && currentRequest == request
+    && currentRequest?.windowID == request.windowID
     && currentAppID == request.expectedAppID
 }

--- a/Sources/DefiMacOS/OverviewPreviewCapture.swift
+++ b/Sources/DefiMacOS/OverviewPreviewCapture.swift
@@ -69,6 +69,14 @@ func overviewCaptureBatchNeeded(
   previewRequestCount > 0 || hasPendingDesktopCapture
 }
 
+func overviewRecordedDesktopCaptureMonitorIDs(
+  existing: Set<MonitorID>,
+  requested: Set<MonitorID>,
+  captured: Set<MonitorID>
+) -> Set<MonitorID> {
+  existing.union(captured.intersection(requested))
+}
+
 struct OverviewPreviewRequest: Equatable, Sendable {
   let windowID: WindowID
   let expectedAppID: String

--- a/Sources/DefiMacOS/OverviewPreviewCapture.swift
+++ b/Sources/DefiMacOS/OverviewPreviewCapture.swift
@@ -62,6 +62,13 @@ public enum OverviewPreviewPermissionState: String, Sendable {
   case denied
 }
 
+func overviewCaptureBatchNeeded(
+  previewRequestCount: Int,
+  hasPendingDesktopCapture: Bool
+) -> Bool {
+  previewRequestCount > 0 || hasPendingDesktopCapture
+}
+
 struct OverviewPreviewRequest: Equatable, Sendable {
   let windowID: WindowID
   let expectedAppID: String

--- a/Sources/DefiMacOS/SnapshotEngine.swift
+++ b/Sources/DefiMacOS/SnapshotEngine.swift
@@ -709,10 +709,17 @@ extension SnapshotEngine {
     guard let resolvedWindowID = record?.id else {
       return .unmatched
     }
+    let windowID = WindowID(rawValue: UInt64(resolvedWindowID))
+    let widthConstraints = onMain { platform in
+      if let ownedWindowID = platform.borderManager.ownedSurfaceWindowID {
+        platform.borderBoundsProvider.probe(ownedWindowID: ownedWindowID)
+      }
+      return platform.borderBoundsProvider.widthConstraints(for: windowID)
+    }
     let monitorID = monitor(containing: frame, monitors: monitors)?.id
     return .discovered(
       Window(
-        id: WindowID(rawValue: UInt64(resolvedWindowID)),
+        id: windowID,
         appID: appID,
         title: title,
         frame: frame,
@@ -721,7 +728,9 @@ extension SnapshotEngine {
         processID: processID,
         isModal: attributes.modal == true,
         monitorID: monitorID,
-        forceTiling: false
+        forceTiling: false,
+        minimumTiledWidth: widthConstraints?.minimum,
+        maximumTiledWidth: widthConstraints?.maximum
       ), resolvedWindowID, decision
     )
   }

--- a/Sources/DefiMacOS/WindowBorderPrivateProviders.swift
+++ b/Sources/DefiMacOS/WindowBorderPrivateProviders.swift
@@ -22,6 +22,26 @@ func normalizedWindowBorderFrame(_ bounds: CGRect) -> Rect? {
   )
 }
 
+struct WindowWidthConstraints: Equatable, Sendable {
+  let minimum: Double?
+  let maximum: Double?
+}
+
+func normalizedWindowWidthConstraints(
+  minimum: CGFloat,
+  maximum: CGFloat
+) -> WindowWidthConstraints {
+  let minimum = minimum.isFinite && minimum > 0 ? Double(minimum) : nil
+  var maximum =
+    maximum.isFinite && maximum > 0 && maximum < 100_000
+    ? Double(maximum)
+    : nil
+  if let minimum, let value = maximum, value < minimum {
+    maximum = minimum
+  }
+  return WindowWidthConstraints(minimum: minimum, maximum: maximum)
+}
+
 func windowBorderFrameSnapshot(
   windowIDs: Set<WindowID>,
   frameProvider: (WindowID) -> Rect?
@@ -37,34 +57,68 @@ final class WindowServerBoundsProvider {
   private typealias MainConnectionIDFunc = @convention(c) () -> Int32
   private typealias GetWindowBoundsFunc =
     @convention(c) (Int32, UInt32, UnsafeMutablePointer<CGRect>) -> Int32
+  private typealias WindowQueryFunc =
+    @convention(c) (Int32, UnsafeRawPointer?, UInt32) -> UnsafeMutableRawPointer?
+  private typealias QueryCopyWindowsFunc =
+    @convention(c) (UnsafeRawPointer?) -> UnsafeMutableRawPointer?
+  private typealias IteratorCountFunc = @convention(c) (UnsafeRawPointer?) -> Int32
+  private typealias IteratorAdvanceFunc = @convention(c) (UnsafeRawPointer?) -> Bool
+  private typealias IteratorWindowIDFunc = @convention(c) (UnsafeRawPointer?) -> UInt32
+  private typealias IteratorConstraintsFunc =
+    @convention(c) (
+      UnsafeRawPointer?,
+      UnsafeMutablePointer<CGSize>,
+      UnsafeMutablePointer<CGSize>,
+      UnsafeMutablePointer<CGSize>
+    ) -> Void
 
   private let libraryHandle: UnsafeMutableRawPointer?
   private let mainConnectionID: MainConnectionIDFunc?
   private let getWindowBounds: GetWindowBoundsFunc?
+  private let windowQuery: WindowQueryFunc?
+  private let queryCopyWindows: QueryCopyWindowsFunc?
+  private let iteratorCount: IteratorCountFunc?
+  private let iteratorAdvance: IteratorAdvanceFunc?
+  private let iteratorWindowID: IteratorWindowIDFunc?
+  private let iteratorConstraints: IteratorConstraintsFunc?
   private(set) var successfulLookupCount = 0
   private(set) var failureCount = 0
+  private(set) var successfulConstraintLookupCount = 0
+  private(set) var constraintFallbackCount = 0
   private var disabled = false
   private var probeSucceeded = false
+  private var constraintProbeSucceeded = false
+  private var constraintsDisabled = false
+  private var constraintCache: [WindowID: WindowWidthConstraints] = [:]
 
   func probe(ownedWindowID: WindowID) {
-    guard !probeSucceeded, !disabled else { return }
-    guard let rawWindowID = UInt32(exactly: ownedWindowID.rawValue),
-      let mainConnectionID,
-      let getWindowBounds
-    else {
+    guard let rawWindowID = UInt32(exactly: ownedWindowID.rawValue) else {
       disabled = true
+      constraintsDisabled = true
       failureCount += 1
+      constraintFallbackCount += 1
       return
     }
-    var bounds = CGRect.zero
-    guard getWindowBounds(mainConnectionID(), rawWindowID, &bounds) == 0,
-      normalizedWindowBorderFrame(bounds) != nil
-    else {
-      disabled = true
-      failureCount += 1
-      return
+    if !probeSucceeded, !disabled {
+      var bounds = CGRect.zero
+      if let mainConnectionID, let getWindowBounds,
+        getWindowBounds(mainConnectionID(), rawWindowID, &bounds) == 0,
+        normalizedWindowBorderFrame(bounds) != nil
+      {
+        probeSucceeded = true
+      } else {
+        disabled = true
+        failureCount += 1
+      }
     }
-    probeSucceeded = true
+    if !constraintProbeSucceeded, !constraintsDisabled {
+      if rawConstraints(for: rawWindowID) != nil {
+        constraintProbeSucceeded = true
+      } else {
+        constraintsDisabled = true
+        constraintFallbackCount += 1
+      }
+    }
   }
 
   init() {
@@ -81,6 +135,24 @@ final class WindowServerBoundsProvider {
 
     mainConnectionID = resolve("SLSMainConnectionID", as: MainConnectionIDFunc.self)
     getWindowBounds = resolve("SLSGetWindowBounds", as: GetWindowBoundsFunc.self)
+    windowQuery = resolve("SLSWindowQueryWindows", as: WindowQueryFunc.self)
+    queryCopyWindows = resolve(
+      "SLSWindowQueryResultCopyWindows",
+      as: QueryCopyWindowsFunc.self
+    )
+    iteratorCount = resolve("SLSWindowIteratorGetCount", as: IteratorCountFunc.self)
+    iteratorAdvance = resolve(
+      "SLSWindowIteratorAdvance",
+      as: IteratorAdvanceFunc.self
+    )
+    iteratorWindowID = resolve(
+      "SLSWindowIteratorGetWindowID",
+      as: IteratorWindowIDFunc.self
+    )
+    iteratorConstraints = resolve(
+      "SLSWindowIteratorGetConstraints",
+      as: IteratorConstraintsFunc.self
+    )
   }
 
   deinit {
@@ -112,8 +184,71 @@ final class WindowServerBoundsProvider {
     return frame
   }
 
+  func widthConstraints(for windowID: WindowID) -> WindowWidthConstraints? {
+    guard !constraintsDisabled, constraintProbeSucceeded else {
+      constraintFallbackCount += 1
+      return nil
+    }
+    if let cached = constraintCache[windowID] { return cached }
+    guard let rawWindowID = UInt32(exactly: windowID.rawValue),
+      let (minimum, maximum, _) = rawConstraints(for: rawWindowID)
+    else {
+      constraintsDisabled = true
+      constraintCache.removeAll(keepingCapacity: false)
+      constraintFallbackCount += 1
+      return nil
+    }
+    let constraints = normalizedWindowWidthConstraints(
+      minimum: minimum.width,
+      maximum: maximum.width
+    )
+    constraintCache[windowID] = constraints
+    successfulConstraintLookupCount += 1
+    return constraints
+  }
+
+  func retainConstraints(for windowIDs: Set<WindowID>) {
+    constraintCache = constraintCache.filter { windowIDs.contains($0.key) }
+  }
+
+  private func rawConstraints(
+    for rawWindowID: UInt32
+  ) -> (CGSize, CGSize, CGSize)? {
+    guard let mainConnectionID,
+      let windowQuery,
+      let queryCopyWindows,
+      let iteratorCount,
+      let iteratorAdvance,
+      let iteratorWindowID,
+      let iteratorConstraints
+    else { return nil }
+    let windowIDs = NSArray(object: NSNumber(value: rawWindowID))
+    let query = windowQuery(
+      mainConnectionID(),
+      Unmanaged.passUnretained(windowIDs).toOpaque(),
+      0
+    )
+    guard let query else { return nil }
+    defer { Unmanaged<AnyObject>.fromOpaque(query).release() }
+    guard let iterator = queryCopyWindows(query) else { return nil }
+    defer { Unmanaged<AnyObject>.fromOpaque(iterator).release() }
+    guard iteratorCount(iterator) > 0,
+      iteratorAdvance(iterator),
+      iteratorWindowID(iterator) == rawWindowID
+    else { return nil }
+    var minimum = CGSize.zero
+    var maximum = CGSize.zero
+    var current = CGSize.zero
+    iteratorConstraints(iterator, &minimum, &maximum, &current)
+    return (minimum, maximum, current)
+  }
+
   var isAvailable: Bool {
     !disabled && probeSucceeded && mainConnectionID != nil && getWindowBounds != nil
+  }
+
+  var constraintsAreAvailable: Bool {
+    !constraintsDisabled && constraintProbeSucceeded
   }
 }
 

--- a/Sources/DefiRuntime/ScrollReconciliation.swift
+++ b/Sources/DefiRuntime/ScrollReconciliation.swift
@@ -1,6 +1,30 @@
 import DefiCore
 import DefiModel
 
+@discardableResult
+public func applyOverviewScrollOffsets(
+  _ offsets: [MonitorID: [WorkspaceID: Double]],
+  state: inout RuntimeState
+) -> Set<MonitorID> {
+  var changedMonitorIDs = Set<MonitorID>()
+  for monitorIndex in state.monitors.indices {
+    let monitorID = state.monitors[monitorIndex].id
+    guard let workspaceOffsets = offsets[monitorID] else { continue }
+    for workspaceIndex in state.monitors[monitorIndex].workspaces.indices {
+      let workspaceID = state.monitors[monitorIndex].workspaces[workspaceIndex].id
+      guard let offset = workspaceOffsets[workspaceID], offset.isFinite else { continue }
+      let workspace = state.monitors[monitorIndex].workspaces[workspaceIndex]
+      guard workspace.scrollOffset != offset || workspace.targetScrollOffset != offset else {
+        continue
+      }
+      state.monitors[monitorIndex].workspaces[workspaceIndex].scrollOffset = offset
+      state.monitors[monitorIndex].workspaces[workspaceIndex].targetScrollOffset = offset
+      changedMonitorIDs.insert(monitorID)
+    }
+  }
+  return changedMonitorIDs
+}
+
 public func synchronizeScrollOffsets(
   state: inout RuntimeState,
   viewports: [MonitorID: Rect]

--- a/Sources/DefiRuntime/WindowReconciliation.swift
+++ b/Sources/DefiRuntime/WindowReconciliation.swift
@@ -238,12 +238,18 @@ public func reconcileWindows(
         }
         updated.forceTiling = existing.forceTiling
         updated.intrinsicSize = existing.intrinsicSize
-        updated.minimumTiledWidth = nativeFullscreenWindowIDs.contains(window.id)
-          ? nil
-          : existing.minimumTiledWidth
-        updated.maximumTiledWidth = nativeFullscreenWindowIDs.contains(window.id)
-          ? nil
-          : existing.maximumTiledWidth
+        if nativeFullscreenWindowIDs.contains(window.id) {
+          updated.minimumTiledWidth = nil
+          updated.maximumTiledWidth = nil
+        } else if window.minimumTiledWidth != nil
+          || window.maximumTiledWidth != nil
+        {
+          updated.minimumTiledWidth = window.minimumTiledWidth
+          updated.maximumTiledWidth = window.maximumTiledWidth
+        } else {
+          updated.minimumTiledWidth = existing.minimumTiledWidth
+          updated.maximumTiledWidth = existing.maximumTiledWidth
+        }
         if existing.intrinsicSize,
           !externallyChangedWindowIDs.contains(window.id)
         {

--- a/Tests/DefiCoreTests/OverviewTests.swift
+++ b/Tests/DefiCoreTests/OverviewTests.swift
@@ -162,6 +162,52 @@ struct OverviewTests {
   }
 
   @Test
+  func `Desktop stays centered while the ribbon pans`() {
+    let windowID = WindowID(rawValue: 1)
+    let workspace = Workspace(
+      id: WorkspaceID(rawValue: "web"),
+      columns: [Column(window: windowID, width: .fraction(1))],
+      scrollOffset: 0.1,
+      targetScrollOffset: 0.25
+    )
+    let snapshot = OverviewSnapshot(
+      monitors: [
+        Monitor(
+          id: monitorID,
+          workspaces: [workspace],
+          activeWorkspace: workspace.id
+        )
+      ],
+      monitorFrames: [monitorID: monitorFrame],
+      windows: [
+        windowID: Window(
+          id: windowID,
+          appID: "app",
+          title: "window",
+          frame: monitorFrame
+        )
+      ]
+    )
+    let real = projectOverview(
+      snapshot: snapshot,
+      monitorID: monitorID,
+      bounds: monitorFrame,
+      viewport: OverviewViewport(horizontalOffsets: [workspace.id: 0.25]),
+      layout: LayoutSettings()
+    ).workspaces[0]
+    let panned = projectOverview(
+      snapshot: snapshot,
+      monitorID: monitorID,
+      bounds: monitorFrame,
+      viewport: OverviewViewport(horizontalOffsets: [workspace.id: 0.5]),
+      layout: LayoutSettings()
+    ).workspaces[0]
+
+    #expect(panned.visibleFrame == real.visibleFrame)
+    #expect(panned.windows[0].frame.x < real.windows[0].frame.x)
+  }
+
+  @Test
   func `Adjacent workspaces remain half visible`() {
     let workspaces = (0..<3).map { Workspace(id: WorkspaceID(rawValue: "\($0)")) }
     let bounds = Rect(x: 0, y: 20, width: 1_200, height: 600)

--- a/Tests/DefiCoreTests/OverviewTests.swift
+++ b/Tests/DefiCoreTests/OverviewTests.swift
@@ -146,8 +146,18 @@ struct OverviewTests {
     #expect(ribbon.width == bounds.width)
     #expect(ribbon.height == (bounds.height - 56) / 2)
     #expect(ribbon.y == bounds.y + (bounds.height - ribbon.height) / 2)
-    #expect(tiled.frame.x > ribbon.x + 28)
-    #expect(tiled.frame.x < ribbon.x + ribbon.width / 4)
+    #expect(projection.workspaces[0].visibleFrame == Rect(
+      x: ribbon.x
+        + (ribbon.width - monitorFrame.width * ribbon.height / monitorFrame.height) / 2,
+      y: ribbon.y,
+      width: monitorFrame.width * ribbon.height / monitorFrame.height,
+      height: ribbon.height
+    ))
+    #expect(tiled.frame.x > projection.workspaces[0].visibleFrame.x)
+    #expect(tiled.frame.x < projection.workspaces[0].visibleFrame.x + ribbon.width / 4)
+    #expect(floating.frame.x == projection.workspaces[0].visibleFrame.x
+      + 200 * ribbon.height / monitorFrame.height)
+    #expect(floating.frame.y == ribbon.y + 100 * ribbon.height / monitorFrame.height)
     #expect(floating.frame.width / floating.frame.height == 2)
   }
 
@@ -317,7 +327,7 @@ struct OverviewTests {
       snapshot: snapshot,
       monitorID: monitorID,
       bounds: monitorFrame,
-      viewport: OverviewViewport(horizontalOffsets: [workspace.id: 1]),
+      viewport: OverviewViewport(horizontalOffsets: [workspace.id: 2]),
       layout: LayoutSettings()
     ).workspaces[0]
 

--- a/Tests/DefiDaemonTests/DaemonCommandPolicyTests.swift
+++ b/Tests/DefiDaemonTests/DaemonCommandPolicyTests.swift
@@ -261,6 +261,19 @@ struct DaemonCommandPolicyTests {
   }
 
   @Test
+  func staleAcceptedSizeCannotBecomeAWidthConstraint() {
+    let previous = Rect(x: 0, y: 0, width: 1_200, height: 900)
+
+    #expect(!acceptedFrameChangedWidth(previous, from: previous))
+    #expect(
+      acceptedFrameChangedWidth(
+        Rect(x: 0, y: 0, width: 800, height: 900),
+        from: previous
+      )
+    )
+  }
+
+  @Test
   func staticFrameOrDeferredFocusKeepsCommandFollowUpResponsive() {
     #expect(
       commandFollowUpIsPending(

--- a/Tests/DefiDaemonTests/DaemonCommandPolicyTests.swift
+++ b/Tests/DefiDaemonTests/DaemonCommandPolicyTests.swift
@@ -261,19 +261,6 @@ struct DaemonCommandPolicyTests {
   }
 
   @Test
-  func staleAcceptedSizeCannotBecomeAWidthConstraint() {
-    let previous = Rect(x: 0, y: 0, width: 1_200, height: 900)
-
-    #expect(!acceptedFrameChangedWidth(previous, from: previous))
-    #expect(
-      acceptedFrameChangedWidth(
-        Rect(x: 0, y: 0, width: 800, height: 900),
-        from: previous
-      )
-    )
-  }
-
-  @Test
   func staticFrameOrDeferredFocusKeepsCommandFollowUpResponsive() {
     #expect(
       commandFollowUpIsPending(

--- a/Tests/DefiMacOSTests/OverviewPreviewTests.swift
+++ b/Tests/DefiMacOSTests/OverviewPreviewTests.swift
@@ -142,6 +142,34 @@ struct OverviewPreviewTests {
   }
 
   @Test
+  func `Preview capture remains valid after its card is resized`() {
+    let original = OverviewPreviewRequest(
+      windowID: WindowID(rawValue: 1),
+      expectedAppID: "app",
+      width: 800,
+      height: 500,
+      blurFadeHeight: 80
+    )
+    let resized = OverviewPreviewRequest(
+      windowID: original.windowID,
+      expectedAppID: original.expectedAppID,
+      width: 1_000,
+      height: 500,
+      blurFadeHeight: original.blurFadeHeight
+    )
+
+    #expect(
+      overviewPreviewRequestIsCurrent(
+        original,
+        generation: 1,
+        currentGeneration: 1,
+        currentRequest: resized,
+        currentAppID: "app"
+      )
+    )
+  }
+
+  @Test
   func `Remembered previews stay inside their memory budget`() {
     let first = WindowID(rawValue: 1)
     let second = WindowID(rawValue: 2)

--- a/Tests/DefiMacOSTests/OverviewPreviewTests.swift
+++ b/Tests/DefiMacOSTests/OverviewPreviewTests.swift
@@ -41,6 +41,24 @@ struct OverviewPreviewTests {
     )
   }
 
+  @Test
+  func `Missing desktop capture schedules an idle retry`() {
+    let monitorID = MonitorID(rawValue: 1)
+
+    #expect(
+      overviewDesktopCaptureRetryNeeded(
+        requested: [monitorID],
+        captured: []
+      )
+    )
+    #expect(
+      !overviewDesktopCaptureRetryNeeded(
+        requested: [monitorID],
+        captured: [monitorID]
+      )
+    )
+  }
+
   @Test("Overview parks windows when captured desktop is unavailable")
   func overviewBackdropFallbackPolicy() {
     #expect(

--- a/Tests/DefiMacOSTests/OverviewPreviewTests.swift
+++ b/Tests/DefiMacOSTests/OverviewPreviewTests.swift
@@ -20,6 +20,27 @@ struct OverviewPreviewTests {
     )
   }
 
+  @Test
+  func `Failed desktop capture remains retryable`() {
+    let monitorID = MonitorID(rawValue: 1)
+    let existingID = MonitorID(rawValue: 2)
+
+    #expect(
+      overviewRecordedDesktopCaptureMonitorIDs(
+        existing: [],
+        requested: [monitorID],
+        captured: []
+      ).isEmpty
+    )
+    #expect(
+      overviewRecordedDesktopCaptureMonitorIDs(
+        existing: [existingID],
+        requested: [monitorID],
+        captured: [monitorID]
+      ) == [existingID, monitorID]
+    )
+  }
+
   @Test("Overview parks windows when captured desktop is unavailable")
   func overviewBackdropFallbackPolicy() {
     #expect(

--- a/Tests/DefiMacOSTests/OverviewPreviewTests.swift
+++ b/Tests/DefiMacOSTests/OverviewPreviewTests.swift
@@ -4,6 +4,22 @@ import Testing
 @testable import DefiMacOS
 
 struct OverviewPreviewTests {
+  @Test
+  func `Desktop capture schedules without window previews`() {
+    #expect(
+      overviewCaptureBatchNeeded(
+        previewRequestCount: 0,
+        hasPendingDesktopCapture: true
+      )
+    )
+    #expect(
+      !overviewCaptureBatchNeeded(
+        previewRequestCount: 0,
+        hasPendingDesktopCapture: false
+      )
+    )
+  }
+
   @Test("Overview parks windows when captured desktop is unavailable")
   func overviewBackdropFallbackPolicy() {
     #expect(

--- a/Tests/DefiMacOSTests/WindowBorderTests.swift
+++ b/Tests/DefiMacOSTests/WindowBorderTests.swift
@@ -333,6 +333,22 @@ struct WindowBorderTests {
   }
 
   @Test
+  func windowServerWidthConstraintsNormalizeUnboundedSentinels() {
+    #expect(
+      normalizedWindowWidthConstraints(minimum: 840, maximum: 100_000)
+        == WindowWidthConstraints(minimum: 840, maximum: nil)
+    )
+    #expect(
+      normalizedWindowWidthConstraints(minimum: 723, maximum: 723)
+        == WindowWidthConstraints(minimum: 723, maximum: 723)
+    )
+    #expect(
+      normalizedWindowWidthConstraints(minimum: 0, maximum: .infinity)
+        == WindowWidthConstraints(minimum: nil, maximum: nil)
+    )
+  }
+
+  @Test
   func nativeBoundsSnapshotQueriesEachWindowOnce() {
     let first = WindowID(rawValue: 1)
     let second = WindowID(rawValue: 2)

--- a/Tests/DefiRuntimeTests/OverviewRuntimeTests.swift
+++ b/Tests/DefiRuntimeTests/OverviewRuntimeTests.swift
@@ -12,6 +12,28 @@ struct OverviewRuntimeTests {
   let remoteWorkspace = WorkspaceID(rawValue: "remote")
 
   @Test
+  func `Commits overview ribbon positions once without touching other workspaces`() {
+    var state = makeState()
+
+    let changed = applyOverviewScrollOffsets(
+      [firstMonitor: [firstWorkspace: 0.5]],
+      state: &state
+    )
+
+    #expect(changed == Set([firstMonitor]))
+    #expect(state.monitors[0].workspaces[0].scrollOffset == 0.5)
+    #expect(state.monitors[0].workspaces[0].targetScrollOffset == 0.5)
+    #expect(state.monitors[0].workspaces[1].scrollOffset == 0)
+    #expect(state.monitors[1].workspaces[0].scrollOffset == 0)
+    #expect(
+      applyOverviewScrollOffsets(
+        [firstMonitor: [firstWorkspace: 0.5]],
+        state: &state
+      ).isEmpty
+    )
+  }
+
+  @Test
   func `Moves a tiled window to an exact stack atomically`() throws {
     let moving = WindowID(rawValue: 1)
     let target = WindowID(rawValue: 2)

--- a/Tests/DefiRuntimeTests/RuntimeWidthLearningTests.swift
+++ b/Tests/DefiRuntimeTests/RuntimeWidthLearningTests.swift
@@ -6,6 +6,39 @@ import Testing
 
 struct RuntimeWidthConstraintTests {
   @Test
+  func discoveredNativeConstraintsReplaceLearnedBounds() {
+    let monitorID = MonitorID(rawValue: 1)
+    let windowID = WindowID(rawValue: 1)
+    var state = RuntimeState(config: Config())
+    state.attachMonitor(monitorID)
+    state.windows[windowID] = Window(
+      id: windowID,
+      appID: "editor",
+      title: "Editor",
+      frame: Rect(x: 0, y: 0, width: 900, height: 700),
+      monitorID: monitorID,
+      minimumTiledWidth: 700,
+      maximumTiledWidth: 1_000
+    )
+    state.monitors[0].workspaces[0].columns = [
+      Column(window: windowID, width: .fraction(0.5))
+    ]
+    let observed = Window(
+      id: windowID,
+      appID: "editor",
+      title: "Editor",
+      frame: Rect(x: 0, y: 0, width: 900, height: 700),
+      monitorID: monitorID,
+      minimumTiledWidth: 840
+    )
+
+    reconcileWindows([observed], config: Config(), state: &state)
+
+    #expect(state.windows[windowID]?.minimumTiledWidth == 840)
+    #expect(state.windows[windowID]?.maximumTiledWidth == nil)
+  }
+
+  @Test
   func cycleSkipsPresetWithTheSameEffectiveMinimumWidth() throws {
     let monitorID = MonitorID(rawValue: 1)
     let windowID = WindowID(rawValue: 1)


### PR DESCRIPTION
## Summary

- Render each monitor’s desktop background in the workspace overview.
- Keep floating windows positioned relative to the visible desktop area.
- Add projection and rendering coverage for desktop-aware layouts.

## Testing

- Not run.