### PR TITLE
docs: simplify stale code comments

### DIFF
--- a/Sources/DefiMacOS/AXFrameCoordinator.swift
+++ b/Sources/DefiMacOS/AXFrameCoordinator.swift
@@ -18,8 +18,7 @@ func completeSupersededFrame(_ frame: QueuedPositionFrame?) {
 }
 
 final class AXFrameCoordinator: @unchecked Sendable {
-  /// Publishes interpolated frames of animated windows each animation tick so
-  /// border overlays ride the motion instead of snapping to targets.
+  /// Reports completed geometry so borders cannot outrun window writes.
   var borderLiveGeometryHandler: (@Sendable ([WindowID: Rect]) -> Void)?
 
   let queue = DispatchQueue(

--- a/Sources/DefiMacOS/SnapshotEngine.swift
+++ b/Sources/DefiMacOS/SnapshotEngine.swift
@@ -4,14 +4,6 @@ import DefiConfig
 import DefiCore
 import DefiModel
 
-/// Owns the desktop-snapshot state domain: window/process registries,
-/// discovery caches, retry bookkeeping, freshness budgets, and snapshot
-/// telemetry.
-///
-/// Every property is lock-guarded so the snapshot pass can run on its own
-/// serial queue while the main thread keeps reading published values. This is
-/// the first strangler branch of ADR 0002; the endgame converts this class
-/// into an actor once no synchronous cross-domain reader remains.
 /// Unchecked sendable envelope for a value produced on the main thread and
 /// consumed synchronously by the waiting engine queue.
 /// AXUIElement handles are remote-object ports, safe to touch from any
@@ -26,6 +18,8 @@ final class AssumedThreadSafe<T>: @unchecked Sendable {
   }
 }
 
+/// Snapshot passes run on a serial queue; shared snapshot state is lock-guarded
+/// for concurrent main-thread readers.
 final class SnapshotEngine: @unchecked Sendable {
   private let lock = NSLock()
   private var storage = Storage()
@@ -46,9 +40,6 @@ final class SnapshotEngine: @unchecked Sendable {
     qos: .userInitiated
   )
 
-  /// Runs a full desktop-snapshot pass off the main thread and publishes the
-  /// result back to it. Serialized by the queue; main-thread readers only
-  /// ever touch lock-guarded state.
   func beginSnapshot(
     config: Config,
     forceFullWindowRefresh: Bool,

--- a/Sources/DefiModel/Window.swift
+++ b/Sources/DefiModel/Window.swift
@@ -61,16 +61,9 @@ public enum FloatingOrigin: String, Equatable, Codable, Sendable {
   case user
 }
 
-/// Resolves an activated process to its window only when there is no
-/// ambiguity to get wrong: exactly one managed window belongs to it.
-/// Multi-window processes return nil so callers keep requiring AX
-/// confirmation instead of picking an arbitrary window by PID.
-///
-/// The supplied array must be a complete set for the process. Discovery
-/// snapshots can temporarily omit sibling windows (cached passes, deferred
-/// fresh reads), so snapshot callers must prove completeness with a fresh
-/// read (see `SnapshotEngine.singleFreshWindowID`) instead of relying on
-/// this alone.
+/// Requires a complete window list for the process. Cached or partial snapshots
+/// can hide siblings; discovery callers must prove uniqueness with a fresh read
+/// (see `SnapshotEngine.singleFreshWindowID`) before using this fallback.
 public func singleManagedWindowID(
   processID: Int32?,
   in windows: [Window]

--- a/Tests/DefiMacOSTests/FrameCommitTransitionTests.swift
+++ b/Tests/DefiMacOSTests/FrameCommitTransitionTests.swift
@@ -353,7 +353,6 @@ struct FrameCommitTransitionTests {
     let windowID = WindowID(rawValue: 7)
     let liveWindowIDs: Set<WindowID> = [windowID]
 
-    // Unresolved and inside the deadline: replanning waits.
     #expect(
       borderRefreshBlockedBySettling(
         liveWindowIDs: liveWindowIDs,
@@ -370,7 +369,6 @@ struct FrameCommitTransitionTests {
         now: 10.8
       ) == false
     )
-    // Observed expectations do not gate either.
     var observed = expectation
     observed.observedAt = 10.4
     #expect(
@@ -380,7 +378,6 @@ struct FrameCommitTransitionTests {
         now: 10.5
       ) == false
     )
-    // Windows without expectations never gate.
     #expect(
       borderRefreshBlockedBySettling(
         liveWindowIDs: [WindowID(rawValue: 9)],

--- a/Tests/DefiMacOSTests/PlatformEventTests.swift
+++ b/Tests/DefiMacOSTests/PlatformEventTests.swift
@@ -439,7 +439,6 @@ struct PlatformEventTests {
 
   @Test
   func windowCreationRetriesWithoutInputHistoryAfterRestart() {
-    // The policy must not depend on a recent keyboard/mouse/close timestamp.
     #expect(windowTopologyRefreshDelays(for: .windowCreated) == [50, 150, 350])
     #expect(windowTopologyRefreshDelays(for: .frame).isEmpty)
   }

--- a/Tests/DefiMacOSTests/WindowBorderTests.swift
+++ b/Tests/DefiMacOSTests/WindowBorderTests.swift
@@ -479,7 +479,6 @@ struct WindowBorderTests {
     for (panel, path) in zip(panels, paths) {
       #expect((panel.contentView?.layer?.sublayers?.first as? CAShapeLayer)?.path === path)
     }
-    // A same-size handoff preserves paths, but resizing must still rebuild them.
     let resized = Rect(x: 180, y: 130, width: 900, height: 650)
     #expect(manager.updateGeometry(frames: [second: resized], style: style))
     for (panel, path) in zip(panels, paths) {

--- a/Tests/DefiMacOSTests/WindowSnapshotStabilityTests.swift
+++ b/Tests/DefiMacOSTests/WindowSnapshotStabilityTests.swift
@@ -18,7 +18,6 @@ struct WindowSnapshotStabilityTests {
     engine.applications = [processID: application]
     #expect(engine.chunkedFullRefreshRemainingProcessIDs == [processID])
 
-    // Snapshot discovery publishes an empty inventory after the last app exits.
     engine.applications = [:]
     #expect(engine.chunkedFullRefreshRemainingProcessIDs == nil)
     #expect(engine.chunkedFullRefreshRemainingProcessIDs?.isEmpty != false)

--- a/Tests/DefiModelTests/ModelTests.swift
+++ b/Tests/DefiModelTests/ModelTests.swift
@@ -154,9 +154,7 @@ struct ModelTests {
       id: WindowID(rawValue: 3), appID: "a", title: "sibling",
       frame: frame, processID: 42
     )
-    // Exactly one managed window: safe to admit without AX confirmation.
     #expect(singleManagedWindowID(processID: 42, in: [solo, other]) == solo.id)
-    // Several windows for the same process: keep requiring AX confirmation.
     #expect(singleManagedWindowID(processID: 42, in: [solo, sibling, other]) == nil)
     #expect(singleManagedWindowID(processID: 99, in: [solo, other]) == nil)
     #expect(singleManagedWindowID(processID: nil, in: [solo]) == nil)

--- a/Tests/DefiRuntimeTests/RuntimeFocusTests.swift
+++ b/Tests/DefiRuntimeTests/RuntimeFocusTests.swift
@@ -25,10 +25,8 @@ struct RuntimeFocusTests {
       )
     }
 
-    // Policy (ADR 0002): discovery inside the active workspace focuses the
-    // newest window (which also runs scroll repair), so the rejection check
-    // targets the semantic outcome - the selection stays pinned at the
-    // boundary - rather than whole-structure equality.
+    // Discovery also repairs scroll state; assert the boundary selection
+    // rather than whole-state equality.
     state.monitors[0].workspaces[0].focusedColumn = 0
     let rejected = try changedState(
       after: .focusColumn(.left), on: monitorID, from: state


### PR DESCRIPTION
## Summary

- Remove outdated implementation details from production and test comments.
- Keep concise comments focused on current behavior and invariants.

## Testing

- Not run; documentation-only changes.