### PR TITLE
fix(overview): keep overview open during arrow navigation

### DIFF
--- a/Sources/DefiDaemon/DaemonOverview.swift
+++ b/Sources/DefiDaemon/DaemonOverview.swift
@@ -73,7 +73,7 @@ extension Daemon {
         guard let self else { return }
         let parksWindows = overviewController?.usesWorkspaceParking == true
         overviewOpenedAt =
-          isOpen && parksWindows
+          isOpen
           ? ProcessInfo.processInfo.systemUptime
           : nil
         hotKeys?.setOverviewModeEnabled(isOpen)

--- a/Sources/DefiMacOS/OverviewController.swift
+++ b/Sources/DefiMacOS/OverviewController.swift
@@ -142,8 +142,6 @@ public final class OverviewController: NSObject {
   private var edgeScrollTimer: Timer?
   private var edgeScrollDirection: Double?
   private var sessionGeneration: UInt64 = 0
-  private var expectedActivationProcessID: pid_t?
-  private var expectedActivationGeneration: UInt64 = 0
   private var windowPreviewsEnabled = false
   private var previewTask: Task<Void, Never>?
   private var desktopCaptureRetryTask: Task<Void, Never>?
@@ -206,12 +204,6 @@ public final class OverviewController: NSObject {
     pressure.resume()
     memoryPressureSource = pressure
     let center = NSWorkspace.shared.notificationCenter
-    center.addObserver(
-      self,
-      selector: #selector(applicationActivated(_:)),
-      name: NSWorkspace.didActivateApplicationNotification,
-      object: nil
-    )
     for name in [
       NSWorkspace.screensDidSleepNotification,
       NSWorkspace.sessionDidResignActiveNotification,
@@ -526,7 +518,6 @@ public final class OverviewController: NSObject {
     edgeScrollDirection = nil
     drag = nil
     alignSelectionOnNextUpdate = false
-    expectedActivationProcessID = nil
     previewTask?.cancel()
     previewTask = nil
     cancelDesktopCaptureRetry()
@@ -560,24 +551,6 @@ public final class OverviewController: NSObject {
     }
   }
 
-  @objc private func applicationActivated(_ notification: Notification) {
-    guard isOpen else { return }
-    let application = notification.userInfo?[NSWorkspace.applicationUserInfoKey]
-      as? NSRunningApplication
-    if application?.processIdentifier == expectedActivationProcessID {
-      expectedActivationProcessID = nil
-      return
-    }
-    if let processID = application?.processIdentifier,
-      let snapshot,
-      let selectedWindowID = selection?.windowID,
-      snapshot.windows[selectedWindowID]?.processID == processID
-    {
-      return
-    }
-    close()
-  }
-
   @objc private func closeForSystemTransition(_ notification: Notification) {
     close()
   }
@@ -593,7 +566,6 @@ public final class OverviewController: NSObject {
     switch selection {
     case .window(let windowID, let monitorID, let workspaceID):
       guard let window = snapshot.windows[windowID] else { return false }
-      expectActivation(of: window.processID)
       focusWindowHandler(windowID, window.appID, monitorID, workspaceID)
     case .workspace(let monitorID, let workspaceID):
       focusWorkspaceHandler(monitorID, workspaceID)
@@ -622,7 +594,7 @@ public final class OverviewController: NSObject {
         from: selection ?? initialSelection(in: snapshot),
         action: action,
         snapshot: snapshot
-      )
+      ), target != selection
     else { return }
     selection = target
     alignSelectionOnNextUpdate = true
@@ -694,17 +666,6 @@ public final class OverviewController: NSObject {
       sourceWorkspaceID: workspaceID,
       target: target
     )
-  }
-
-  private func expectActivation(of processID: Int32?) {
-    guard let processID else { return }
-    expectedActivationGeneration &+= 1
-    let generation = expectedActivationGeneration
-    expectedActivationProcessID = pid_t(processID)
-    DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) { [weak self] in
-      guard let self, self.expectedActivationGeneration == generation else { return }
-      self.expectedActivationProcessID = nil
-    }
   }
 
   private func navigationTarget(
@@ -1570,7 +1531,6 @@ extension OverviewController: OverviewViewDelegate {
       workspaceID: location.workspaceID
     )
     alignSelectionOnNextUpdate = true
-    expectActivation(of: snapshot?.windows[windowID]?.processID)
     activateMonitorHandler(location.monitorID)
     dropHandler(
       windowID,

--- a/Tests/DefiMacOSTests/OverviewNavigationTests.swift
+++ b/Tests/DefiMacOSTests/OverviewNavigationTests.swift
@@ -1,0 +1,71 @@
+import AppKit
+import DefiCore
+import DefiModel
+import Testing
+
+@testable import DefiMacOS
+
+@MainActor
+struct OverviewNavigationTests {
+  @Test(arguments: [OverviewKeyAction.left, .right, .up, .down])
+  func delayedActivationAfterRepeatedArrowsKeepsOverviewOpen(action: OverviewKeyAction) {
+    // A nonexistent display exercises the controller without creating desktop panels.
+    let monitorID = MonitorID(rawValue: .max)
+    let workspaceID = WorkspaceID(rawValue: "test")
+    let windows = (1...3).map { index in
+      Window(
+        id: WindowID(rawValue: UInt64(index)), appID: "test.\(index)",
+        title: "Test", frame: Rect(x: 0, y: 0, width: 100, height: 100),
+        processID: index == 2 ? NSRunningApplication.current.processIdentifier : Int32(index)
+      )
+    }
+    let startsAtEnd = action == .left || action == .up
+    let vertical = action == .up || action == .down
+    let workspaces = vertical
+      ? windows.map { window in
+        Workspace(
+          id: WorkspaceID(rawValue: "test.\(window.id.rawValue)"),
+          columns: [Column(window: window.id, width: .fraction(0.5))]
+        )
+      }
+      : [Workspace(
+        id: workspaceID,
+        columns: windows.map { Column(window: $0.id, width: .fraction(0.5)) },
+        focusedColumn: startsAtEnd ? 2 : 0
+      )]
+    var focused: [WindowID] = []
+    let controller = OverviewController(
+      focusWindow: { id, _, _, _ in focused.append(id) },
+      focusWorkspace: { _, _ in }, drop: { _, _, _, _, _ in },
+      activateMonitor: { _ in }, openStateChanged: { _ in },
+      commitScrollOffsets: { _ in }
+    )
+    controller.open(
+      snapshot: OverviewSnapshot(
+        monitors: [Monitor(
+          id: monitorID,
+          workspaces: workspaces,
+          activeWorkspace: workspaces[vertical && startsAtEnd ? 2 : 0].id
+        )],
+        monitorFrames: [:],
+        windows: Dictionary(uniqueKeysWithValues: windows.map { ($0.id, $0) })
+      ),
+      layout: LayoutSettings()
+    )
+    defer { controller.close() }
+
+    let lastWindowID = windows[startsAtEnd ? 0 : 2].id
+    for _ in 0..<20 { controller.handleKey(action) }
+    #expect(controller.isOpen)
+    #expect(focused.last == lastWindowID)
+    NSWorkspace.shared.notificationCenter.post(
+      name: NSWorkspace.didActivateApplicationNotification,
+      object: nil,
+      userInfo: [NSWorkspace.applicationUserInfoKey: NSRunningApplication.current]
+    )
+    #expect(controller.isOpen)
+    #expect(focused == [windows[1].id, lastWindowID])
+    controller.handleKey(.cancel)
+    #expect(controller.isOpen == false)
+  }
+}


### PR DESCRIPTION
## Summary

- Keep overview mode active while arrow navigation triggers window activation.
- Remove delayed activation tracking and close-on-activation handling.
- Add navigation coverage for repeated directional input and delayed activation.

## Testing

- Not run (change request content only).