### PR TITLE
perf: reduce redundant desktop refresh work

### DIFF
--- a/Sources/DefiDaemon/DaemonDesktopSynchronization.swift
+++ b/Sources/DefiDaemon/DaemonDesktopSynchronization.swift
@@ -110,6 +110,13 @@ extension Daemon {
           forceApplicationInventoryRefresh: pending.forceApplicationInventoryRefresh,
           consumePeriodicWindowRefresh: pending.consumePeriodicWindowRefresh
         )
+      } else if platform.hasDeferredFreshWindowReads
+        || platform.hasChunkedFullRefreshPending
+      {
+        // Continue when the preceding chunk completes, never by spinning ticks
+        // that can only supersede a snapshot still waiting on Accessibility.
+        needsDesktopSync = true
+        scheduleTick()
       }
     }
     let snapshotCompletedAt = ProcessInfo.processInfo.systemUptime

--- a/Sources/DefiDaemon/DefiDaemon.swift
+++ b/Sources/DefiDaemon/DefiDaemon.swift
@@ -141,9 +141,6 @@ final class Daemon: NSObject {
       forceApplicationInventoryRefresh: Bool,
       consumePeriodicWindowRefresh: Bool
     )?
-  var axPrefetchInvalidationRetries = 0
-  var cgPrefetchInvalidationRetries = 0
-  var bypassPrefetchOnce = false
   var observedPlatformEventCount = 0
   var targetMismatches: [FrameMismatch] = []
   var activelyResizedWindowID: WindowID?
