### PR TITLE
fix(focus): admit unambiguous app activations without AX

### DIFF
--- a/Sources/DefiMacOS/MacOSPlatform+Snapshot.swift
+++ b/Sources/DefiMacOS/MacOSPlatform+Snapshot.swift
@@ -696,12 +696,12 @@ extension SnapshotEngine {
       requiresConfirmedWindow: activation != nil
     )
     if focusedWindowID == nil, let activation {
-      // AX confirmation lags genuine activation on slow apps. When the
-      // frontmost process owns exactly one managed window there is no
+      // AX confirmation lags genuine activation on slow apps. A fresh read
+      // proving the frontmost process owns exactly one window leaves no
       // ambiguity to resolve, so admit it without waiting for AX.
-      // Multi-window processes keep requiring AX confirmation.
-      if let fallback = singleManagedWindowID(
-        processID: frontmostProcessID,
+      // Anything else keeps requiring AX confirmation.
+      if let fallback = singleFreshWindowID(
+        frontmostProcessID: frontmostProcessID,
         in: windows
       ) {
         focusedWindowID = fallback

--- a/Sources/DefiMacOS/MacOSPlatform+Snapshot.swift
+++ b/Sources/DefiMacOS/MacOSPlatform+Snapshot.swift
@@ -690,11 +690,31 @@ extension SnapshotEngine {
     let activation = userInputTracker.pendingApplicationActivation(
       frontmostProcessID: frontmostProcessID
     )
-    let focusedWindowID = focusedWindowID(
+    var focusedWindowID = focusedWindowID(
       in: windows,
       frontmostProcessID: frontmostProcessID,
       requiresConfirmedWindow: activation != nil
     )
+    if focusedWindowID == nil, let activation {
+      // AX confirmation lags genuine activation on slow apps. When the
+      // frontmost process owns exactly one managed window there is no
+      // ambiguity to resolve, so admit it without waiting for AX.
+      // Multi-window processes keep requiring AX confirmation.
+      if let fallback = singleManagedWindowID(
+        processID: frontmostProcessID,
+        in: windows
+      ) {
+        focusedWindowID = fallback
+        frameCoordinator.recordTrace(
+          "native-activation-single-window pid=\(activation.processID) target=\(fallback.rawValue)"
+        )
+      } else if lastUnconfirmedActivationTimestamp != activation.timestamp {
+        lastUnconfirmedActivationTimestamp = activation.timestamp
+        frameCoordinator.recordTrace(
+          "native-activation-unconfirmed pid=\(activation.processID)"
+        )
+      }
+    }
     lastNativeFocusedWindowID = focusedWindowID
     verifiedNativeFocusedWindowID = focusedWindowID
     if let focusedWindowID,

--- a/Sources/DefiMacOS/PlatformEventMonitor.swift
+++ b/Sources/DefiMacOS/PlatformEventMonitor.swift
@@ -70,9 +70,14 @@ final class PlatformEventMonitor {
             NSWorkspace.applicationUserInfoKey
           ] as? NSRunningApplication)?.processIdentifier
         MainActor.assumeIsolated {
-          if let processID,
-            NSWorkspace.shared.frontmostApplication?.processIdentifier == processID
-          {
+          // The notification PID is authoritative. Do not gate on the current
+          // frontmost app here: slow-activating apps (e.g. Electron) lag
+          // behind the notification, and dropping the token strands Dock and
+          // Cmd-Tab focus with no usable intent. Snapshot-time
+          // pendingApplicationActivation revalidates against the current
+          // frontmost app within a 2s bound, so a stale token cannot be
+          // admitted later.
+          if let processID {
             self?.userInputTracker.recordApplicationActivation(processID: processID)
           }
           self?.handler(.focus, processID)

--- a/Sources/DefiMacOS/SnapshotEngine.swift
+++ b/Sources/DefiMacOS/SnapshotEngine.swift
@@ -267,6 +267,11 @@ final class SnapshotEngine: @unchecked Sendable {
     set { read { $0.verifiedNativeFocusedWindowID = newValue } }
   }
 
+  var lastUnconfirmedActivationTimestamp: TimeInterval? {
+    get { read { $0.lastUnconfirmedActivationTimestamp } }
+    set { read { $0.lastUnconfirmedActivationTimestamp = newValue } }
+  }
+
   // MARK: registries
 
   var elements: [WindowID: AXUIElement] {
@@ -1286,6 +1291,7 @@ private struct Storage {
   var pendingFrameDebtWindowIDs: Set<WindowID> = Set<WindowID>()
   var lastNativeFocusedWindowID: WindowID? = nil
   var verifiedNativeFocusedWindowID: WindowID? = nil
+  var lastUnconfirmedActivationTimestamp: TimeInterval?
 }
 
 /// A discovery cutoff. Observations recorded after consumption belong to the next pass.

--- a/Sources/DefiMacOS/SnapshotEngine.swift
+++ b/Sources/DefiMacOS/SnapshotEngine.swift
@@ -1015,6 +1015,35 @@ extension SnapshotEngine {
     )
   }
 
+  /// Activation fallback for slow-AX processes. When AX focus confirmation
+  /// lags a genuine app activation, performs one bounded fresh read of the
+  /// frontmost process's AX window list and admits its window only when that
+  /// read proves there is exactly one window and it is the single managed
+  /// one. A sibling created but not yet discovered appears in the fresh
+  /// list, forcing nil so multi-window cases keep requiring AX
+  /// confirmation. Returns nil for unknown processes and on AX timeout.
+  func singleFreshWindowID(
+    frontmostProcessID: pid_t?,
+    in windows: [Window]
+  ) -> WindowID? {
+    guard let frontmostProcessID,
+      let appElement = applications[frontmostProcessID]
+    else { return nil }
+    let rawWindows: [AXUIElement]? = AXMessagingTimeoutAccess.shared.withTimeout(
+      focusSnapshotAccessibilityTimeoutSeconds,
+      elements: [appElement]
+    ) {
+      copyElements(appElement, attribute: kAXWindowsAttribute)
+    }
+    guard rawWindows?.count == 1,
+      let rawWindow = rawWindows?.first,
+      let match = singleManagedWindowID(processID: frontmostProcessID, in: windows),
+      let element = elements[match],
+      CFEqual(rawWindow, element)
+    else { return nil }
+    return match
+  }
+
   func stableWindowID(
     processID: pid_t?,
     in windows: [Window],

--- a/Sources/DefiModel/Window.swift
+++ b/Sources/DefiModel/Window.swift
@@ -60,3 +60,20 @@ public enum FloatingOrigin: String, Equatable, Codable, Sendable {
   case configured
   case user
 }
+
+/// Resolves an activated process to its window only when there is no
+/// ambiguity to get wrong: exactly one managed window belongs to it.
+/// Multi-window processes return nil so callers keep requiring AX
+/// confirmation instead of picking an arbitrary window by PID.
+public func singleManagedWindowID(
+  processID: Int32?,
+  in windows: [Window]
+) -> WindowID? {
+  guard let processID else { return nil }
+  var match: WindowID?
+  for window in windows where window.processID == processID {
+    guard match == nil else { return nil }
+    match = window.id
+  }
+  return match
+}

--- a/Sources/DefiModel/Window.swift
+++ b/Sources/DefiModel/Window.swift
@@ -65,6 +65,12 @@ public enum FloatingOrigin: String, Equatable, Codable, Sendable {
 /// ambiguity to get wrong: exactly one managed window belongs to it.
 /// Multi-window processes return nil so callers keep requiring AX
 /// confirmation instead of picking an arbitrary window by PID.
+///
+/// The supplied array must be a complete set for the process. Discovery
+/// snapshots can temporarily omit sibling windows (cached passes, deferred
+/// fresh reads), so snapshot callers must prove completeness with a fresh
+/// read (see `SnapshotEngine.singleFreshWindowID`) instead of relying on
+/// this alone.
 public func singleManagedWindowID(
   processID: Int32?,
   in windows: [Window]

--- a/Tests/DefiModelTests/ModelTests.swift
+++ b/Tests/DefiModelTests/ModelTests.swift
@@ -138,4 +138,28 @@ struct ModelTests {
   ) {
     #expect(testCase.command.explicitlyFocusesFloating == testCase.expected)
   }
+
+  @Test
+  func `Single-window activation fallback is unambiguous`() {
+    let frame = Rect(x: 0, y: 0, width: 10, height: 10)
+    let solo = Window(
+      id: WindowID(rawValue: 1), appID: "a", title: "solo",
+      frame: frame, processID: 42
+    )
+    let other = Window(
+      id: WindowID(rawValue: 2), appID: "b", title: "other",
+      frame: frame, processID: 43
+    )
+    let sibling = Window(
+      id: WindowID(rawValue: 3), appID: "a", title: "sibling",
+      frame: frame, processID: 42
+    )
+    // Exactly one managed window: safe to admit without AX confirmation.
+    #expect(singleManagedWindowID(processID: 42, in: [solo, other]) == solo.id)
+    // Several windows for the same process: keep requiring AX confirmation.
+    #expect(singleManagedWindowID(processID: 42, in: [solo, sibling, other]) == nil)
+    #expect(singleManagedWindowID(processID: 99, in: [solo, other]) == nil)
+    #expect(singleManagedWindowID(processID: nil, in: [solo]) == nil)
+    #expect(singleManagedWindowID(processID: 42, in: []) == nil)
+  }
 }


### PR DESCRIPTION
## Summary

- Accept application activation immediately when the process owns exactly one managed window.
- Preserve Accessibility confirmation for multi-window processes.
- Record activation diagnostics and add model coverage for ambiguous and missing matches.

## Testing

- Added `DefiModelTests` coverage for single-window, multi-window, unknown-process, nil-process, and empty-window cases.
- Not run: full verification suite.