### PR TITLE
docs: publish alpha installation instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ focused branch and conventional prefix such as `feat/`, `fix/`, `docs/`, or
 ## Release packaging
 
 Release archives are signed with a stable self-signed certificate and are not
-notarized. The planned Homebrew Cask removes quarantine automatically. For a
+notarized. The Homebrew Cask removes quarantine automatically. For a
 manual installation of an official release, move `Defi.app` to
 `/Applications`, then run:
 
@@ -99,9 +99,9 @@ xattr -dr com.apple.quarantine /Applications/Defi.app
 open /Applications/Defi.app
 ```
 
-Only use archives from the official Defi repository. Homebrew distribution
-should document `brew install --cask qeude/tap/defi` and
-`brew uninstall --cask --zap defi` once the Cask is published.
+Only use archives from the official Defi repository. Install through Homebrew
+with `brew install --cask qeude/tap/defi`; remove the app and its user data with
+`brew uninstall --cask --zap defi`.
 
 Create the stable self-signed release identity once:
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,20 @@ windows. Click a window, select it in the Dock, or use Command-Tab as usual.
 ## Get started
 
 Defi supports **Apple Silicon Macs running macOS 26 or newer**.
-The first public `v0.2.0-alpha` package is being prepared. For now, follow the
-[build from source guide](CONTRIBUTING.md#build-and-run).
+Install with Homebrew:
+
+```sh
+brew install --cask qeude/tap/defi
+open /Applications/Defi.app
+```
+
+The app is signed with a self-signed certificate and is not notarized. The
+Cask removes its quarantine attribute to allow it to open; only install if
+you trust this source.
+
+For manual installation, download the ZIP and follow the instructions in
+[the release notes](https://github.com/qeude/Defi/releases/tag/v0.2.0-alpha).
+You can also [build from source](CONTRIBUTING.md#build-and-run).
 
 The alpha is experimental. Behavior and configuration may change before the
 first stable release.
@@ -110,7 +122,10 @@ See the [command reference](CONFIGURATION.md#commands) for the full list.
 <details>
 <summary>Uninstall completely</summary>
 
-Run the CLI from your installed app:
+For a Homebrew installation, use `brew uninstall --cask --zap defi`.
+This also removes your configuration and saved state.
+
+For a manual or source installation, run the CLI from your installed app:
 
 ```sh
 ~/Applications/Defi.app/Contents/MacOS/defi uninstall --purge


### PR DESCRIPTION
Document the published v0.2.0-alpha release and Homebrew Cask. Explain the self-signed, non-notarized distribution and distinguish Homebrew uninstall from manual installation. Documentation only; public ZIP download and checksum verified.