### PR TITLE
fix: activate window management after Accessibility grant

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Defi is `0.2.0-alpha`: experimental macOS software. APIs, behavior, and
+Defi is experimental macOS software. APIs, behavior, and
 configuration may change before the first stable release.
 
 ## Prerequisites
@@ -121,7 +121,7 @@ After the required checks pass, create the non-notarized arm64 ZIP and checksum:
 The script validates the bundle signature and architecture, rejects private
 key material, provisioning profiles, personal source paths, and email addresses,
 then writes `Defi-v<version>.zip` and its SHA-256 file under `dist/`. Upload only
-those two files to the matching prerelease tag.
+those two files to the matching release tag.
 
 Finally, update `qeude/homebrew-tap` with the release URL and SHA-256. The Cask
 must install `Defi.app`, remove `com.apple.quarantine` in `postflight`, and zap:

--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ You can also [build from source](CONTRIBUTING.md#build-and-run).
 The alpha is experimental. Behavior and configuration may change before the
 first stable release.
 
-On first launch, grant Defi **Accessibility** access in System Settings, then
-quit and reopen it. Defi needs this permission to focus and arrange windows.
+On first launch, Defi requests **Accessibility** access. Grant it in System
+Settings; Defi starts managing windows automatically, without a restart.
+Defi needs this permission to focus and arrange windows.
 Screen Recording is only needed if you enable window previews in Overview.
 
 Enable **Launch at Login** in the menu bar if you want Defi to start with macOS.
@@ -142,7 +143,8 @@ Other Defi app bundles are preserved, but they share the removed user data.
 ## Troubleshooting
 
 If shortcuts do not respond, check Accessibility permission for the installed
-Defi app, then quit and reopen it. Check `default_key_modifier` in your config:
+Defi app; newly granted access is detected automatically. Check
+`default_key_modifier` in your config:
 custom Hyper bindings require a matching keyboard remap. Temporarily quit
 other window managers to rule out conflicting shortcuts or window moves.
 

--- a/Sources/DefiDaemon/DaemonConfiguration.swift
+++ b/Sources/DefiDaemon/DaemonConfiguration.swift
@@ -202,6 +202,7 @@ extension Daemon {
   }
 
   func installHotKeys() {
+    guard windowManagementStarted else { return }
     hotKeyGeneration &+= 1
     let generation = hotKeyGeneration
     let manager = HotKeyManager(

--- a/Sources/DefiDaemon/DaemonDesktopSynchronization.swift
+++ b/Sources/DefiDaemon/DaemonDesktopSynchronization.swift
@@ -43,7 +43,7 @@ extension Daemon {
     forceApplicationInventoryRefresh: Bool = false,
     consumePeriodicWindowRefresh: Bool = false
   ) {
-    guard desktopSessionActive else { return }
+    guard windowManagementStarted, desktopSessionActive else { return }
     let sessionGeneration = desktopSessionGeneration
     let requestedConfigGeneration = configGeneration
     let nativeFocusWasPending = platform.hasPendingNativeFocusEvent

--- a/Sources/DefiDaemon/DaemonStatusLifecycle.swift
+++ b/Sources/DefiDaemon/DaemonStatusLifecycle.swift
@@ -335,6 +335,7 @@ extension Daemon {
   }
 
   func shutdown() -> Never {
+    accessibilityPermissionMonitor.stop()
     handleCheatsheetInput(.dismiss)
     configWatcher?.stop()
     timer?.cancel()

--- a/Sources/DefiDaemon/DefiDaemon.swift
+++ b/Sources/DefiDaemon/DefiDaemon.swift
@@ -82,6 +82,8 @@ final class Daemon: NSObject {
   let configURL: URL
   var config: Config
   let platform = MacOSPlatform()
+  let accessibilityPermissionMonitor = AccessibilityPermissionMonitor()
+  var windowManagementStarted = false
   let server: UnixSocketServer
   let placementStore: PlacementStore
   let topologyStore: WorkspaceTopologyStore
@@ -224,11 +226,22 @@ final class Daemon: NSObject {
 
   func start() {
     installSignalHandlers()
-    let trusted = platform.accessibilityTrusted(prompt: false)
-    if !trusted {
-      log("Accessibility permission pending. Grant Defi access in System Settings.")
-      showAccessibilityOnboardingIfNeeded()
+    updateMenuBarAvailability()
+    startConfigWatcher()
+    installIPCSource()
+    accessibilityPermissionMonitor.start { [weak self] in
+      self?.startWindowManagement()
     }
+    if !windowManagementStarted {
+      log("Accessibility permission pending. Grant Defi access in System Settings.")
+    }
+    log("running; socket=\(server.url.path)")
+  }
+
+  private func startWindowManagement() {
+    guard !windowManagementStarted else { return }
+    windowManagementStarted = true
+    menuBar.refreshAccessibilityPermission()
     platform.startObserving(
       { [weak self] in
         guard let self, desktopSessionActive else { return }
@@ -254,9 +267,6 @@ final class Daemon: NSObject {
     )
 
     installHotKeys()
-    updateMenuBarAvailability()
-    startConfigWatcher()
-    installIPCSource()
 
     synchronizeDesktop(
       forceFullWindowRefresh: true,
@@ -264,7 +274,7 @@ final class Daemon: NSObject {
       forceApplicationInventoryRefresh: true
     )
     replaceTimer(frequencyHz: 2)
-    log("running; socket=\(server.url.path)")
+    log("Accessibility permission granted; window management started")
   }
 
   func handleDesktopSessionActivity(_ active: Bool) {
@@ -311,7 +321,7 @@ final class Daemon: NSObject {
   }
 
   func tick() {
-    guard desktopSessionActive else { return }
+    guard windowManagementStarted, desktopSessionActive else { return }
     processPendingHotKeys()
     finishPendingAnimatedFocusIfReady()
     finishPendingWorkspaceFocusIfReady()

--- a/Sources/DefiMacOS/AccessibilityPermissionMonitor.swift
+++ b/Sources/DefiMacOS/AccessibilityPermissionMonitor.swift
@@ -1,0 +1,65 @@
+import ApplicationServices
+import Foundation
+
+/// Waits for the initial AX grant without depending on an undocumented notification.
+@MainActor
+public final class AccessibilityPermissionMonitor {
+  static let notification = Notification.Name("com.apple.accessibility.api")
+  private let center: NotificationCenter
+  private let checkTrust: (Bool) -> Bool
+  private var observer: NSObjectProtocol?
+  private var timer: Timer?
+  private var onGranted: (() -> Void)?
+  private var started = false
+
+  public init(
+    center: NotificationCenter = DistributedNotificationCenter.default(),
+    checkTrust: @escaping (Bool) -> Bool = { prompt in
+      AXIsProcessTrustedWithOptions(
+        ["AXTrustedCheckOptionPrompt": prompt] as CFDictionary
+      )
+    }
+  ) {
+    self.center = center
+    self.checkTrust = checkTrust
+  }
+
+  public func start(onGranted: @escaping () -> Void) {
+    guard !started else { return }
+    started = true
+    self.onGranted = onGranted
+    refresh()
+    guard self.onGranted != nil else { return }
+    // This notification is a hint only. Always confirm trust through the public API.
+    observer = center.addObserver(forName: Self.notification, object: nil, queue: .main) {
+      [weak self] _ in
+      MainActor.assumeIsolated { self?.refresh() }
+    }
+    let timer = Timer(timeInterval: 1, repeats: true) { [weak self] _ in
+      MainActor.assumeIsolated { self?.refresh() }
+    }
+    self.timer = timer
+    RunLoop.main.add(timer, forMode: .common)
+    _ = checkTrust(true)
+    refresh()
+  }
+
+  func refresh() {
+    guard let onGranted, checkTrust(false) else { return }
+    stop()
+    onGranted()
+  }
+
+  public func stop() {
+    timer?.invalidate()
+    timer = nil
+    if let observer { center.removeObserver(observer) }
+    observer = nil
+    onGranted = nil
+  }
+
+  isolated deinit {
+    timer?.invalidate()
+    if let observer { center.removeObserver(observer) }
+  }
+}

--- a/Sources/DefiMacOS/PermissionAlerts.swift
+++ b/Sources/DefiMacOS/PermissionAlerts.swift
@@ -1,26 +1,6 @@
 import AppKit
 
 @MainActor
-public func showAccessibilityOnboardingIfNeeded() {
-  let defaults = UserDefaults.standard
-  let key = "didShowAccessibilityOnboarding"
-  guard defaults.bool(forKey: key) == false else { return }
-  defaults.set(true, forKey: key)
-
-  let alert = NSAlert()
-  alert.alertStyle = .informational
-  alert.messageText = "Allow Defi to Manage Windows"
-  alert.informativeText =
-    "Defi needs Accessibility permission to discover, focus, move, and resize windows."
-  alert.addButton(withTitle: "Open Accessibility Settings")
-  alert.addButton(withTitle: "Later")
-  NSApplication.shared.activate(ignoringOtherApps: true)
-  if alert.runModal() == .alertFirstButtonReturn {
-    openDefiAccessibilitySettings()
-  }
-}
-
-@MainActor
 public func presentDefiStartupError(_ error: Error) {
   guard Bundle.main.bundleURL.pathExtension == "app" else { return }
   NSApplication.shared.setActivationPolicy(.accessory)

--- a/Support/Defi-Info.plist
+++ b/Support/Defi-Info.plist
@@ -13,9 +13,9 @@
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.2.0-alpha</string>
+  <string>0.2.1</string>
   <key>CFBundleVersion</key>
-  <string>2</string>
+  <string>3</string>
   <key>LSMinimumSystemVersion</key>
   <string>26.0</string>
   <key>LSUIElement</key>

--- a/Tests/DefiMacOSTests/AccessibilityPermissionMonitorTests.swift
+++ b/Tests/DefiMacOSTests/AccessibilityPermissionMonitorTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+@testable import DefiMacOS
+
+@MainActor
+struct AccessibilityPermissionMonitorTests {
+  @Test
+  func promptsOnceAndStartsOnceAfterNotification() {
+    let center = NotificationCenter()
+    var trusted = false
+    var prompts = 0
+    var starts = 0
+    let monitor = AccessibilityPermissionMonitor(center: center) { prompt in
+      if prompt { prompts += 1 }
+      return trusted
+    }
+    monitor.start { starts += 1 }
+    monitor.start { starts += 1 }
+    #expect(prompts == 1)
+    #expect(starts == 0)
+    center.post(name: AccessibilityPermissionMonitor.notification, object: nil)
+    #expect(starts == 0)
+    trusted = true
+    center.post(name: AccessibilityPermissionMonitor.notification, object: nil)
+    #expect(starts == 1)
+    monitor.refresh()
+    center.post(name: AccessibilityPermissionMonitor.notification, object: nil)
+    #expect(starts == 1)
+    #expect(prompts == 1)
+  }
+
+  @Test
+  func fallbackDetectsGrantAndStopCancelsStartup() {
+    var trusted = false
+    var starts = 0
+    let monitor = AccessibilityPermissionMonitor(center: NotificationCenter()) { _ in trusted }
+    monitor.start { starts += 1 }
+    trusted = true
+    monitor.refresh()
+    monitor.refresh()
+    #expect(starts == 1)
+
+    trusted = false
+    let cancelled = AccessibilityPermissionMonitor(center: NotificationCenter()) { _ in trusted }
+    cancelled.start { starts += 1 }
+    cancelled.stop()
+    trusted = true
+    cancelled.refresh()
+    #expect(starts == 1)
+  }
+
+  @Test
+  func alreadyTrustedStartsWithoutPrompt() {
+    var prompts = 0
+    var starts = 0
+    let monitor = AccessibilityPermissionMonitor(center: NotificationCenter()) { prompt in
+      if prompt { prompts += 1 }
+      return true
+    }
+    monitor.start { starts += 1 }
+    monitor.start { starts += 1 }
+    #expect(starts == 1)
+    #expect(prompts == 0)
+  }
+}


### PR DESCRIPTION
## Summary
- Request Accessibility access through the native macOS prompt.
- Start window observation and hotkeys after permission is granted, without restarting Defi.
- Use Accessibility notifications as hints, with a public trust check and a one-second fallback while waiting.
- Remove the old one-time modal and update onboarding instructions.
- Bump the app to 0.2.1, build 3.

## Validation
- swift build and all 763 tests pass on the latest main.
- Signed installed build verified with the existing Defi Release identity.
- Real permission-off to permission-on test kept PID 56485: 54 bindings and 16 windows became active without restart.
- Exactly one daemon remained running.