### PR TITLE
ci: automate signed releases and Homebrew updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,11 @@ jobs:
         # DesktopE2ETests require a real interactive session and Accessibility permission.
         run: swift test --skip DesktopE2ETests
 
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: '1.25.x'
+          cache: false
+
       - name: Release automation checks
         run: |
           go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,8 @@ jobs:
       - name: Deterministic tests
         # DesktopE2ETests require a real interactive session and Accessibility permission.
         run: swift test --skip DesktopE2ETests
+
+      - name: Release automation checks
+        run: |
+          go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.11
+          bash Tests/Release/test_homebrew_release.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,131 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+  # Manual runs verify signing and packaging without publishing anything.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  validate:
+    runs-on: macos-26
+    timeout-minutes: 15
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Validate version and source
+        id: version
+        env:
+          RELEASE_EVENT: ${{ github.event_name }}
+        run: |
+          version="$(plutil -extract CFBundleShortVersionString raw -o - Support/Defi-Info.plist)"
+          [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?$ ]] || exit 1
+          git merge-base --is-ancestor HEAD origin/main
+          if [[ "$RELEASE_EVENT" == push ]]; then
+            [[ "$GITHUB_REF" == "refs/tags/v$version" ]] || exit 1
+          else
+            [[ "$GITHUB_REF" == refs/heads/main ]] || exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - run: swift build
+      - run: swift test --skip DesktopE2ETests
+
+  release:
+    needs: validate
+    runs-on: macos-26
+    timeout-minutes: 20
+    environment: release
+    permissions:
+      contents: write
+    env:
+      VERSION: ${{ needs.validate.outputs.version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Import release identity into temporary keychain
+        env:
+          P12_BASE64: ${{ secrets.DEFI_RELEASE_P12_BASE64 }}
+          P12_PASSWORD: ${{ secrets.DEFI_RELEASE_P12_PASSWORD }}
+        run: |
+          umask 077
+          test -n "$P12_BASE64"
+          test -n "$P12_PASSWORD"
+          keychain="$RUNNER_TEMP/defi-release.keychain-db"
+          keychain_password="$(openssl rand -hex 32)"
+          echo "::add-mask::$keychain_password"
+          printf '%s' "$P12_BASE64" | base64 --decode > "$RUNNER_TEMP/defi-release.p12"
+          security create-keychain -p "$keychain_password" "$keychain"
+          security set-keychain-settings -lut 3600 "$keychain"
+          security unlock-keychain -p "$keychain_password" "$keychain"
+          security import "$RUNNER_TEMP/defi-release.p12" -k "$keychain" \
+            -P "$P12_PASSWORD" -T /usr/bin/codesign >/dev/null
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$keychain_password" "$keychain" >/dev/null
+          security list-keychains -d user -s "$keychain"
+          security find-certificate -c 'Defi Release' -p "$keychain" > "$RUNNER_TEMP/defi-release.cer"
+          # Pin the existing public certificate so updates retain their TCC identity.
+          fingerprint="$(openssl x509 -in "$RUNNER_TEMP/defi-release.cer" -outform DER | shasum -a 1 | cut -d ' ' -f 1)"
+          [[ "$fingerprint" == b81a903423676253b0eff36c4cdfbe3351742b68 ]] || exit 1
+          sudo security add-trusted-cert -d -r trustRoot -p codeSign -k "$keychain" "$RUNNER_TEMP/defi-release.cer"
+      - name: Package signed arm64 app
+        run: ./script/package_release.sh
+      - name: Clean up signing material
+        if: always()
+        run: |
+          if [[ -f "$RUNNER_TEMP/defi-release.keychain-db" ]]; then
+            security delete-keychain "$RUNNER_TEMP/defi-release.keychain-db"
+          fi
+          rm -f "$RUNNER_TEMP/defi-release.p12" "$RUNNER_TEMP/defi-release.cer"
+      - name: Publish release
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Never replace an already-published archive on a retry.
+          if gh release view "v$VERSION" >/dev/null 2>&1; then
+            [[ "$(gh release view "v$VERSION" --json isDraft --jq .isDraft)" == true ]] || exit 1
+          else
+            gh release create "v$VERSION" --verify-tag --draft --generate-notes --title "Defi v$VERSION"
+          fi
+          gh release upload "v$VERSION" "dist/Defi-v$VERSION.zip" "dist/Defi-v$VERSION.zip.sha256" --clobber
+          if [[ "$VERSION" == *-* ]]; then
+            gh release edit "v$VERSION" --draft=false --prerelease --latest=false
+          else
+            gh release edit "v$VERSION" --draft=false --latest
+          fi
+  homebrew:
+    needs: [validate, release]
+    if: github.event_name == 'push' && !contains(needs.validate.outputs.version, '-')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: release
+    env:
+      VERSION: ${{ needs.validate.outputs.version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Download published checksum
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release download "v$VERSION" --pattern "Defi-v$VERSION.zip.sha256" --dir "$RUNNER_TEMP"
+      - name: Open Homebrew update PR
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: ./script/update_homebrew_release.sh "$VERSION" "$RUNNER_TEMP/Defi-v$VERSION.zip.sha256"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,7 @@ installed service, but do not run them while important unsaved work is exposed.
 | `resolve_signing_identity.sh` | Select the signing identity for the build script. |
 | `setup_release_certificate.sh` | Create the stable local release certificate. |
 | `package_release.sh` | Package the signed app as a ZIP with a checksum. |
+| `update_homebrew_release.sh` | Open a Cask update PR using a published release checksum. |
 | `test_desktop.sh` | Stop Defi, run desktop tests, and restore the app. |
 
 ## Code boundaries
@@ -110,7 +111,45 @@ Create the stable self-signed release identity once:
 ```
 
 Back up `Defi Release` from Keychain Access to encrypted offline storage. Never
-commit or upload the exported private key.
+commit the exported private key or attach it to a release. The encrypted export
+may be stored only as a protected GitHub Actions secret for automated signing.
+
+### Automated releases
+
+After merging the version and build-number changes in `Support/Defi-Info.plist`,
+push a matching tag from `main`, for example `v0.2.2`. The Release workflow checks
+the version and ancestry, runs the build and tests, then waits for approval of
+the `release` environment. Inspect the tagged commit before approving it.
+
+The signing job uses a temporary keychain, verifies the existing certificate
+fingerprint, packages the app, and removes the signing files. It publishes only
+the ZIP and checksum. Stable tags then open a PR in `qeude/homebrew-tap`, which
+must be reviewed and merged separately. Prerelease tags do not update the Cask.
+
+Configure the `release` environment with a required maintainer reviewer and
+deployment rules allowing only `v*` tags and `main`. Store these environment secrets:
+
+- `DEFI_RELEASE_P12_BASE64`: Base64-encoded encrypted export of the existing
+  `Defi Release` certificate **and private key**.
+- `DEFI_RELEASE_P12_PASSWORD`: the export password.
+- `HOMEBREW_TAP_TOKEN`: a fine-grained token restricted to `qeude/homebrew-tap`,
+  with Contents and Pull requests read/write access. Renew it before expiration.
+
+The maintainer can approve their own deployment, so a solo-maintained repository
+does not require a second account. Homebrew is a separate job and may require
+another environment approval. If it fails, rerun only that failed job; it reads
+the published checksum and does not rebuild or replace the release.
+
+Use **Actions → Release → Run workflow** on `main` to verify signing and
+packaging without publishing a release or creating a Homebrew PR. A published
+release cannot be overwritten by a workflow retry. A failed draft upload can
+be retried before publication.
+
+See GitHub's [certificate setup](https://docs.github.com/en/actions/how-tos/deploy/deploy-to-third-party-platforms/sign-xcode-applications)
+and [environment protection](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments)
+documentation for secret storage and approval controls.
+
+### Local packaging
 
 After the required checks pass, create the non-notarized arm64 ZIP and checksum:
 

--- a/Tests/Release/test_homebrew_release.sh
+++ b/Tests/Release/test_homebrew_release.sh
@@ -11,6 +11,9 @@ printf '%s  Defi-v0.2.2.zip\n' "$CHECKSUM" > "$TEST_DIR/checksum"
 gh() {
   case "$*" in
     'api repos/qeude/homebrew-tap/git/ref/heads/'*) printf 'base-sha\n' ;;
+    'api repos/qeude/homebrew-tap/merges '*)
+      [[ "${MERGE_CONFLICT:-0}" == 0 ]] || return 1
+      ;;
     'api repos/qeude/homebrew-tap/contents/'*)
       local fixture
       fixture=$'cask "defi" do\n  version "0.2.1"\n  sha256 "old"\n  # preserve this\nend\n'
@@ -40,6 +43,9 @@ result="$(GH_TOKEN=test bash "$ROOT/script/update_homebrew_release.sh" 0.2.2 "$T
 [[ "$result" == 'PR created' ]] || exit 1
 if BAD_FORMAT=1 GH_TOKEN=test bash "$ROOT/script/update_homebrew_release.sh" 0.2.2 "$TEST_DIR/checksum" 2>/dev/null; then
   echo 'Accepted an unexpected Cask format' >&2; exit 1
+fi
+if MERGE_CONFLICT=1 GH_TOKEN=test bash "$ROOT/script/update_homebrew_release.sh" 0.2.2 "$TEST_DIR/checksum"; then
+  echo 'Continued after a retry merge conflict' >&2; exit 1
 fi
 for version in '0.2.2-alpha' '../main' '0.2.3'; do
   if GH_TOKEN=test bash "$ROOT/script/update_homebrew_release.sh" "$version" "$TEST_DIR/checksum"; then

--- a/Tests/Release/test_homebrew_release.sh
+++ b/Tests/Release/test_homebrew_release.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_DIR="$(mktemp -d)"
+trap 'rm -f "$TEST_DIR/checksum"; rmdir "$TEST_DIR"' EXIT
+CHECKSUM="$(printf '%064d' 1)"
+printf '%s  Defi-v0.2.2.zip\n' "$CHECKSUM" > "$TEST_DIR/checksum"
+
+# No GitHub writes: exercise the script through a fake CLI boundary.
+gh() {
+  case "$*" in
+    'api repos/qeude/homebrew-tap/git/ref/heads/'*) printf 'base-sha\n' ;;
+    'api repos/qeude/homebrew-tap/contents/'*)
+      local fixture
+      fixture=$'cask "defi" do\n  version "0.2.1"\n  sha256 "old"\n  # preserve this\nend\n'
+      if [[ "${BAD_FORMAT:-0}" == 1 ]]; then fixture='unexpected format'; fi
+      jq -n --arg content "$(printf '%s' "$fixture" | base64)" '{sha:"file-sha", content:$content}'
+      ;;
+    'api --method PUT '*)
+      local argument content=''
+      for argument in "$@"; do
+        if [[ "$argument" == content=* ]]; then content="${argument#content=}"; fi
+      done
+      local updated
+      updated="$(printf '%s' "$content" | base64 --decode)"
+      [[ "$updated" == *'version "0.2.2"'* ]]
+      [[ "$updated" == *"sha256 \"$CHECKSUM\""* ]]
+      [[ "$updated" == *'# preserve this'* ]]
+      ;;
+    'pr list '*) printf '0\n' ;;
+    'pr create '*) printf 'PR created\n' ;;
+    *) echo "Unexpected gh invocation: $*" >&2; return 1 ;;
+  esac
+}
+export -f gh
+export CHECKSUM
+
+result="$(GH_TOKEN=test bash "$ROOT/script/update_homebrew_release.sh" 0.2.2 "$TEST_DIR/checksum")"
+[[ "$result" == 'PR created' ]]
+if BAD_FORMAT=1 GH_TOKEN=test bash "$ROOT/script/update_homebrew_release.sh" 0.2.2 "$TEST_DIR/checksum" 2>/dev/null; then
+  echo 'Accepted an unexpected Cask format' >&2; exit 1
+fi
+for version in '0.2.2-alpha' '../main' '0.2.3'; do
+  if GH_TOKEN=test bash "$ROOT/script/update_homebrew_release.sh" "$version" "$TEST_DIR/checksum"; then
+    echo 'Accepted an invalid version or mismatched checksum filename' >&2; exit 1
+  fi
+done
+echo 'Homebrew release checks passed'

--- a/Tests/Release/test_homebrew_release.sh
+++ b/Tests/Release/test_homebrew_release.sh
@@ -24,9 +24,9 @@ gh() {
       done
       local updated
       updated="$(printf '%s' "$content" | base64 --decode)"
-      [[ "$updated" == *'version "0.2.2"'* ]]
-      [[ "$updated" == *"sha256 \"$CHECKSUM\""* ]]
-      [[ "$updated" == *'# preserve this'* ]]
+      [[ "$updated" == *'version "0.2.2"'* &&
+         "$updated" == *"sha256 \"$CHECKSUM\""* &&
+         "$updated" == *'# preserve this'* ]] || return 1
       ;;
     'pr list '*) printf '0\n' ;;
     'pr create '*) printf 'PR created\n' ;;
@@ -37,7 +37,7 @@ export -f gh
 export CHECKSUM
 
 result="$(GH_TOKEN=test bash "$ROOT/script/update_homebrew_release.sh" 0.2.2 "$TEST_DIR/checksum")"
-[[ "$result" == 'PR created' ]]
+[[ "$result" == 'PR created' ]] || exit 1
 if BAD_FORMAT=1 GH_TOKEN=test bash "$ROOT/script/update_homebrew_release.sh" 0.2.2 "$TEST_DIR/checksum" 2>/dev/null; then
   echo 'Accepted an unexpected Cask format' >&2; exit 1
 fi

--- a/script/package_release.sh
+++ b/script/package_release.sh
@@ -23,8 +23,8 @@ DEFI_BUILD_ARCH=arm64 \
 DEFI_CODESIGN_IDENTITY="$IDENTITY" \
   "$ROOT_DIR/script/build_and_run.sh" --stage
 
-[[ "$(lipo -archs "$APP_BUNDLE/Contents/MacOS/defi-daemon")" == "arm64" ]]
-[[ "$(lipo -archs "$APP_BUNDLE/Contents/MacOS/defi")" == "arm64" ]]
+[[ "$(lipo -archs "$APP_BUNDLE/Contents/MacOS/defi-daemon")" == "arm64" ]] || exit 1
+[[ "$(lipo -archs "$APP_BUNDLE/Contents/MacOS/defi")" == "arm64" ]] || exit 1
 codesign --verify --deep --strict --verbose=2 "$APP_BUNDLE"
 codesign -dvv "$APP_BUNDLE" 2>&1 \
   | grep -F "Authority=$IDENTITY" >/dev/null

--- a/script/update_homebrew_release.sh
+++ b/script/update_homebrew_release.sh
@@ -14,6 +14,9 @@ BRANCH="release/defi-$VERSION"
 BASE_SHA="$(gh api "repos/$REPO/git/ref/heads/main" --jq .object.sha)"
 if ! gh api "repos/$REPO/git/ref/heads/$BRANCH" >/dev/null 2>&1; then
   gh api "repos/$REPO/git/refs" -f ref="refs/heads/$BRANCH" -f sha="$BASE_SHA" >/dev/null
+else
+  # Preserve existing edits on retry; conflicts require maintainer resolution.
+  gh api "repos/$REPO/merges" -f base="$BRANCH" -f head="$BASE_SHA" >/dev/null
 fi
 FILE_JSON="$(gh api "repos/$REPO/contents/Casks/defi.rb?ref=$BRANCH")"
 FILE_SHA="$(printf '%s' "$FILE_JSON" | jq -r .sha)"

--- a/script/update_homebrew_release.sh
+++ b/script/update_homebrew_release.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="${1:?usage: update_homebrew_release.sh VERSION CHECKSUM_FILE}"
+CHECKSUM_FILE="${2:?missing checksum file}"
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || exit 1
+SHA256="$(cut -d ' ' -f 1 "$CHECKSUM_FILE")"
+[[ "$SHA256" =~ ^[0-9a-f]{64}$ ]] || exit 1
+[[ "$(< "$CHECKSUM_FILE")" == "$SHA256  Defi-v$VERSION.zip" ]] || exit 1
+: "${GH_TOKEN:?Set HOMEBREW_TAP_TOKEN with contents and pull-requests write access to qeude/homebrew-tap}"
+
+REPO=qeude/homebrew-tap
+BRANCH="release/defi-$VERSION"
+BASE_SHA="$(gh api "repos/$REPO/git/ref/heads/main" --jq .object.sha)"
+if ! gh api "repos/$REPO/git/ref/heads/$BRANCH" >/dev/null 2>&1; then
+  gh api "repos/$REPO/git/refs" -f ref="refs/heads/$BRANCH" -f sha="$BASE_SHA" >/dev/null
+fi
+FILE_JSON="$(gh api "repos/$REPO/contents/Casks/defi.rb?ref=$BRANCH")"
+FILE_SHA="$(printf '%s' "$FILE_JSON" | jq -r .sha)"
+CONTENT="$(printf '%s' "$FILE_JSON" | jq -r .content | base64 --decode \
+  | ruby -e '
+    text = STDIN.read
+    abort "Unexpected Cask format" unless text.scan(/^  version ".*"$/).size == 1 && text.scan(/^  sha256 ".*"$/).size == 1
+    text.sub!(/^  version ".*"$/, "  version \"#{ARGV[0]}\"")
+    text.sub!(/^  sha256 ".*"$/, "  sha256 \"#{ARGV[1]}\"")
+    print text
+  ' "$VERSION" "$SHA256" | base64 | tr -d '\n')"
+gh api --method PUT "repos/$REPO/contents/Casks/defi.rb" \
+  -f message="chore: update Defi to $VERSION" -f branch="$BRANCH" \
+  -f sha="$FILE_SHA" -f content="$CONTENT" >/dev/null
+if [[ "$(gh pr list --repo "$REPO" --head "$BRANCH" --json number --jq length)" == 0 ]]; then
+  gh pr create --repo "$REPO" --base main --head "$BRANCH" \
+    --title "chore: update Defi to $VERSION" \
+    --body "Update to https://github.com/qeude/Defi/releases/tag/v$VERSION. SHA-256: $SHA256."
+fi


### PR DESCRIPTION
## Summary
- Validate tag/version and main ancestry, then build and test before protected release approval.
- Import the existing signing identity into a temporary keychain, pin its public certificate fingerprint, package with the existing script, and clean up signing files.
- Publish ZIP and SHA-256 without replacing published releases.
- Open a separate Homebrew update PR using a narrowly scoped token; retry that job independently of publication.
- Add a manual signing/package verification run that never publishes.
- Document environment secrets, approvals, token renewal, and release steps.

## Validation
- swift build and all 763 Swift tests pass.
- actionlint v1.7.11 passes.
- Mocked Homebrew CLI regression checks pass, including malformed Cask and version/checksum rejection.
- No app/runtime behavior changes; existing installed daemon left running.
- Protected release environment configured; certificate and export password stored as environment secrets.
- Hosted signing still needs the manual verification run after merge. No new release is created by this PR.