### PR TITLE
fix(runtime): block cross-app pointer focus while a modal holds selection

### DIFF
--- a/Sources/DefiRuntime/FocusSelection.swift
+++ b/Sources/DefiRuntime/FocusSelection.swift
@@ -167,6 +167,20 @@ public func modalAllowsPointerFocus(
   while let current = candidate, ancestry.insert(current).inserted {
     candidate = state.windows[current]?.transientOwnerID
   }
+  // A focused modal holds an open decision: pointer travel toward its buttons
+  // crosses other windows, and that transit must not refocus them in another
+  // application, where activation would bury the dialog behind the new
+  // frontmost app. Same-application targets keep the existing below, since
+  // no app switch can demote the modal.
+  if let selectedID = state.selectedWindowID(on: location.monitorID),
+    selectedID != windowID,
+    let selected = state.windows[selectedID],
+    selected.isModal,
+    selected.appID != target.appID,
+    !ancestry.contains(selectedID)
+  {
+    return false
+  }
   let ownerlessModalIDs = Set(state.windows.values.lazy.filter { modal in
     modal.appID == target.appID
       && (target.processID.map { modal.processID == $0 } ?? true)

--- a/Tests/DefiRuntimeTests/PointerFocusTests.swift
+++ b/Tests/DefiRuntimeTests/PointerFocusTests.swift
@@ -287,6 +287,44 @@ struct PointerFocusTests {
   }
 
   @Test
+  func focusedModalOfAnotherAppBlocksPointerFocus() throws {
+    var state = try makeState(columnWidths: [0.5, 0.5])
+    let documentID = WindowID(rawValue: 1)
+    let modalID = WindowID(rawValue: 2)
+    state.windows[documentID]?.appID = "editor"
+    state.windows[modalID]?.appID = "com.apple.finder"
+    state.windows[modalID]?.isModal = true
+    _ = focusWindow(modalID, state: &state)
+    #expect(state.selectedWindowID(on: monitorID) == modalID)
+
+    #expect(modalAllowsPointerFocus(documentID, state: state) == false)
+    #expect(modalAllowsPointerFocus(modalID, state: state))
+  }
+
+  @Test
+  func pointerFocusFromTransitOverDocumentKeepsFocusedModal() throws {
+    var state = try makeState(columnWidths: [0.5, 0.5])
+    let documentID = WindowID(rawValue: 1)
+    let modalID = WindowID(rawValue: 2)
+    state.windows[documentID]?.appID = "editor"
+    state.windows[modalID]?.appID = "com.apple.finder"
+    state.windows[modalID]?.isModal = true
+    _ = focusWindow(modalID, state: &state)
+    let original = state
+
+    #expect(
+      focusWindowFromPointer(
+        documentID,
+        activeMonitorID: monitorID,
+        state: &state,
+        viewports: [monitorID: viewport],
+        maximumScrollAmount: 0
+      ) == nil
+    )
+    #expect(state == original)
+  }
+
+  @Test
   func alreadySelectedPointerTargetCanRestoreNativeFocus() throws {
     var state = try makeState(columnWidths: [0.4, 0.4])
     let original = state


### PR DESCRIPTION
## Why

Hovering a window in another application stole focus while a modal dialog (e.g. Finder empty-trash confirmation) held the selection. Activating the other app buried the dialog behind it. Pointer travel toward the dialog's own buttons crosses other windows, and that transit must not refocus them.

## Changes

- `modalAllowsPointerFocus` now denies pointer focus to another application's windows while the selected window on the target monitor is modal (modal itself and its descendants stay eligible).
- Same-application targets keep the existing modal policy — no app switch can demote the modal there.

## How to test

- `python3 script/verify.py local` (build + unit tests + workflow tests).
- Live: open the Finder empty-trash confirmation from a strip workspace, hover another app's window → focus stays; hover within the same app unchanged.