### PR TITLE
chore(release): prepare v0.2.3

### DIFF
--- a/Support/Defi-Info.plist
+++ b/Support/Defi-Info.plist
@@ -13,9 +13,9 @@
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.2.2</string>
+  <string>0.2.3</string>
   <key>CFBundleVersion</key>
-  <string>4</string>
+  <string>5</string>
   <key>LSMinimumSystemVersion</key>
   <string>26.0</string>
   <key>LSUIElement</key>


### PR DESCRIPTION
Prepare v0.2.3 with build number 5, including the desktop refresh optimization merged since v0.2.2.

Validation: build, 779 Swift tests, workflow tests, and Homebrew release checks passed. Signed bundle staged and installed successfully. Desktop validation: 23 passed, 0 failed, 1 skipped because no on-screen floating window from a different app was available. Accessibility was available. Session restoration passed and exactly one daemon remained. The full verification run reports incomplete due to that skipped test.
