### PR TITLE
fix(snapshot): retain confirmed live windows during AX recovery

### DIFF
--- a/Sources/DefiMacOS/MacOSPlatform+WindowSnapshotDiscovery.swift
+++ b/Sources/DefiMacOS/MacOSPlatform+WindowSnapshotDiscovery.swift
@@ -243,6 +243,7 @@ extension SnapshotEngine {
             || capturedTopologyRequiresFullSnapshot
             || forceWindowListRefresh,
           topologyProcessWasInvalidated: topologyProcessIDs.contains(processID)
+            || retainedWindowIDs.contains { previousProcessIDs[$0] == processID }
         )
         let appWindows: [AXUIElement]?
         if refreshesWindowList {
@@ -501,17 +502,20 @@ onMain { $0.eventMonitor?.prepareForWindowDiscovery(
             }
           }
         }
+        let retentionCGWindows = needsCachedWindowValidation ? publicCGWindows() : []
         let retainableWindowIDs = cachedWindowIDsToRetain(
           processID: processID,
           previousWindows: previousWindows,
           discoveredWindowIDs: discoveredWindowIDs,
           ignoredWindowIDs: ignoredPreviousWindowIDs,
-          cgWindows: needsCachedWindowValidation ? publicCGWindows() : [],
+          cgWindows: retentionCGWindows,
           cachedMinimizedState: cachedMinimizedState
         )
         let retention = retainedWindowIDsWithinGracePeriod(
           retainableWindowIDs,
-          previousDeadlines: retainedWindowDeadlines,
+          // Confirmed live windows must survive AX recovery after wake. Only
+          // unconfirmed existence uses the bounded omission grace period.
+          previousDeadlines: retentionCGWindows == nil ? retainedWindowDeadlines : [:],
           now: ProcessInfo.processInfo.systemUptime
         )
         let processRetainedWindowIDs = retention.windowIDs

--- a/Tests/DefiMacOSTests/WindowSnapshotStabilityTests.swift
+++ b/Tests/DefiMacOSTests/WindowSnapshotStabilityTests.swift
@@ -1,4 +1,5 @@
 import ApplicationServices
+import DefiConfig
 import DefiModel
 import Testing
 
@@ -369,6 +370,49 @@ struct WindowSnapshotStabilityTests {
     #expect(
       windowGeometryDiscovery(minimized: false, frame: { frame }) == .usable(frame)
     )
+  }
+
+  @Test func sessionRecoveryRefreshesReferencesAndKeepsLiveWindowsPastGrace() {
+    let engine = SnapshotEngine(
+      frameCoordinator: AXFrameCoordinator(),
+      userInputTracker: UserInputTracker()
+    )
+    let window = makeWindow(id: 42)
+    let stale = AXUIElementCreateApplication(-1)
+    engine.elements = [window.id: stale]
+    engine.processIDs = [window.id: processID]
+    engine.applications = [processID: stale]
+    engine.applicationIDsByProcess = [processID: window.appID]
+    engine.enhancedUIByProcess = [processID: false]
+    engine.hasCompletedWindowSnapshot = true
+    engine.lastSnapshotWindows = [window]
+    engine.lastApplicationWindowElements = [processID: [stale]]
+    engine.retainedWindowIDs = [window.id]
+    engine.retainedWindowDeadlines = [window.id: 0]
+
+    // AX still omits the window after wake, but WindowServer confirms it exists.
+    let result = engine.discoverSnapshotWindows(
+      monitors: [],
+      config: Config(),
+      incrementalProcessIDs: [processID],
+      forceWindowListRefresh: false,
+      forceApplicationInventoryRefresh: false,
+      capturedTopologyRequiresFullSnapshot: false,
+      topologyProcessIDs: [],
+      preparedWindowAttributes: [window.id: AXWindowAttributes(
+        minimized: nil, frame: nil, title: "", role: nil, subrole: nil
+      )],
+      preparedTransientOwnerWindowIDs: [:],
+      preparedApplicationWindows: [processID: PreparedAXApplicationWindows(
+        elements: [], durationMS: 0
+      )],
+      explicitlyDestroyedWindowIDs: [],
+      publicCGWindows: { [makeCGWindow(id: 42)] }
+    )
+
+    #expect(engine.applicationWindowListReadCount == 1)
+    #expect(result.windows.map(\.id) == [window.id])
+    #expect(result.nextRetainedWindowIDs == [window.id])
   }
 
   @Test func existingCGWindowSurvivesTransientAccessibilityOmission() {


### PR DESCRIPTION
## Summary

- Refresh window references when a retained window's process is invalidated.
- Preserve WindowServer-confirmed live windows beyond the omission grace period during Accessibility recovery.
- Add regression coverage for wake/session recovery behavior.

## Testing

- Added `sessionRecoveryRefreshesReferencesAndKeepsLiveWindowsPastGrace`.
- Not run: repository verification commands.