### PR TITLE
fix: disable native position animation during navigation

### DIFF
--- a/Sources/DefiMacOS/AXFrameAccessibilityWriter.swift
+++ b/Sources/DefiMacOS/AXFrameAccessibilityWriter.swift
@@ -29,21 +29,8 @@ final class AXFrameAccessibilityWriter {
     _ write: AsyncPositionWrite,
     point: CGPoint,
     forceOffscreenAccess: Bool = false,
-    suppressNativeAnimation: Bool = false,
     enhancedUIManagedByBatch: Bool = false
   ) -> Bool {
-    if suppressNativeAnimation, write.enhancedUIWasEnabled {
-      // WindowServer can animate a successful offscreen-to-visible AX write.
-      if !enhancedUIManagedByBatch {
-        setEnhancedUserInterface(false, application: write.application)
-      }
-      defer {
-        if !enhancedUIManagedByBatch {
-          setEnhancedUserInterface(true, application: write.application)
-        }
-      }
-      return apply(write, point: point) == .success
-    }
     if write.isParked || forceOffscreenAccess {
       if !enhancedUIManagedByBatch {
         setEnhancedUserInterface(false, application: write.application)

--- a/Sources/DefiMacOS/AXFrameCoordinatorWrites.swift
+++ b/Sources/DefiMacOS/AXFrameCoordinatorWrites.swift
@@ -362,14 +362,14 @@ extension AXFrameCoordinator {
     let pendingEnhancedUIRestore = hasDeferredEnhancedUIRestore(
       processID: batch.processID
     )
+    // Keep native animation disabled through every position sample and its
+    // asynchronous consumption, including horizontal navigation.
     let defersEnhancedUIRestore =
       enhancedUIWasEnabled
       && (
         pendingEnhancedUIRestore
           || batch.writes.contains {
             DefiMacOS.defersEnhancedUIRestore(
-              stagesVisibleBeforeParking: frame.stagesVisibleBeforeParking,
-              isIntermediate: intermediate,
               enhancedUIWasEnabled: $0.value.enhancedUIWasEnabled,
               positionChanged: $0.value.positionChanged
             )
@@ -490,11 +490,6 @@ extension AXFrameCoordinator {
                 point: point,
                 forceOffscreenAccess: (stagingReentry && item.value.isReentering)
                   || (!intermediate && item.value.requiresVerifiedOffscreenWrite),
-                suppressNativeAnimation: suppressesNativePositionAnimation(
-                  stagesVisibleBeforeParking: frame.stagesVisibleBeforeParking,
-                  isParked: item.value.isParked,
-                  isIntermediate: intermediate
-                ),
                 enhancedUIManagedByBatch: managesEnhancedUI
                   || defersEnhancedUIRestore
               )

--- a/Sources/DefiMacOS/FrameCommit.swift
+++ b/Sources/DefiMacOS/FrameCommit.swift
@@ -396,22 +396,11 @@ func positionWritePhases(
     .filter { !$0.isEmpty }
 }
 
-func suppressesNativePositionAnimation(
-  stagesVisibleBeforeParking: Bool,
-  isParked: Bool,
-  isIntermediate: Bool
-) -> Bool {
-  stagesVisibleBeforeParking && !isParked && !isIntermediate
-}
-
 func defersEnhancedUIRestore(
-  stagesVisibleBeforeParking: Bool,
-  isIntermediate: Bool,
   enhancedUIWasEnabled: Bool,
   positionChanged: Bool
 ) -> Bool {
-  stagesVisibleBeforeParking && !isIntermediate
-    && enhancedUIWasEnabled && positionChanged
+  enhancedUIWasEnabled && positionChanged
 }
 
 func shouldApplyDeferredFocus(

--- a/Tests/DefiMacOSTests/FrameCommitTests.swift
+++ b/Tests/DefiMacOSTests/FrameCommitTests.swift
@@ -1122,55 +1122,21 @@ struct FrameCommitTests {
   }
 
   @Test
-  func `Only incoming workspace writes suppress native position animation`() {
-    #expect(
-      suppressesNativePositionAnimation(
-        stagesVisibleBeforeParking: true,
-        isParked: false,
-        isIntermediate: false
-      ))
-    #expect(
-      suppressesNativePositionAnimation(
-        stagesVisibleBeforeParking: true,
-        isParked: true,
-        isIntermediate: false
-      ) == false)
-    #expect(
-      suppressesNativePositionAnimation(
-        stagesVisibleBeforeParking: false,
-        isParked: false,
-        isIntermediate: false
-      ) == false)
-    #expect(
-      suppressesNativePositionAnimation(
-        stagesVisibleBeforeParking: true,
-        isParked: false,
-        isIntermediate: true
-      ) == false)
-  }
-
-  @Test
-  func `Final workspace writes defer enhanced UI restoration`() {
+  func `Position writes defer enhanced UI restoration throughout navigation`() {
     #expect(
       defersEnhancedUIRestore(
-        stagesVisibleBeforeParking: true,
-        isIntermediate: false,
         enhancedUIWasEnabled: true,
         positionChanged: true
       ))
     #expect(
       defersEnhancedUIRestore(
-        stagesVisibleBeforeParking: true,
-        isIntermediate: true,
-        enhancedUIWasEnabled: true,
+        enhancedUIWasEnabled: false,
         positionChanged: true
       ) == false)
     #expect(
       defersEnhancedUIRestore(
-        stagesVisibleBeforeParking: false,
-        isIntermediate: false,
         enhancedUIWasEnabled: true,
-        positionChanged: true
+        positionChanged: false
       ) == false)
   }
 


### PR DESCRIPTION
## Summary
- Defer enhanced UI restoration for every changed position write during navigation
- Remove the narrower workspace-entry animation suppression path
- Update frame commit unit coverage for horizontal and intermediate navigation

## Testing
- Updated unit tests in `FrameCommitTests`