@@ -479,51 +476,6 @@ final class Daemon: NSObject {
         && (forcesWindowInventory
           || (periodicWindowRefreshDue
             && !platform.hasReliableWindowTopologyObservation))
-      if !mouseGestureSyncPending,
-        !nativeFocusSyncPending,
-        forcesFullWindowRefresh,
-        !bypassPrefetchOnce,
-        platform.prepareAXWindowAttributesIfNeeded(
-          completion: { [weak self] published in
-            guard let self else { return }
-            if published {
-              self.axPrefetchInvalidationRetries = 0
-            } else {
-              self.axPrefetchInvalidationRetries += 1
-              if self.axPrefetchInvalidationRetries >= 2 {
-                self.bypassPrefetchOnce = true
-              }
-            }
-            self.needsDesktopSync = true
-            self.scheduleTick()
-          }
-        )
-      {
-        return
-      }
-      if !mouseGestureSyncPending,
-        !nativeFocusSyncPending,
-        forcesFullWindowRefresh,
-        !bypassPrefetchOnce,
-        platform.prepareCGWindowInventoryIfNeeded(
-          completion: { [weak self] published in
-            guard let self else { return }
-            if published {
-              self.cgPrefetchInvalidationRetries = 0
-            } else {
-              self.cgPrefetchInvalidationRetries += 1
-              if self.cgPrefetchInvalidationRetries >= 2 {
-                self.bypassPrefetchOnce = true
-              }
-            }
-            self.needsDesktopSync = true
-            self.scheduleTick()
-          }
-        )
-      {
-        return
-      }
-      bypassPrefetchOnce = false
       needsDesktopSync = false
       synchronizeDesktop(
         forceFullWindowRefresh: forcesFullWindowRefresh,
@@ -531,13 +483,6 @@ final class Daemon: NSObject {
         forceApplicationInventoryRefresh: forceApplicationInventoryRefresh,
         consumePeriodicWindowRefresh: periodicWindowRefreshDue
       )
-      if platform.hasDeferredFreshWindowReads
-        || platform.hasChunkedFullRefreshPending
-      {
-        needsDesktopSync = true
-        setTimerFrequency(30)
-        scheduleTick()
-      }
     }
     if liveBorderGesture || animatedWritesPending {
       platform.refreshWindowBorders()

--- a/Sources/DefiMacOS/AXFrameCoordinatorWrites.swift
+++ b/Sources/DefiMacOS/AXFrameCoordinatorWrites.swift
@@ -23,6 +23,10 @@ extension AXFrameCoordinator {
     completionSpreadMS: Double,
     frames: Int
   ) {
+    guard isCurrent(generation: frame.generation) else {
+      let stale = frame.writes.values.lazy.filter { !skippedProcesses.contains($0.processID) }.count
+      return (0, stale, [], 0, 0)
+    }
     let accumulator = FrameResultAccumulator()
     let parkedWindowIDs = Set(
       frame.writes.compactMap { windowID, write in
@@ -351,6 +355,9 @@ extension AXFrameCoordinator {
     slowProcesses: Set<pid_t>,
     attempted: Bool
   ) {
+    guard isCurrent(generation: frame.generation) else {
+      return (0, batch.writes.count, [], false)
+    }
     var applied = 0
     var stale = 0
     var slowProcesses = Set<pid_t>()

--- a/Sources/DefiMacOS/MacOSPlatform+EventObservation.swift
+++ b/Sources/DefiMacOS/MacOSPlatform+EventObservation.swift
@@ -15,7 +15,7 @@ extension MacOSPlatform {
   }
 
   public func invalidateStateForDesktopSessionChange() {
-    invalidatePreparedAXWindowAttributes()
+    invalidateWindowSnapshot()
     snapshotEngine.invalidateAccessibilitySession()
     eventMonitor?.resetAccessibilityObservers()
     frameCoordinator.invalidate(reason: "desktop-session-change")

--- a/Sources/DefiMacOS/MacOSPlatform+Snapshot.swift
+++ b/Sources/DefiMacOS/MacOSPlatform+Snapshot.swift
@@ -98,12 +98,6 @@ extension SnapshotEngine {
         unmatchedWindowElementsByProcess[processID] = nil
         unmatchedWindowRetryAttemptsByProcess[processID] = nil
       }
-      if retriesAllUnmatchedWindows {
-        for processID in unmatchedWindowElementsByProcess.keys {
-          unmatchedWindowRetryAttemptsByProcess[processID, default: 0] += 1
-        }
-        unmatchedWindowElementsByProcess.removeAll(keepingCapacity: true)
-      }
     }
     let incrementalProcessIDs =
       forceFullWindowRefresh
@@ -193,6 +187,9 @@ extension SnapshotEngine {
       deferredFreshReadProcessIDs.removeAll(keepingCapacity: true)
       deferredFreshReadsStartedAt = nil
     }
+    if !eventRequiresFullSnapshot, retriesAllUnmatchedWindows || chunkedFullActive {
+      retryUnmatchedWindows(processIDs: effectiveIncrementalProcessIDs)
+    }
     let forceWindowListRefreshEffective =
       forceWindowListRefresh || chunkedFullActive
     let snapshotMode: String
@@ -230,19 +227,11 @@ extension SnapshotEngine {
         cachedCGWindows = reusableCGWindows
         return cachedCGWindows
       }
-      let copied: [CGWindowRecord]?
-      let copyDurationMS: Double
-      if preparedCGWindowInventoryAvailable {
-        copied = preparedCGWindowInventory
-        copyDurationMS = preparedCGWindowInventoryDurationMS
-      } else {
-        let copyStartedAt = ProcessInfo.processInfo.systemUptime
-        copied = copyCGWindowsIfAvailable()
-        copyDurationMS =
-          (ProcessInfo.processInfo.systemUptime - copyStartedAt) * 1_000
-      }
-      preparedCGWindowInventory = nil
-      preparedCGWindowInventoryAvailable = false
+      let copyStartedAt = ProcessInfo.processInfo.systemUptime
+      let inventoryGeneration = windowSnapshotObservationGeneration
+      let copied = copyCGWindowsIfAvailable()
+      let copyDurationMS =
+        (ProcessInfo.processInfo.systemUptime - copyStartedAt) * 1_000
       snapshotCGWindowCopyCount += 1
       lastSnapshotCGWindowCopyDurationMS = copyDurationMS
       maximumSnapshotCGWindowCopyDurationMS = max(
@@ -251,7 +240,9 @@ extension SnapshotEngine {
       )
       hasResolvedCGWindows = true
       cachedCGWindows = copied
-      lastCGWindowInventory = copied
+      publishCGWindowInventory(copied.map {
+        CGWindowInventory(records: $0, generation: inventoryGeneration, capturedAt: copyStartedAt)
+      })
       cgWindowInventoryRetryAttempts =
         updatedWindowListReadRetryAttempts(
           previousAttempts: cgWindowInventoryRetryAttempts,
@@ -265,36 +256,11 @@ extension SnapshotEngine {
     ) {
       _ = publicCGWindows()
     }
-    let preparedAXIsCurrent =
-      preparedAXWindowAttributesAvailable
-      && preparedAXWindowAttributesGeneration.map {
-        preparedAXWindowAttributesAreCurrent(
-          capturedGeneration: $0,
-          currentGeneration: windowSnapshotObservationGeneration,
-          capturedInputTimestamp: preparedAXWindowAttributesInputTimestamp ?? .nan,
-          currentInputTimestamp: userInputTracker.latestEventTimestamp,
-          capturedWindowIDs: preparedAXWindowAttributesWindowIDs,
-          currentWindowIDs: Set(elements.keys),
-          capturedProcessIDs: preparedAXWindowAttributesProcessIDs,
-          currentProcessIDs: Set(applications.keys)
-        )
-      } ?? false
-    let preparedWindowAttributes =
-      preparedAXIsCurrent
-      ? preparedAXWindowAttributes
-      : [:]
-    let preparedTransientOwners =
-      preparedAXIsCurrent
-      ? preparedTransientOwnerWindowIDs
-      : [:]
-    let preparedApplicationWindows =
-      preparedAXIsCurrent
-      ? preparedAXApplicationWindows
-      : [:]
-    preparedAXWindowAttributes.removeAll(keepingCapacity: true)
-    preparedTransientOwnerWindowIDs.removeAll(keepingCapacity: true)
-    preparedAXApplicationWindows.removeAll(keepingCapacity: true)
-    preparedAXWindowAttributesAvailable = false
+    // Prepare only this chunk, on the snapshot queue. Deferred applications
+    // must not be read here and then read again when their chunk runs.
+    let prepared = chunkedFullActive
+      ? prepareWindowAttributes(processIDs: effectiveIncrementalProcessIDs ?? Set(applications.keys))
+      : (attributes: [:], owners: [:], applications: [:])
     let previousElements = elements
     let discovery = discoverSnapshotWindows(
       monitors: monitors,
@@ -304,14 +270,12 @@ extension SnapshotEngine {
       forceApplicationInventoryRefresh: forceApplicationInventoryRefresh,
       capturedTopologyRequiresFullSnapshot: capturedTopologyRequiresFullSnapshot,
       topologyProcessIDs: topologyProcessIDs,
-      preparedWindowAttributes: preparedWindowAttributes,
-      preparedTransientOwnerWindowIDs: preparedTransientOwners,
-      preparedApplicationWindows: preparedApplicationWindows,
+      preparedWindowAttributes: prepared.attributes,
+      preparedTransientOwnerWindowIDs: prepared.owners,
+      preparedApplicationWindows: prepared.applications,
       explicitlyDestroyedWindowIDs: explicitlyDestroyedWindowIDs,
       publicCGWindows: publicCGWindows
     )
-    preparedCGWindowInventory = nil
-    preparedCGWindowInventoryAvailable = false
     var nextElements = discovery.nextElements
     var nextProcessIDs = discovery.nextProcessIDs
     let nextApplications = discovery.nextApplications

--- a/Sources/DefiMacOS/MacOSPlatform+WindowBorderObservation.swift
+++ b/Sources/DefiMacOS/MacOSPlatform+WindowBorderObservation.swift
@@ -13,7 +13,7 @@ extension MacOSPlatform {
     processID: pid_t,
     inputTimestamp: TimeInterval? = nil
   ) {
-    invalidatePreparedAXWindowAttributes()
+    invalidateWindowSnapshot()
     snapshotEngine.recordObservation(
       .windows,
       processID: processID,
@@ -47,7 +47,7 @@ extension MacOSPlatform {
       let previousWindowCount = processID.flatMap {
         self?.applicationWindowCounts[$0]
       }
-      self?.invalidatePreparedAXWindowAttributes()
+      self?.invalidateWindowSnapshot()
       let windowID = element.flatMap { element in
         self?.elements.first(where: { CFEqual($0.value, element) })?.key
       }
@@ -126,19 +126,14 @@ extension MacOSPlatform {
             deadline: .now() + .milliseconds(delay)
           ) { [weak self] in
             guard let self else { return }
-            self.invalidatePreparedAXWindowAttributes()
+            self.invalidateWindowSnapshot()
             self.snapshotEngine.recordObservation(.windows, processID: nil)
             handler()
           }
         }
       }
       if let processID, let previousWindowCount {
-        for delay in windowTopologyRefreshDelays(
-          for: kind,
-          latestInputTimestamp: eventInputTimestamp,
-          latestCloseIntentTimestamp: eventInput?.latestCloseIntent ?? 0,
-          now: ProcessInfo.processInfo.systemUptime
-        ) {
+        for delay in windowTopologyRefreshDelays(for: kind) {
           DispatchQueue.main.asyncAfter(
             deadline: .now() + .milliseconds(delay)
           ) { [weak self] in
@@ -194,7 +189,8 @@ extension MacOSPlatform {
     monitor.refresh(applications: windowsByProcess)
   }
 
-  func scheduleWindowBorderStackingRefresh() {
+  func scheduleWindowBorderStackingRefresh(reusingSnapshot: Bool = false) {
+    if !reusingSnapshot { invalidateWindowSnapshot() }
     let request = borderStackingRefreshState.request(
       for: borderManager.activeWindowID
     )
@@ -226,6 +222,22 @@ extension MacOSPlatform {
         }()
         ?? borderFrames.first(where: { $0.windowID == request.windowID })?.frame
         ?? latestObservedFrames[request.windowID]
+      if reusingSnapshot, !hasPendingFrameWrites,
+        let inventory = snapshotEngine.borderStackingInventory(now: ProcessInfo.processInfo.systemUptime),
+        let entries = windowBorderStackEntries(
+          inventory: inventory, targetWindowID: request.windowID,
+          targetProcessID: targetProcessID, targetFrame: targetFrame
+        )
+      {
+        let stacking = DefiMacOS.windowBorderStacking(
+          targetWindowID: request.windowID,
+          ownProcessID: ProcessInfo.processInfo.processIdentifier,
+          floatingLevel: NSWindow.Level.floating.rawValue, entries: entries,
+          monitorFrames: monitorFrames, knownWindowIDs: knownWindowIDs
+        )
+        refreshWindowBorderStacking(request, stacking: stacking)
+        return
+      }
       let stacking = await copyWindowBorderStackingOffMain(
         targetWindowID: request.windowID,
         targetProcessID: targetProcessID,
@@ -277,7 +289,7 @@ extension MacOSPlatform {
     if let ownedWindowID = borderManager.ownedSurfaceWindowID {
       borderBoundsProvider.probe(ownedWindowID: ownedWindowID)
     }
-    scheduleWindowBorderStackingRefresh()
+    scheduleWindowBorderStackingRefresh(reusingSnapshot: true)
     revealWindowBordersIfReady()
   }
 
@@ -567,7 +579,7 @@ extension MacOSPlatform {
   public func setFrameNotificationsEnabled(_ enabled: Bool) {
     let suppressedRefresh = eventMonitor?.setFrameNotificationsEnabled(enabled)
     guard enabled else { return }
-    invalidatePreparedAXWindowAttributes()
+    invalidateWindowSnapshot()
     // Notifications were ignored while animated writes ran. Force fresh reads
     // before trusting the final committed frames.
     let committedWindowIDs = Set(frameCommitExpectations.keys)

--- a/Sources/DefiMacOS/MacOSPlatform+WindowDiscovery.swift
+++ b/Sources/DefiMacOS/MacOSPlatform+WindowDiscovery.swift
@@ -7,173 +7,129 @@ import DefiModel
 import OSLog
 
 let focusSnapshotAccessibilityTimeoutSeconds: Float = 0.05
-@MainActor
-extension MacOSPlatform {
-
-  public func prepareAXWindowAttributesIfNeeded(
-    completion: @escaping @MainActor @Sendable (Bool) -> Void
-  ) -> Bool {
-    if preparedAXWindowAttributesAvailable { return false }
-    guard !axWindowAttributePreparationPending else { return true }
-    let capturedWindowIDs = Set(elements.keys)
-    let capturedProcessIDs = Set(applications.keys)
-    let candidates: [PreparedAXWindowElement] = elements.compactMap {
-      windowID, element in
-      guard let processID = processIDs[windowID] else { return nil }
+extension SnapshotEngine {
+  func prepareWindowAttributes(processIDs refreshingProcessIDs: Set<pid_t>) -> (
+    attributes: [WindowID: AXWindowAttributes],
+    owners: [WindowID: WindowID],
+    applications: [pid_t: PreparedAXApplicationWindows]
+  ) {
+    let generation = windowSnapshotObservationGeneration
+    let inputTracker = userInputTracker
+    let inputTimestamp = inputTracker.latestEventTimestamp
+    let windowProcessIDs = processIDs
+    let batchSupport = multipleAttributeReadsSupportedByProcess
+    let candidates = elements.compactMap { windowID, element -> PreparedAXWindowElement? in
+      guard let processID = windowProcessIDs[windowID],
+        refreshingProcessIDs.contains(processID)
+      else { return nil }
       return PreparedAXWindowElement(
-        windowID: windowID,
-        processID: processID,
-        element: element,
-        usesBatchedAttributeReads:
-          multipleAttributeReadsSupportedByProcess[processID] != false
+        windowID: windowID, processID: processID, element: element,
+        usesBatchedAttributeReads: batchSupport[processID] != false
       )
     }
-    guard !candidates.isEmpty else {
-      preparedTransientOwnerWindowIDs.removeAll(keepingCapacity: true)
-      preparedAXWindowAttributesAvailable = true
-      preparedAXWindowAttributesGeneration = windowSnapshotObservationGeneration
-      preparedAXWindowAttributesInputTimestamp = userInputTracker.latestEventTimestamp
-      preparedAXWindowAttributesWindowIDs = capturedWindowIDs
-      preparedAXWindowAttributesProcessIDs = capturedProcessIDs
-      return false
-    }
-    let generation = windowSnapshotObservationGeneration
-    let inputTimestamp = userInputTracker.latestEventTimestamp
-    let inputTracker = userInputTracker
-    let windowIDs = capturedWindowIDs
-    let applicationProcessIDs = capturedProcessIDs
-    let applicationCandidates = applications.map {
-      PreparedAXApplicationElement(processID: $0.key, element: $0.value)
+    let applicationCandidates = applications.compactMap { processID, element in
+      refreshingProcessIDs.contains(processID)
+        ? PreparedAXApplicationElement(processID: processID, element: element) : nil
     }
     for candidate in applicationCandidates {
-      eventMonitor?.prepareForWindowDiscovery(
-        processID: candidate.processID,
-        application: candidate.element
-      )
-    }
-    axWindowAttributePreparationPending = true
-    DispatchQueue.global(qos: .utility).async {
-      let startedAt = ProcessInfo.processInfo.systemUptime
-      let reads = candidates.compactMap { candidate -> PreparedAXWindowRead? in
-        guard inputTracker.latestEventTimestamp == inputTimestamp else {
-          return nil
-        }
-        return AXMessagingTimeoutAccess.shared.withTimeout(
-          0.05,
-          elements: [candidate.element]
-        ) {
-          var attributes: AXWindowAttributes?
-          var parent: AXUIElement?
-          var sheets: [AXUIElement]?
-          if candidate.usesBatchedAttributeReads {
-            let read = copyBatchedWindowAttributes(
-              candidate.element,
-              includingTransientRelationships: true
-            )
-            attributes = read.attributes
-            parent = read.parent
-            sheets = read.sheets
-          }
-          if parent == nil || sheets == nil {
-            let fallback = copyTransientOwnerRelationships(candidate.element)
-            parent = parent ?? fallback.parent
-            sheets = sheets ?? fallback.sheets
-          }
-          return PreparedAXWindowRead(
-            windowID: candidate.windowID,
-            attributes: attributes,
-            parent: parent,
-            sheets: sheets ?? []
-          )
-        }
-      }
-      let attributes: [WindowID: AXWindowAttributes] = Dictionary(
-        uniqueKeysWithValues: reads.compactMap { read in
-          read.attributes.map { (read.windowID, $0) }
-        }
-      )
-      let transientOwnerWindowIDs = transientOwnerWindowIDsFromPreparedRelationships(
-        elements: Dictionary(uniqueKeysWithValues: candidates.map {
-          ($0.windowID, $0.element)
-        }),
-        parents: Dictionary(uniqueKeysWithValues: reads.compactMap { read in
-          read.parent.map { (read.windowID, $0) }
-        }),
-        sheets: Dictionary(uniqueKeysWithValues: reads.map {
-          ($0.windowID, $0.sheets)
-        })
-      )
-      let durationMS =
-        (ProcessInfo.processInfo.systemUptime - startedAt) * 1_000
-      let applicationWindows: [pid_t: PreparedAXApplicationWindows] =
-        Dictionary(
-          uniqueKeysWithValues: applicationCandidates.compactMap { candidate in
-            guard inputTracker.latestEventTimestamp == inputTimestamp else {
-              return nil
-            }
-            let readStartedAt = ProcessInfo.processInfo.systemUptime
-            let windows = AXMessagingTimeoutAccess.shared.withTimeout(
-              0.05,
-              elements: [candidate.element]
-            ) {
-              var value: CFTypeRef?
-              guard AXUIElementCopyAttributeValue(
-                candidate.element,
-                kAXWindowsAttribute as CFString,
-                &value
-              ) == .success else {
-                return nil as [AXUIElement]?
-              }
-              return value as? [AXUIElement]
-            }
-            let readDurationMS =
-              (ProcessInfo.processInfo.systemUptime - readStartedAt) * 1_000
-            return windows.map {
-              (
-                candidate.processID,
-                PreparedAXApplicationWindows(
-                  elements: $0,
-                  durationMS: readDurationMS
-                )
-              )
-            }
-          }
+      onMain { platform in
+        platform.eventMonitor?.prepareForWindowDiscovery(
+          processID: candidate.processID, application: candidate.element
         )
-      DispatchQueue.main.async { [weak self] in
-        MainActor.assumeIsolated {
-          guard let self else { return }
-          self.axWindowAttributePreparationPending = false
-          guard preparedAXWindowAttributesAreCurrent(
-            capturedGeneration: generation,
-            currentGeneration: self.windowSnapshotObservationGeneration,
-            capturedInputTimestamp: inputTimestamp,
-            currentInputTimestamp: self.userInputTracker.latestEventTimestamp,
-            capturedWindowIDs: windowIDs,
-            currentWindowIDs: Set(self.elements.keys),
-            capturedProcessIDs: applicationProcessIDs,
-            currentProcessIDs: Set(self.applications.keys)
-          ) else {
-            completion(false)
-            return
-          }
-          self.preparedAXWindowAttributes = attributes
-          self.preparedTransientOwnerWindowIDs = transientOwnerWindowIDs
-          self.preparedAXApplicationWindows = applicationWindows
-          self.preparedAXWindowAttributesAvailable = true
-          self.preparedAXWindowAttributesGeneration = generation
-          self.preparedAXWindowAttributesInputTimestamp = inputTimestamp
-          self.preparedAXWindowAttributesWindowIDs = windowIDs
-          self.preparedAXWindowAttributesProcessIDs = applicationProcessIDs
-          let formattedDuration = String(format: "%.2f", durationMS)
-          self.frameCoordinator.recordTrace(
-            "snapshot-prefetch windows=\(attributes.count) ms=\(formattedDuration)"
-          )
-          completion(true)
-        }
       }
     }
-    return true
+    let reads = candidates.compactMap { candidate -> PreparedAXWindowRead? in
+      guard inputTracker.latestEventTimestamp == inputTimestamp else {
+        return nil
+      }
+      return AXMessagingTimeoutAccess.shared.withTimeout(
+        0.05,
+        elements: [candidate.element]
+      ) {
+        var attributes: AXWindowAttributes?
+        var parent: AXUIElement?
+        var sheets: [AXUIElement]?
+        if candidate.usesBatchedAttributeReads {
+          let read = copyBatchedWindowAttributes(
+            candidate.element,
+            includingTransientRelationships: true
+          )
+          attributes = read.attributes
+          parent = read.parent
+          sheets = read.sheets
+        }
+        if parent == nil || sheets == nil {
+          let fallback = copyTransientOwnerRelationships(candidate.element)
+          parent = parent ?? fallback.parent
+          sheets = sheets ?? fallback.sheets
+        }
+        return PreparedAXWindowRead(
+          windowID: candidate.windowID,
+          attributes: attributes,
+          parent: parent,
+          sheets: sheets ?? []
+        )
+      }
+    }
+    let attributes: [WindowID: AXWindowAttributes] = Dictionary(
+      uniqueKeysWithValues: reads.compactMap { read in
+        read.attributes.map { (read.windowID, $0) }
+      }
+    )
+    let transientOwnerWindowIDs = transientOwnerWindowIDsFromPreparedRelationships(
+      elements: Dictionary(uniqueKeysWithValues: candidates.map {
+        ($0.windowID, $0.element)
+      }),
+      parents: Dictionary(uniqueKeysWithValues: reads.compactMap { read in
+        read.parent.map { (read.windowID, $0) }
+      }),
+      sheets: Dictionary(uniqueKeysWithValues: reads.map {
+        ($0.windowID, $0.sheets)
+      })
+    )
+    let applicationWindows: [pid_t: PreparedAXApplicationWindows] =
+      Dictionary(
+        uniqueKeysWithValues: applicationCandidates.compactMap { candidate in
+          guard inputTracker.latestEventTimestamp == inputTimestamp else {
+            return nil
+          }
+          let readStartedAt = ProcessInfo.processInfo.systemUptime
+          let windows = AXMessagingTimeoutAccess.shared.withTimeout(
+            0.05,
+            elements: [candidate.element]
+          ) {
+            var value: CFTypeRef?
+            guard AXUIElementCopyAttributeValue(
+              candidate.element,
+              kAXWindowsAttribute as CFString,
+              &value
+            ) == .success else {
+              return nil as [AXUIElement]?
+            }
+            return value as? [AXUIElement]
+          }
+          let readDurationMS =
+            (ProcessInfo.processInfo.systemUptime - readStartedAt) * 1_000
+          return windows.map {
+            (
+              candidate.processID,
+              PreparedAXApplicationWindows(
+                elements: $0,
+                durationMS: readDurationMS
+              )
+            )
+          }
+        }
+      )
+    guard generation == windowSnapshotObservationGeneration,
+      inputTimestamp == inputTracker.latestEventTimestamp
+    else { return ([:], [:], [:]) }
+    return (attributes, transientOwnerWindowIDs, applicationWindows)
   }
+}
+
+@MainActor
+extension MacOSPlatform {
 
   public func discoverMonitors() -> [MonitorSnapshot] {
     let mainTop = NSScreen.screens.first?.frame.maxY ?? 0

--- a/Sources/DefiMacOS/MacOSPlatform.swift
+++ b/Sources/DefiMacOS/MacOSPlatform.swift
@@ -302,58 +302,6 @@ public final class MacOSPlatform {
     get { snapshotEngine.maximumSnapshotCGWindowCopyDurationMS }
     set { snapshotEngine.maximumSnapshotCGWindowCopyDurationMS = newValue }
   }
-  var preparedCGWindowInventory: [CGWindowRecord]? {
-    get { snapshotEngine.preparedCGWindowInventory }
-    set { snapshotEngine.preparedCGWindowInventory = newValue }
-  }
-  var preparedCGWindowInventoryDurationMS: Double {
-    get { snapshotEngine.preparedCGWindowInventoryDurationMS }
-    set { snapshotEngine.preparedCGWindowInventoryDurationMS = newValue }
-  }
-  var preparedCGWindowInventoryAvailable: Bool {
-    get { snapshotEngine.preparedCGWindowInventoryAvailable }
-    set { snapshotEngine.preparedCGWindowInventoryAvailable = newValue }
-  }
-  var cgWindowInventoryPreparationPending: Bool {
-    get { snapshotEngine.cgWindowInventoryPreparationPending }
-    set { snapshotEngine.cgWindowInventoryPreparationPending = newValue }
-  }
-  var preparedAXWindowAttributes: [WindowID: AXWindowAttributes] {
-    get { snapshotEngine.preparedAXWindowAttributes }
-    set { snapshotEngine.preparedAXWindowAttributes = newValue }
-  }
-  var preparedTransientOwnerWindowIDs: [WindowID: WindowID] {
-    get { snapshotEngine.preparedTransientOwnerWindowIDs }
-    set { snapshotEngine.preparedTransientOwnerWindowIDs = newValue }
-  }
-  var preparedAXApplicationWindows: [pid_t: PreparedAXApplicationWindows] {
-    get { snapshotEngine.preparedAXApplicationWindows }
-    set { snapshotEngine.preparedAXApplicationWindows = newValue }
-  }
-  var preparedAXWindowAttributesAvailable: Bool {
-    get { snapshotEngine.preparedAXWindowAttributesAvailable }
-    set { snapshotEngine.preparedAXWindowAttributesAvailable = newValue }
-  }
-  var preparedAXWindowAttributesGeneration: UInt64? {
-    get { snapshotEngine.preparedAXWindowAttributesGeneration }
-    set { snapshotEngine.preparedAXWindowAttributesGeneration = newValue }
-  }
-  var preparedAXWindowAttributesInputTimestamp: TimeInterval? {
-    get { snapshotEngine.preparedAXWindowAttributesInputTimestamp }
-    set { snapshotEngine.preparedAXWindowAttributesInputTimestamp = newValue }
-  }
-  var preparedAXWindowAttributesWindowIDs: Set<WindowID> {
-    get { snapshotEngine.preparedAXWindowAttributesWindowIDs }
-    set { snapshotEngine.preparedAXWindowAttributesWindowIDs = newValue }
-  }
-  var preparedAXWindowAttributesProcessIDs: Set<pid_t> {
-    get { snapshotEngine.preparedAXWindowAttributesProcessIDs }
-    set { snapshotEngine.preparedAXWindowAttributesProcessIDs = newValue }
-  }
-  var axWindowAttributePreparationPending: Bool {
-    get { snapshotEngine.axWindowAttributePreparationPending }
-    set { snapshotEngine.axWindowAttributePreparationPending = newValue }
-  }
   var windowSnapshotObservationGeneration: UInt64 {
     get { snapshotEngine.windowSnapshotObservationGeneration }
     set { snapshotEngine.windowSnapshotObservationGeneration = newValue }
@@ -567,7 +515,7 @@ public final class MacOSPlatform {
   }
 
   public func requestFrameRefresh(for windowID: WindowID) {
-    invalidatePreparedAXWindowAttributes()
+    invalidateWindowSnapshot()
     snapshotEngine.recordObservation(
       .frame,
       processID: processIDs[windowID],
@@ -575,18 +523,9 @@ public final class MacOSPlatform {
     )
   }
 
-  func invalidatePreparedAXWindowAttributes() {
+  func invalidateWindowSnapshot() {
     windowSnapshotObservationGeneration &+= 1
-    preparedCGWindowInventory = nil
-    preparedCGWindowInventoryAvailable = false
-    preparedAXWindowAttributes.removeAll(keepingCapacity: true)
-    preparedTransientOwnerWindowIDs.removeAll(keepingCapacity: true)
-    preparedAXApplicationWindows.removeAll(keepingCapacity: true)
-    preparedAXWindowAttributesAvailable = false
-    preparedAXWindowAttributesGeneration = nil
-    preparedAXWindowAttributesInputTimestamp = nil
-    preparedAXWindowAttributesWindowIDs.removeAll(keepingCapacity: true)
-    preparedAXWindowAttributesProcessIDs.removeAll(keepingCapacity: true)
+
   }
 
 }

--- a/Sources/DefiMacOS/MenuBarContent.swift
+++ b/Sources/DefiMacOS/MenuBarContent.swift
@@ -5,7 +5,7 @@ import SwiftUI
 public struct MenuBarContent: View {
   let state: MenuBarState
   let commandHandler: (String) -> Void
-  @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
+  @State private var launchAtLogin = false
 
   public init(state: MenuBarState, commandHandler: @escaping (String) -> Void) {
     self.state = state

--- a/Sources/DefiMacOS/Platform.swift
+++ b/Sources/DefiMacOS/Platform.swift
@@ -37,6 +37,20 @@ struct CGWindowRecord: Sendable {
   }
 }
 
+struct CGWindowInventory: Sendable {
+  let records: [CGWindowRecord]
+  let generation: UInt64
+  let capturedAt: TimeInterval
+
+  func recordsForBorderStacking(generation: UInt64, now: TimeInterval) -> [CGWindowRecord]? {
+    // Only share a recent snapshot pass; native order events still force a read.
+    guard self.generation == generation, now >= capturedAt,
+      now - capturedAt <= 0.05
+    else { return nil }
+    return records
+  }
+}
+
 func copyCGWindows(
   options: CGWindowListOption = [.optionAll, .excludeDesktopElements]
 ) -> [CGWindowRecord] {
@@ -55,39 +69,6 @@ func copyCGWindowsIfAvailable(
     return nil
   }
   return info.compactMap(cgWindowRecord)
-}
-
-@MainActor
-extension MacOSPlatform {
-  public func prepareCGWindowInventoryIfNeeded(
-    completion: @escaping @MainActor @Sendable (Bool) -> Void
-  ) -> Bool {
-    if preparedCGWindowInventoryAvailable { return false }
-    guard !cgWindowInventoryPreparationPending else { return true }
-    let capturedGeneration = windowSnapshotObservationGeneration
-    cgWindowInventoryPreparationPending = true
-    DispatchQueue.global(qos: .utility).async {
-      let startedAt = ProcessInfo.processInfo.systemUptime
-      let windows = copyCGWindowsIfAvailable()
-      let durationMS =
-        (ProcessInfo.processInfo.systemUptime - startedAt) * 1_000
-      DispatchQueue.main.async { [weak self] in
-        MainActor.assumeIsolated {
-          guard let self else { return }
-          self.cgWindowInventoryPreparationPending = false
-          guard capturedGeneration == self.windowSnapshotObservationGeneration else {
-            completion(false)
-            return
-          }
-          self.preparedCGWindowInventory = windows
-          self.preparedCGWindowInventoryDurationMS = durationMS
-          self.preparedCGWindowInventoryAvailable = true
-          completion(true)
-        }
-      }
-    }
-    return true
-  }
 }
 
 func cgWindowRecord(_ item: [String: Any]) -> CGWindowRecord? {

--- a/Sources/DefiMacOS/PlatformEventNormalization.swift
+++ b/Sources/DefiMacOS/PlatformEventNormalization.swift
@@ -118,19 +118,10 @@ func applicationLifecycleRefreshDelays(for kind: PlatformEventKind) -> [Int] {
   }
 }
 
-func windowTopologyRefreshDelays(
-  for kind: PlatformEventKind,
-  latestInputTimestamp: TimeInterval?,
-  latestCloseIntentTimestamp: TimeInterval,
-  now: TimeInterval
-) -> [Int] {
-  guard let latestInputTimestamp,
-    kind == .windowCreated,
-    latestCloseIntentTimestamp < latestInputTimestamp,
-    latestInputTimestamp <= now,
-    now - latestInputTimestamp <= 1
-  else { return [] }
-  return [50, 150, 350]
+func windowTopologyRefreshDelays(for kind: PlatformEventKind) -> [Int] {
+  // Window creation can precede AXWindows/geometry readiness, including without
+  // input history after a daemon restart. Discovery is independent of focus intent.
+  kind == .windowCreated ? [50, 150, 350] : []
 }
 
 func nativeFocusedWindowIDAfterEvent(

--- a/Sources/DefiMacOS/SnapshotEngine.swift
+++ b/Sources/DefiMacOS/SnapshotEngine.swift
@@ -286,7 +286,15 @@ final class SnapshotEngine: @unchecked Sendable {
 
   var applications: [pid_t: AXUIElement] {
     get { read { $0.applications } }
-    set { read { $0.applications = newValue } }
+    set {
+      read {
+        $0.applications = newValue
+        // An empty inventory cannot leave a full-refresh continuation pending.
+        if newValue.isEmpty {
+          $0.chunkedFullRefreshRemainingProcessIDs = nil
+        }
+      }
+    }
   }
 
   var applicationIDsByProcess: [pid_t: String] {

--- a/Sources/DefiMacOS/SnapshotEngine.swift
+++ b/Sources/DefiMacOS/SnapshotEngine.swift
@@ -446,76 +446,22 @@ final class SnapshotEngine: @unchecked Sendable {
     set { read { $0.windowSnapshotObservationGeneration = newValue } }
   }
 
-  // MARK: prepared AX prefetch
-
-  var preparedCGWindowInventory: [CGWindowRecord]? {
-    get { read { $0.preparedCGWindowInventory } }
-    set { read { $0.preparedCGWindowInventory = newValue } }
-  }
+  // MARK: window inventory
 
   var lastCGWindowInventory: [CGWindowRecord]? {
-    get { read { $0.lastCGWindowInventory } }
-    set { read { $0.lastCGWindowInventory = newValue } }
+    read { $0.lastCGWindowInventory?.records }
   }
 
-  var preparedCGWindowInventoryDurationMS: Double {
-    get { read { $0.preparedCGWindowInventoryDurationMS } }
-    set { read { $0.preparedCGWindowInventoryDurationMS = newValue } }
+  func publishCGWindowInventory(_ inventory: CGWindowInventory?) {
+    read { $0.lastCGWindowInventory = inventory }
   }
 
-  var preparedCGWindowInventoryAvailable: Bool {
-    get { read { $0.preparedCGWindowInventoryAvailable } }
-    set { read { $0.preparedCGWindowInventoryAvailable = newValue } }
-  }
-
-  var cgWindowInventoryPreparationPending: Bool {
-    get { read { $0.cgWindowInventoryPreparationPending } }
-    set { read { $0.cgWindowInventoryPreparationPending = newValue } }
-  }
-
-  var preparedAXWindowAttributes: [WindowID: AXWindowAttributes] {
-    get { read { $0.preparedAXWindowAttributes } }
-    set { read { $0.preparedAXWindowAttributes = newValue } }
-  }
-
-  var preparedTransientOwnerWindowIDs: [WindowID: WindowID] {
-    get { read { $0.preparedTransientOwnerWindowIDs } }
-    set { read { $0.preparedTransientOwnerWindowIDs = newValue } }
-  }
-
-  var preparedAXApplicationWindows: [pid_t: PreparedAXApplicationWindows] {
-    get { read { $0.preparedAXApplicationWindows } }
-    set { read { $0.preparedAXApplicationWindows = newValue } }
-  }
-
-  var preparedAXWindowAttributesAvailable: Bool {
-    get { read { $0.preparedAXWindowAttributesAvailable } }
-    set { read { $0.preparedAXWindowAttributesAvailable = newValue } }
-  }
-
-  var preparedAXWindowAttributesGeneration: UInt64? {
-    get { read { $0.preparedAXWindowAttributesGeneration } }
-    set { read { $0.preparedAXWindowAttributesGeneration = newValue } }
-  }
-
-  var preparedAXWindowAttributesInputTimestamp: TimeInterval? {
-    get { read { $0.preparedAXWindowAttributesInputTimestamp } }
-    set { read { $0.preparedAXWindowAttributesInputTimestamp = newValue } }
-  }
-
-  var preparedAXWindowAttributesWindowIDs: Set<WindowID> {
-    get { read { $0.preparedAXWindowAttributesWindowIDs } }
-    set { read { $0.preparedAXWindowAttributesWindowIDs = newValue } }
-  }
-
-  var preparedAXWindowAttributesProcessIDs: Set<pid_t> {
-    get { read { $0.preparedAXWindowAttributesProcessIDs } }
-    set { read { $0.preparedAXWindowAttributesProcessIDs = newValue } }
-  }
-
-  var axWindowAttributePreparationPending: Bool {
-    get { read { $0.axWindowAttributePreparationPending } }
-    set { read { $0.axWindowAttributePreparationPending = newValue } }
+  func borderStackingInventory(now: TimeInterval) -> [CGWindowRecord]? {
+    read {
+      $0.lastCGWindowInventory?.recordsForBorderStacking(
+        generation: $0.windowSnapshotObservationGeneration, now: now
+      )
+    }
   }
 
   // MARK: freshness budgets
@@ -1281,20 +1227,7 @@ private struct Storage {
   var snapshotCGWindowCopyCount = 0
   var lastSnapshotCGWindowCopyDurationMS = 0.0
   var maximumSnapshotCGWindowCopyDurationMS = 0.0
-  var preparedCGWindowInventory: [CGWindowRecord]?
-  var lastCGWindowInventory: [CGWindowRecord]?
-  var preparedCGWindowInventoryDurationMS = 0.0
-  var preparedCGWindowInventoryAvailable = false
-  var cgWindowInventoryPreparationPending = false
-  var preparedAXWindowAttributes: [WindowID: AXWindowAttributes] = [:]
-  var preparedTransientOwnerWindowIDs: [WindowID: WindowID] = [:]
-  var preparedAXApplicationWindows: [pid_t: PreparedAXApplicationWindows] = [:]
-  var preparedAXWindowAttributesAvailable = false
-  var preparedAXWindowAttributesGeneration: UInt64?
-  var preparedAXWindowAttributesInputTimestamp: TimeInterval?
-  var preparedAXWindowAttributesWindowIDs = Set<WindowID>()
-  var preparedAXWindowAttributesProcessIDs = Set<pid_t>()
-  var axWindowAttributePreparationPending = false
+  var lastCGWindowInventory: CGWindowInventory?
   var windowSnapshotObservationGeneration: UInt64 = 0
   var deferredFrameCommitMismatchCount = 0
   var observedFrameCommitCount = 0

--- a/Sources/DefiMacOS/UserInputTracking.swift
+++ b/Sources/DefiMacOS/UserInputTracking.swift
@@ -137,16 +137,29 @@ public final class UserInputTracker: @unchecked Sendable {
 
   /// Pending resolution is bounded and belongs only to the current frontmost app.
   public func pendingApplicationActivation(
-    frontmostProcessID: pid_t?,
+    frontmostProcessID: @autoclosure () -> pid_t?,
     at timestamp: TimeInterval = ProcessInfo.processInfo.systemUptime
   ) -> ApplicationActivation? {
     lock.lock()
-    defer { lock.unlock() }
-    guard let activation = applicationActivation else { return nil }
-    guard activation.processID == frontmostProcessID,
-      timestamp >= activation.timestamp,
+    guard let activation = applicationActivation else {
+      lock.unlock()
+      return nil
+    }
+    guard timestamp >= activation.timestamp,
       timestamp - activation.timestamp <= 2
     else {
+      applicationActivation = nil
+      lock.unlock()
+      return nil
+    }
+    lock.unlock()
+    // LaunchServices can block. Keep input recording responsive during this read
+    // and reject its result if newer human intent superseded the activation.
+    let processID = frontmostProcessID()
+    lock.lock()
+    defer { lock.unlock() }
+    guard applicationActivation == activation else { return nil }
+    guard activation.processID == processID else {
       applicationActivation = nil
       return nil
     }

--- a/Sources/DefiMacOS/WindowBorderManager.swift
+++ b/Sources/DefiMacOS/WindowBorderManager.swift
@@ -84,10 +84,10 @@ final class WindowBorderManager {
     guard !isSuppressed else { return }
     let activeStacking = stacking ?? .inactive(for: windowID)
     if activeWindowID == windowID {
-      if let windowID {
+      if let windowID, let stacking {
         updateActiveStacking(
           for: windowID,
-          stacking: activeStacking
+          stacking: stacking
         )
       }
       return
@@ -101,11 +101,20 @@ final class WindowBorderManager {
       let overlay = overlays[previousActiveWindowID],
       overlay.isVisible
     {
-      overlay.setStacking(.inactive(for: previousActiveWindowID))
-      if style.inactiveEnabled {
-        overlay.updateAppearance(to: style.inactiveColor)
+      if !style.inactiveEnabled, style.enabled, style.width > 0,
+        windowBorderAlpha(of: style.activeColor) > 0,
+        let windowID, displayedFrame != nil, overlays[windowID] == nil
+      {
+        overlay.retarget(to: windowID, preservingBacking: true)
+        overlays[previousActiveWindowID] = nil
+        overlays[windowID] = overlay
       } else {
-        overlay.hide()
+        overlay.setStacking(.inactive(for: previousActiveWindowID))
+        if style.inactiveEnabled {
+          overlay.updateAppearance(to: style.inactiveColor)
+        } else {
+          overlay.hide()
+        }
       }
     }
     if style.enabled,

--- a/Sources/DefiMacOS/WindowBorderOverlay.swift
+++ b/Sources/DefiMacOS/WindowBorderOverlay.swift
@@ -15,6 +15,7 @@ final class BorderOverlay {
   private var visible = false
   private var opacityValue: Float = 0
   private var pendingOpacityReveal: Float?
+  private var geometryNeedsRefresh = false
 
   var isVisible: Bool { visible }
 
@@ -33,10 +34,11 @@ final class BorderOverlay {
   }
 
   var windowIDs: Set<CGWindowID> {
-    Set(segments.values.compactMap { panel in
-      guard panel.windowNumber > 0 else { return nil }
-      return CGWindowID(panel.windowNumber)
-    })
+    Set(
+      segments.values.compactMap { panel in
+        guard panel.windowNumber > 0 else { return nil }
+        return CGWindowID(panel.windowNumber)
+      })
   }
 
   init(windowID: WindowID) {
@@ -48,8 +50,17 @@ final class BorderOverlay {
     )
   }
 
-  func retarget(to windowID: WindowID) {
-    compactBacking()
+  func retarget(to windowID: WindowID, preservingBacking: Bool = false) {
+    if preservingBacking {
+      // Reuse only during a synchronous selection handoff, never as a hidden cache.
+      for segment in segments.values { segment.orderOut() }
+      opacityValue = 0
+      pendingOpacityReveal = nil
+      visible = false
+      geometryNeedsRefresh = true
+    } else {
+      compactBacking()
+    }
     let targetWindowNumber = Int(windowID.rawValue)
     for segment in segments.values {
       segment.retarget(to: targetWindowNumber)
@@ -86,9 +97,14 @@ final class BorderOverlay {
     // its corner radius grows by the same outset so the stroke keeps hugging
     // the real window curvature.
     let radius = placement == .outside ? baseRadius + width : baseRadius
+    let drawingChanged =
+      windowFrame?.width != frame.width
+      || windowFrame?.height != frame.height || self.width != width
+      || self.radius != radius || self.placement != placement
     guard
       windowFrame != frame || self.width != width || self.radius != radius
         || self.captureEnabled != captureEnabled || self.placement != placement
+        || geometryNeedsRefresh
     else {
       return false
     }
@@ -119,7 +135,7 @@ final class BorderOverlay {
         width: width,
         radius: radius,
         captureEnabled: captureEnabled,
-        directMovementEnabled: false
+        drawingChanged: drawingChanged
       )
     }
     windowFrame = frame
@@ -127,6 +143,7 @@ final class BorderOverlay {
     self.radius = radius
     self.captureEnabled = captureEnabled
     self.placement = placement
+    geometryNeedsRefresh = false
     return true
   }
 
@@ -277,7 +294,7 @@ private final class BorderSegment {
     width: Double,
     radius: Double,
     captureEnabled: Bool,
-    directMovementEnabled: Bool
+    drawingChanged: Bool
   ) {
     let previousFrame = frame
     let sizeChanged =
@@ -291,37 +308,37 @@ private final class BorderSegment {
       width: geometry.frame.width,
       height: geometry.frame.height
     )
-    if previousFrame == nil || sizeChanged || scaleChanged
-      || !directMovementEnabled
-    {
+    if previousFrame != geometry.frame || scaleChanged {
       panel.setFrame(appKitRect(for: geometry.frame), display: false)
     }
 
-    CATransaction.begin()
-    CATransaction.setDisableActions(true)
-    rootView.layer?.contentsScale = scale
-    shapeLayer.contentsScale = scale
-    if previousFrame == nil || sizeChanged {
-      rootView.frame = localBounds
-      rootView.layer?.frame = localBounds
-      shapeLayer.frame = localBounds
+    if drawingChanged || previousFrame == nil || sizeChanged || scaleChanged {
+      CATransaction.begin()
+      CATransaction.setDisableActions(true)
+      rootView.layer?.contentsScale = scale
+      shapeLayer.contentsScale = scale
+      if previousFrame == nil || sizeChanged {
+        rootView.frame = localBounds
+        rootView.layer?.frame = localBounds
+        shapeLayer.frame = localBounds
+      }
+      let strokeInset = width / 2
+      let pathRect = CGRect(
+        x: strokeInset - geometry.pathOriginFromWindowBottom.x,
+        y: strokeInset - geometry.pathOriginFromWindowBottom.y,
+        width: max(windowFrame.width - width, 0),
+        height: max(windowFrame.height - width, 0)
+      )
+      let strokeRadius = max(radius - strokeInset, 0)
+      shapeLayer.path = CGPath(
+        roundedRect: pathRect,
+        cornerWidth: strokeRadius,
+        cornerHeight: strokeRadius,
+        transform: nil
+      )
+      shapeLayer.lineWidth = width
+      CATransaction.commit()
     }
-    let strokeInset = width / 2
-    let pathRect = CGRect(
-      x: strokeInset - geometry.pathOriginFromWindowBottom.x,
-      y: strokeInset - geometry.pathOriginFromWindowBottom.y,
-      width: max(windowFrame.width - width, 0),
-      height: max(windowFrame.height - width, 0)
-    )
-    let strokeRadius = max(radius - strokeInset, 0)
-    shapeLayer.path = CGPath(
-      roundedRect: pathRect,
-      cornerWidth: strokeRadius,
-      cornerHeight: strokeRadius,
-      transform: nil
-    )
-    shapeLayer.lineWidth = width
-    CATransaction.commit()
 
     if panel.sharingType != (captureEnabled ? .readOnly : .none) {
       panel.sharingType = captureEnabled ? .readOnly : .none
@@ -344,6 +361,7 @@ private final class BorderSegment {
   }
 
   func setOpacityImmediately(_ opacity: Float) {
+    guard shapeLayer.opacity != opacity else { return }
     CATransaction.begin()
     CATransaction.setDisableActions(true)
     shapeLayer.opacity = opacity
@@ -377,17 +395,25 @@ private final class BorderSegment {
 
   func applyCompositorFallback() {
     guard let frame else { return }
-    panel.setFrame(appKitRect(for: frame), display: false)
+    let expectedFrame = appKitRect(for: frame)
+    if panel.frame != expectedFrame { panel.setFrame(expectedFrame, display: false) }
+    let wasOrderedIn = orderedIn
     ensureOrderedIn()
-    panel.alphaValue = 1
-    orderForCurrentStacking()
+    if panel.alphaValue != 1 { panel.alphaValue = 1 }
+    if wasOrderedIn { orderForCurrentStacking() }
   }
 
-  func compactBacking() {
-    panel.alphaValue = 0
+  func orderOut() {
+    if panel.alphaValue != 0 { panel.alphaValue = 0 }
     if orderedIn {
       panel.orderOut(nil)
     }
+    orderedIn = false
+  }
+
+  func compactBacking() {
+    guard frame != nil else { return }
+    orderOut()
     let compactBounds = CGRect(x: 0, y: 0, width: 1, height: 1)
     CATransaction.begin()
     CATransaction.setDisableActions(true)

--- a/Sources/DefiMacOS/WindowBorderStacking.swift
+++ b/Sources/DefiMacOS/WindowBorderStacking.swift
@@ -37,6 +37,24 @@ struct WindowStackEntry: Equatable, Sendable {
   let frame: Rect
 }
 
+func windowBorderStackEntries(
+  inventory: [CGWindowRecord], targetWindowID: WindowID,
+  targetProcessID: pid_t?, targetFrame: Rect?
+) -> [WindowStackEntry]? {
+  guard let index = inventory.firstIndex(where: { UInt64($0.id) == targetWindowID.rawValue }),
+    inventory[index].isOnscreen, inventory[index].processID == targetProcessID,
+    inventory[index].layer == NSWindow.Level.normal.rawValue,
+    inventory[index].frame == targetFrame
+  else { return nil }
+  return inventory[...index].compactMap { record in
+    guard record.isOnscreen else { return nil }
+    return WindowStackEntry(
+      windowID: WindowID(rawValue: UInt64(record.id)), processID: record.processID,
+      layer: record.layer, frame: record.frame
+    )
+  }
+}
+
 struct WindowBorderStacking: Equatable, Sendable {
   let targetWindowID: WindowID?
   let activeWindowIsFrontmost: Bool

--- a/Sources/DefiMacOS/WindowDiscoverySupport.swift
+++ b/Sources/DefiMacOS/WindowDiscoverySupport.swift
@@ -427,22 +427,6 @@ final class AXWindowIDProvider {
   }
 }
 
-func preparedAXWindowAttributesAreCurrent(
-  capturedGeneration: UInt64,
-  currentGeneration: UInt64,
-  capturedInputTimestamp: TimeInterval,
-  currentInputTimestamp: TimeInterval,
-  capturedWindowIDs: Set<WindowID>,
-  currentWindowIDs: Set<WindowID>,
-  capturedProcessIDs: Set<pid_t>,
-  currentProcessIDs: Set<pid_t>
-) -> Bool {
-  capturedGeneration == currentGeneration
-    && capturedInputTimestamp == currentInputTimestamp
-    && capturedWindowIDs == currentWindowIDs
-    && capturedProcessIDs == currentProcessIDs
-}
-
 func transientOwnerWindowIDsFromPreparedRelationships(
   elements: [WindowID: AXUIElement],
   parents: [WindowID: AXUIElement],

--- a/Sources/DefiMacOS/WindowRefreshPolicy.swift
+++ b/Sources/DefiMacOS/WindowRefreshPolicy.swift
@@ -160,3 +160,15 @@ func budgetedFreshReadPartition(
     stillDeferred.isEmpty ? nil : (deferredSince ?? now)
   return (allowed, stillDeferred, nextDeferredSince)
 }
+
+extension SnapshotEngine {
+  func retryUnmatchedWindows(processIDs refreshingProcessIDs: Set<pid_t>?) {
+    // A deferred app keeps its cache and retry count until its own chunk runs.
+    // Clearing it early makes snapshot cleanup discard the count and retry forever.
+    for processID in unmatchedWindowElementsByProcess.keys
+    where refreshingProcessIDs?.contains(processID) ?? true {
+      unmatchedWindowRetryAttemptsByProcess[processID, default: 0] += 1
+      unmatchedWindowElementsByProcess[processID] = nil
+    }
+  }
+}

--- a/Tests/DefiMacOSTests/FrameCommitTests.swift
+++ b/Tests/DefiMacOSTests/FrameCommitTests.swift
@@ -8,6 +8,39 @@ import Testing
 @testable import DefiMacOS
 
 struct FrameCommitTests {
+  @Test func supersededFramesSkipQueueAndEnhancedUISetup() {
+    let coordinator = AXFrameCoordinator()
+    coordinator.latestGeneration = 2
+    // An invalid process handle keeps the pre-fix failure independent of desktop permission.
+    let element = AXUIElementCreateApplication(-1)
+    let write = AsyncPositionWrite(
+      element: element, application: element, processID: -1,
+      fromPoint: CGPoint(x: 0, y: 40), point: CGPoint(x: 100, y: 40),
+      fromSize: CGSize(width: 800, height: 700), size: CGSize(width: 800, height: 700),
+      positionChanged: true, sizeChanged: false, animatesSize: false,
+      synchronousSizeWriteSucceeded: true, enhancedUIWasEnabled: true,
+      timeoutSeconds: 0.016, isParked: false, isReentering: false,
+      requiresVerifiedOffscreenWrite: false
+    )
+    let windowID = WindowID(rawValue: 1)
+    let frame = QueuedPositionFrame(
+      generation: 1, source: "stale-setup-test", writes: [windowID: write],
+      animatedWindowIDs: [], animationDuration: 0, refreshRateHz: 120,
+      displayIDs: [], initialProgressVelocity: 0, stagesVisibleBeforeParking: false, completion: nil
+    )
+    let batch = coordinator.applyBatch(
+      ProcessWriteBatch(processID: -1, writes: [(windowID, write)]), frame: frame,
+      progress: 1, intermediate: false, stagingReentry: false, recordFinalSuccess: true
+    )
+    #expect(batch.applied == 0 && batch.stale == 1 && !batch.attempted)
+    #expect(coordinator.deferredEnhancedUIRestores.isEmpty)
+    let result = coordinator.applyFrame(frame, progress: 1, skippedProcesses: [])
+    #expect(result.applied == 0 && result.stale == 1 && result.frames == 0)
+    #expect(coordinator.processWriteQueues.isEmpty)
+    let excluded = coordinator.applyFrame(frame, progress: 1, skippedProcesses: [-1])
+    #expect(excluded.stale == 0)
+  }
+
   @Test func completedTargetDoesNotWaitForSlowSibling() {
     let target = WindowID(rawValue: 1)
     let sibling = WindowID(rawValue: 2)

--- a/Tests/DefiMacOSTests/PlatformEventTests.swift
+++ b/Tests/DefiMacOSTests/PlatformEventTests.swift
@@ -15,6 +15,30 @@ private final class TestAXElement: @unchecked Sendable {
 }
 
 struct PlatformEventTests {
+  @Test
+  func activationOnlyQueriesFrontmostForLiveIntentAndRejectsSupersededReads() {
+    let tracker = UserInputTracker()
+    var queries = 0
+    func frontmost() -> pid_t? {
+      queries += 1
+      return 20
+    }
+    #expect(tracker.pendingApplicationActivation(frontmostProcessID: frontmost(), at: 10) == nil)
+    #expect(queries == 0)
+    tracker.recordApplicationActivation(processID: 20, at: 10)
+    #expect(tracker.pendingApplicationActivation(frontmostProcessID: frontmost(), at: 13) == nil)
+    #expect(queries == 0)
+    tracker.recordApplicationActivation(processID: 20, at: 14)
+    #expect(tracker.pendingApplicationActivation(frontmostProcessID: frontmost(), at: 15)?.processID == 20)
+    #expect(queries == 1)
+    func supersededFrontmost() -> pid_t? {
+      tracker.recordApplicationActivation(processID: 30, at: 15.5)
+      return 20
+    }
+    #expect(tracker.pendingApplicationActivation(frontmostProcessID: supersededFrontmost(), at: 15) == nil)
+    #expect(tracker.pendingApplicationActivation(frontmostProcessID: 30, at: 16)?.processID == 30)
+  }
+
   @Test @MainActor
   func sessionChangeDiscardsCachedAXConnectionsBeforeNextDiscovery() {
     let platform = MacOSPlatform()
@@ -396,38 +420,9 @@ struct PlatformEventTests {
         == [50, 150, 350, 700, 1_200, 2_000, 3_500, 5_500, 8_000, 12_000]
     )
     #expect(applicationLifecycleRefreshDelays(for: .focus).isEmpty)
-    #expect(
-      windowTopologyRefreshDelays(
-        for: .windowCreated,
-        latestInputTimestamp: 9.5,
-        latestCloseIntentTimestamp: 0,
-        now: 10
-      ) == [50, 150, 350]
-    )
-    #expect(
-      windowTopologyRefreshDelays(
-        for: .windowCreated,
-        latestInputTimestamp: 8.5,
-        latestCloseIntentTimestamp: 0,
-        now: 10
-      ).isEmpty
-    )
-    #expect(
-      windowTopologyRefreshDelays(
-        for: .windows,
-        latestInputTimestamp: 9.5,
-        latestCloseIntentTimestamp: 0,
-        now: 10
-      ).isEmpty
-    )
-    #expect(
-      windowTopologyRefreshDelays(
-        for: .windowCreated,
-        latestInputTimestamp: 9.5,
-        latestCloseIntentTimestamp: 9.5,
-        now: 10
-      ).isEmpty
-    )
+    #expect(windowTopologyRefreshDelays(for: .windowCreated) == [50, 150, 350])
+    #expect(windowTopologyRefreshDelays(for: .windows).isEmpty)
+    #expect(windowTopologyRefreshDelays(for: .focus).isEmpty)
   }
 
   @Test @MainActor
@@ -440,6 +435,13 @@ struct PlatformEventTests {
     #expect(platform.hasPendingWindowTopologyEvent)
     #expect(platform.snapshotEngine.pendingObservations.topologyProcessIDs == [101])
     #expect(platform.snapshotEngine.pendingObservations.topologyInputTimestamp == 12)
+  }
+
+  @Test
+  func windowCreationRetriesWithoutInputHistoryAfterRestart() {
+    // The policy must not depend on a recent keyboard/mouse/close timestamp.
+    #expect(windowTopologyRefreshDelays(for: .windowCreated) == [50, 150, 350])
+    #expect(windowTopologyRefreshDelays(for: .frame).isEmpty)
   }
 
   @Test

--- a/Tests/DefiMacOSTests/WindowBorderTests.swift
+++ b/Tests/DefiMacOSTests/WindowBorderTests.swift
@@ -425,6 +425,81 @@ struct WindowBorderTests {
   }
 
   @Test @MainActor
+  func unchangedSelectionPreservesStackingUntilExplicitObservation() {
+    let manager = WindowBorderManager()
+    defer { manager.hide() }
+    let windowID = WindowID(rawValue: 1)
+    let frame = Rect(x: 100, y: 100, width: 800, height: 600)
+    let plan = planWindowBorders(
+      frames: [FrameAssignment(windowID: windowID, frame: frame)],
+      selectedWindowID: windowID, hiddenWindowIDs: [], monitorFrames: [monitor], style: style
+    )
+    manager.prepareForSelection(windowID, displayedFrame: frame)
+    manager.sync(plan, displayedFrames: [windowID: frame], stacking: frontmostStacking(for: windowID))
+    let panels = NSApp.windows.filter {
+      manager.transparentSurfaceWindowIDs.contains(CGWindowID($0.windowNumber))
+    }
+    #expect(panels.count == 4)
+    #expect(panels.allSatisfy { $0.level == .floating })
+    manager.prepareForSelection(windowID, displayedFrame: frame)
+    #expect(panels.allSatisfy { $0.level == .floating })
+    manager.prepareForSelection(windowID, displayedFrame: frame, stacking: .inactive(for: windowID))
+    #expect(panels.allSatisfy { $0.level == .normal })
+  }
+
+  @Test @MainActor
+  func translationReusesBorderPathsAndSelectionBacking() {
+    let manager = WindowBorderManager()
+    let first = WindowID(rawValue: 1)
+    let second = WindowID(rawValue: 2)
+    let frame = Rect(x: 100, y: 100, width: 800, height: 600)
+    let plan = planWindowBorders(
+      frames: [FrameAssignment(windowID: first, frame: frame)],
+      selectedWindowID: first, hiddenWindowIDs: [], monitorFrames: [monitor], style: style
+    )
+    manager.prepareForSelection(first, displayedFrame: frame)
+    manager.sync(plan, displayedFrames: [first: frame], stacking: frontmostStacking(for: first))
+    manager.revealPendingBorders()
+    let panels = NSApp.windows.filter {
+      manager.transparentSurfaceWindowIDs.contains(CGWindowID($0.windowNumber))
+    }
+    let paths = panels.map { $0.contentView?.layer?.sublayers?.first as? CAShapeLayer }
+      .compactMap { $0?.path }
+    #expect(paths.count == 4)
+    let translated = Rect(x: 180, y: 130, width: 800, height: 600)
+    manager.updateGeometry(frames: [first: translated], style: style)
+    for (panel, path) in zip(panels, paths) {
+      #expect((panel.contentView?.layer?.sublayers?.first as? CAShapeLayer)?.path === path)
+    }
+    let pixels = manager.performance.estimatedSurfacePixels
+    manager.prepareForSelection(second, displayedFrame: translated)
+    manager.revealPendingBorders()
+    #expect(manager.performance.allocated == 1)
+    #expect(manager.performance.estimatedSurfacePixels == pixels)
+    for (panel, path) in zip(panels, paths) {
+      #expect((panel.contentView?.layer?.sublayers?.first as? CAShapeLayer)?.path === path)
+    }
+    // A same-size handoff preserves paths, but resizing must still rebuild them.
+    let resized = Rect(x: 180, y: 130, width: 900, height: 650)
+    #expect(manager.updateGeometry(frames: [second: resized], style: style))
+    for (panel, path) in zip(panels, paths) {
+      #expect((panel.contentView?.layer?.sublayers?.first as? CAShapeLayer)?.path !== path)
+    }
+    #expect(!manager.updateGeometry(frames: [second: resized], style: style))
+    // Reassert native geometry if AppKit moved one of our panels independently.
+    if let panel = panels.first {
+      let expected = panel.frame
+      panel.setFrameOrigin(NSPoint(x: expected.minX + 20, y: expected.minY))
+      manager.revealPendingBorders()
+      #expect(panel.frame == expected)
+    }
+    manager.prepareForSelection(nil, displayedFrame: nil)
+    #expect(manager.performance.estimatedSurfacePixels == 0)
+    #expect(manager.performance.visible == 0)
+    manager.hide()
+  }
+
+  @Test @MainActor
   func activeSelectionReusesDormantBorderPanels() {
     let manager = WindowBorderManager()
     let first = WindowID(rawValue: 1)

--- a/Tests/DefiMacOSTests/WindowSnapshotStabilityTests.swift
+++ b/Tests/DefiMacOSTests/WindowSnapshotStabilityTests.swift
@@ -9,6 +9,24 @@ struct WindowSnapshotStabilityTests {
   private let processID: pid_t = 42
   private let frame = Rect(x: 4, y: 34, width: 1_200, height: 800)
 
+  @Test func emptyApplicationInventoryDrainsPendingFullRefreshChunks() {
+    let engine = SnapshotEngine(frameCoordinator: AXFrameCoordinator(), userInputTracker: UserInputTracker())
+    let application = AXUIElementCreateApplication(processID)
+    engine.applications = [processID: application]
+    engine.chunkedFullRefreshRemainingProcessIDs = [processID]
+
+    engine.applications = [processID: application]
+    #expect(engine.chunkedFullRefreshRemainingProcessIDs == [processID])
+
+    // Snapshot discovery publishes an empty inventory after the last app exits.
+    engine.applications = [:]
+    #expect(engine.chunkedFullRefreshRemainingProcessIDs == nil)
+    #expect(engine.chunkedFullRefreshRemainingProcessIDs?.isEmpty != false)
+
+    engine.applications = [processID: application]
+    #expect(engine.chunkedFullRefreshRemainingProcessIDs == nil)
+  }
+
   @Test func deferredUnmatchedWindowsExhaustRetriesAcrossFullSnapshotChunks() {
     let engine = SnapshotEngine(frameCoordinator: AXFrameCoordinator(), userInputTracker: UserInputTracker())
     let first = AXUIElementCreateApplication(41)

--- a/Tests/DefiMacOSTests/WindowSnapshotStabilityTests.swift
+++ b/Tests/DefiMacOSTests/WindowSnapshotStabilityTests.swift
@@ -9,6 +9,82 @@ struct WindowSnapshotStabilityTests {
   private let processID: pid_t = 42
   private let frame = Rect(x: 4, y: 34, width: 1_200, height: 800)
 
+  @Test func deferredUnmatchedWindowsExhaustRetriesAcrossFullSnapshotChunks() {
+    let engine = SnapshotEngine(frameCoordinator: AXFrameCoordinator(), userInputTracker: UserInputTracker())
+    let first = AXUIElementCreateApplication(41)
+    let deferred = AXUIElementCreateApplication(42)
+    engine.unmatchedWindowElementsByProcess = [41: [first], 42: [deferred]]
+    engine.unmatchedWindowRetryAttemptsByProcess = [41: 0, 42: 0]
+    for attempt in 1...3 {
+      engine.retryUnmatchedWindows(processIDs: [41])
+      #expect(engine.unmatchedWindowElementsByProcess[42]?.count == 1)
+      #expect(engine.unmatchedWindowRetryAttemptsByProcess[42] == attempt - 1)
+      cacheWindowElementForShortRetry(
+        first, processID: 41, elementsByProcess: &engine.unmatchedWindowElementsByProcess,
+        attemptsByProcess: &engine.unmatchedWindowRetryAttemptsByProcess
+      )
+      engine.retryUnmatchedWindows(processIDs: [42])
+      cacheWindowElementForShortRetry(
+        deferred, processID: 42, elementsByProcess: &engine.unmatchedWindowElementsByProcess,
+        attemptsByProcess: &engine.unmatchedWindowRetryAttemptsByProcess
+      )
+      #expect(engine.unmatchedWindowRetryAttemptsByProcess[42] == attempt)
+    }
+    #expect(!unmatchedWindowRetryIsPending(attempts: engine.unmatchedWindowRetryAttemptsByProcess[42] ?? 0))
+  }
+
+  @Test func snapshotPreparationDoesNotVisitDeferredApplications() {
+    let engine = SnapshotEngine(frameCoordinator: AXFrameCoordinator(), userInputTracker: UserInputTracker())
+    // No host is attached: visiting a deferred application's observer would fail.
+    let element = AXUIElementCreateApplication(processID)
+    engine.applications = [processID: element]
+    engine.elements = [WindowID(rawValue: 1): element]
+    engine.processIDs = [WindowID(rawValue: 1): processID]
+    let prepared = engine.prepareWindowAttributes(processIDs: [])
+    #expect(prepared.attributes.isEmpty)
+    #expect(prepared.owners.isEmpty)
+    #expect(prepared.applications.isEmpty)
+  }
+
+  @Test func borderInventoryRejectsEventsDuringCaptureAndExpiredSnapshots() {
+    let engine = SnapshotEngine(frameCoordinator: AXFrameCoordinator(), userInputTracker: UserInputTracker())
+    let inventory = CGWindowInventory(records: [], generation: 0, capturedAt: 10)
+    engine.publishCGWindowInventory(inventory)
+    #expect(engine.borderStackingInventory(now: 10.01) != nil)
+    #expect(engine.borderStackingInventory(now: 10.1) == nil)
+    #expect(engine.borderStackingInventory(now: 9) == nil)
+    engine.recordObservation(.focus, processID: processID)
+    // Even a result published after an intervening event must remain invalid.
+    engine.publishCGWindowInventory(inventory)
+    #expect(engine.borderStackingInventory(now: 10.01) == nil)
+  }
+
+  @Test func borderInventoryPreservesVisibleOrderAndRequiresMatchingTarget() {
+    let target = WindowID(rawValue: 3)
+    let inventory = [
+      CGWindowRecord(id: 1, processID: 7, layer: 0, title: "", frame: frame),
+      CGWindowRecord(id: 2, processID: 7, layer: 0, title: "", frame: frame, isOnscreen: false),
+      CGWindowRecord(id: 3, processID: processID, layer: 0, title: "", frame: frame),
+      CGWindowRecord(id: 4, processID: 7, layer: 0, title: "", frame: frame),
+    ]
+    let entries = windowBorderStackEntries(
+      inventory: inventory, targetWindowID: target, targetProcessID: processID, targetFrame: frame
+    )
+    #expect(entries?.map(\.windowID.rawValue) == [1, 3])
+    for id in [2, 5] {
+      #expect(windowBorderStackEntries(
+        inventory: inventory, targetWindowID: WindowID(rawValue: UInt64(id)),
+        targetProcessID: 7, targetFrame: frame
+      ) == nil)
+    }
+    #expect(windowBorderStackEntries(
+      inventory: inventory, targetWindowID: target, targetProcessID: 99, targetFrame: frame
+    ) == nil)
+    #expect(windowBorderStackEntries(
+      inventory: inventory, targetWindowID: target, targetProcessID: processID, targetFrame: nil
+    ) == nil)
+  }
+
   @Test func destroyedWindowsArrivingDuringSnapshotRemainPending() {
     let engine = SnapshotEngine(
       frameCoordinator: AXFrameCoordinator(),
@@ -79,44 +155,6 @@ struct WindowSnapshotStabilityTests {
       #expect(destroyed.topologyPending)
       #expect(destroyed.topologyRequiresFullSnapshot == (processID == nil))
     }
-  }
-
-  @Test func preparedAttributesAreRejectedAfterInputOrObservationChanges() {
-    let windowIDs: Set<WindowID> = [WindowID(rawValue: 1)]
-    #expect(
-      preparedAXWindowAttributesAreCurrent(
-        capturedGeneration: 4,
-        currentGeneration: 4,
-        capturedInputTimestamp: 10,
-        currentInputTimestamp: 10,
-        capturedWindowIDs: windowIDs,
-        currentWindowIDs: windowIDs,
-        capturedProcessIDs: [42],
-        currentProcessIDs: [42]
-      )
-    )
-    #expect(
-      preparedAXWindowAttributesAreCurrent(
-        capturedGeneration: 4,
-        currentGeneration: 5,
-        capturedInputTimestamp: 10,
-        currentInputTimestamp: 10,
-        capturedWindowIDs: windowIDs,
-        currentWindowIDs: windowIDs,
-        capturedProcessIDs: [42],
-        currentProcessIDs: [42]
-      ) == false)
-    #expect(
-      preparedAXWindowAttributesAreCurrent(
-        capturedGeneration: 4,
-        currentGeneration: 4,
-        capturedInputTimestamp: 10,
-        currentInputTimestamp: 11,
-        capturedWindowIDs: windowIDs,
-        currentWindowIDs: windowIDs,
-        capturedProcessIDs: [42],
-        currentProcessIDs: [42]
-      ) == false)
   }
 
   @Test func applicationInventoryUsesEventsAndBoundedWatchdog() {


### PR DESCRIPTION
## Summary

- Remove speculative AX and CGWindow prefetch state and duplicate reads.
- Reuse recent window inventory data for border stacking when valid.
- Prevent stale frame writes and continue deferred/chunked refreshes without tick spinning.
- Expand window discovery retries to cover daemon restarts and delayed AX readiness.

## Testing

- Not run.