### PR TITLE
chore(release): prepare v0.2.4

### DIFF
--- a/Support/Defi-Info.plist
+++ b/Support/Defi-Info.plist
@@ -13,9 +13,9 @@
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.2.3</string>
+  <string>0.2.4</string>
   <key>CFBundleVersion</key>
-  <string>5</string>
+  <string>6</string>
   <key>LSMinimumSystemVersion</key>
   <string>26.0</string>
   <key>LSUIElement</key>


### PR DESCRIPTION
Prepare v0.2.4 with build number 6, including the Overview arrow-navigation fix merged since v0.2.3 (#77).

Validation: build, 780 Swift tests, 10 verification workflow tests, Homebrew release checks, and GitHub CI passed. Signed bundle staged and installed with the existing designated requirement preserved. `DesktopE2ETests/testConfiguredHyperArrowNavigatesOverview` passed with Accessibility available (1 passed, 0 failed, 0 skipped); session restoration passed.

Computer Use confirmed that Overview remained open across left/right CLI navigation between applications and that normal card clicks closed it and activated the selected window. Direct Computer Use keystrokes did not reach the global event tap, so manual arrow-key validation remains unverified; repeated arrows and delayed activation are covered by the automated Overview tests.
